### PR TITLE
Support sqlalchemy>=2

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -540,3 +540,69 @@ jobs:
     #       run: make test
 
     ##########################################################################################################################
+
+
+    #################################
+    #~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~#
+    #~~~~~~~~~|##########|~~~~~~~~~~#
+    #~~~~~~~~~|##|~~~~~~~~~~~~~~~~~~#
+    #~~~~~~~~~|##|~~~~~~~~~~~~~~~~~~#
+    #~~~~~~~~~|##########|~~~~~~~~~~#
+    #~~~~~~~~~|##|~~~~|##|~~~~~~~~~~#
+    #~~~~~~~~~|##|~~~~|##|~~~~~~~~~~#
+    #~~~~~~~~~|##########|~~~~~~~~~~#
+    #~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~#
+    #~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~#
+    # Test Dependencies/Regressions #
+    #~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~#
+    test_dependencies:
+      needs:
+        - initialize
+        - build
+
+      strategy:
+        matrix:
+          os:
+            - ubuntu-20.04
+          python-version:
+            - 3.9
+          package:
+            - "sqlalchemy>=2"
+            - "sqlalchemy<2"
+
+      runs-on: ${{ matrix.os }}
+
+      steps:
+        - name: Checkout
+          uses: actions/checkout@v4
+          with:
+              submodules: recursive
+
+        - name: Set up Python ${{ matrix.python-version }}
+          uses: ./.github/actions/setup-python
+          with:
+            version: '${{ matrix.python-version }}'
+
+        - name: Install python dependencies
+          run: make requirements
+
+        - name: Install test dependencies
+          shell: bash
+          run: sudo apt-get install graphviz
+
+        # Download artifact
+        - name: Download wheel
+          uses: actions/download-artifact@v4
+          with:
+            name: csp-dist-${{ runner.os }}-${{ runner.arch }}-${{ matrix.python-version }}
+
+        - name: Install wheel
+          run: python -m pip install -U *manylinux2014*.whl --target .
+
+        - name: Install package - ${{ matrix.package }}
+          run: python -m pip install -U "${{ matrix.package }}"
+
+        # Run tests
+        - name: Python Test Steps
+          run: make test TEST_ARGS="-k TestDBReader"
+          if: ${{ contains( 'sqlalchemy', matrix.package )}}

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ EXTRA_ARGS :=
 #########
 .PHONY: develop build-py build install
 
-requirements:  ## install python dev dependnecies
+requirements:  ## install python dev and runtime dependencies
 	python -m pip install toml
 	python -m pip install `python -c 'import toml; c = toml.load("pyproject.toml"); print("\n".join(c["build-system"]["requires"]))'`
 	python -m pip install `python -c 'import toml; c = toml.load("pyproject.toml"); print("\n".join(c["project"]["optional-dependencies"]["develop"]))'`
@@ -64,11 +64,12 @@ checks: check
 #########
 .PHONY: test-py coverage-py test tests
 
+TEST_ARGS :=
 test-py: ## Clean and Make unit tests
-	python -m pytest -v csp/tests --junitxml=junit.xml
+	python -m pytest -v csp/tests --junitxml=junit.xml $(TEST_ARGS)
 
 coverage-py:
-	python -m pytest -v csp/tests --junitxml=junit.xml --cov=csp --cov-report xml --cov-report html --cov-branch --cov-fail-under=80 --cov-report term-missing
+	python -m pytest -v csp/tests --junitxml=junit.xml --cov=csp --cov-report xml --cov-report html --cov-branch --cov-fail-under=80 --cov-report term-missing $(TEST_ARGS)
 
 test: test-py  ## run the tests
 

--- a/csp/adapters/db.py
+++ b/csp/adapters/db.py
@@ -9,8 +9,8 @@ except ImportError:
     from backports import zoneinfo
 
 import pytz
+from importlib.metadata import PackageNotFoundError, version as get_package_version
 from packaging import version
-from pkg_resources import DistributionNotFound, get_distribution
 
 from csp import PushMode, ts
 from csp.impl.adaptermanager import AdapterManagerImpl, ManagedSimInputAdapter
@@ -19,7 +19,7 @@ from csp.impl.wiring import py_managed_adapter_def
 UTC = zoneinfo.ZoneInfo("UTC")
 
 try:
-    if version.parse(get_distribution("sqlalchemy").version) >= version.parse("2"):
+    if version.parse(get_package_version("sqlalchemy")) >= version.parse("2"):
         _SQLALCHEMY_2 = True
     else:
         _SQLALCHEMY_2 = False
@@ -27,7 +27,7 @@ try:
     import sqlalchemy as db
 
     _HAS_SQLALCHEMY = True
-except (DistributionNotFound, ValueError, TypeError, ImportError):
+except (PackageNotFoundError, ValueError, TypeError, ImportError):
     _HAS_SQLALCHEMY = False
     db = None
 

--- a/csp/adapters/output_adapters/parquet.py
+++ b/csp/adapters/output_adapters/parquet.py
@@ -1,6 +1,6 @@
 import numpy
 import os
-import pkg_resources
+from importlib.metadata import PackageNotFoundError, version as get_package_version
 from packaging import version
 from typing import Callable, Dict, Optional, TypeVar
 
@@ -37,10 +37,13 @@ class ParquetOutputConfig(Struct):
 
 
 def _get_default_parquet_version():
-    if version.parse(pkg_resources.get_distribution("pyarrow").version) >= version.parse("6.0.1"):
-        return "2.6"
-    else:
-        return "2.0"
+    try:
+        if version.parse(get_package_version("pyarrow")) >= version.parse("6.0.1"):
+            return "2.6"
+    except PackageNotFoundError:
+        # Don't need to do anything in particular
+        ...
+    return "2.0"
 
 
 class ParquetWriter:

--- a/csp/adapters/parquet.py
+++ b/csp/adapters/parquet.py
@@ -1,10 +1,10 @@
 import datetime
 import io
 import numpy
-import pkg_resources
 import platform
 import pyarrow
 import pyarrow.parquet
+from importlib.metadata import PackageNotFoundError, version as get_package_version
 from packaging import version
 from typing import TypeVar
 
@@ -28,9 +28,9 @@ T = TypeVar("T")
 
 try:
     _CAN_READ_ARROW_BINARY = False
-    if version.parse(pkg_resources.get_distribution("pyarrow").version) >= version.parse("4.0.1"):
+    if version.parse(get_package_version("pyarrow")) >= version.parse("4.0.1"):
         _CAN_READ_ARROW_BINARY = True
-except (ValueError, TypeError):
+except (PackageNotFoundError, ValueError, TypeError):
     # Cannot read binary arrow
     ...
 

--- a/dev-environment.yml
+++ b/dev-environment.yml
@@ -11,7 +11,7 @@ dependencies:
  - ruamel.yaml
  - scikit-build
  - psutil
- - sqlalchemy<2
+ - sqlalchemy
  - bump2version>=1.0.0
  - python-graphviz
  - httpx

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,7 +61,7 @@ develop = [
     "pytest-cov",
     "pytest-sugar",
     "scikit-build",
-    "sqlalchemy<2",
+    "sqlalchemy",
     "tornado",
 ]
 


### PR DESCRIPTION
This PR adds support for `sqlalchemy>=2` for the `DBReader` adapter.


- [x] Fix lint / remove debugging and prints
- [x] Add CI/CD for testing `test_db.py` for `SQLAlchemy` >2 and <2
- [x] Restore behavior necessary to facilitate bullet 2
- [x] update `dev-dependencies.yml` conda env
