### PR TITLE
Add a dev-envrionment.yml to simplify setting up a dev environment

### DIFF
--- a/dev-environment.yml
+++ b/dev-environment.yml
@@ -1,0 +1,26 @@
+dependencies:
+ - flex
+ - cmake
+ - ninja
+ - bison
+ - tar
+ - unzip
+ - zip
+ - numpy
+ - pyarrow>=7.0.0
+ - ruamel.yaml
+ - scikit-build
+ - psutil
+ - sqlalchemy<2
+ - bump2version>=1.0.0
+ - graphviz
+ - httpx
+ - isort
+ - ruff
+ - twine
+ - wheel
+ - polars
+ - pytest
+ - pytest-cov
+ - pytest-sugar
+ - python<3.12


### PR DESCRIPTION
This defines a conda environment suitable for bootstrapping csp development. If we add this and update the build instructions in the wiki to use it, we can get rid of a big chunk of the OS-specific build environment setup instructions.

I successfully built `csp` and ran the tests on a M3 Macbook Pro and a aarch64 Ubuntu VM running on the same machine and this seems to work on both systems.

To get this to work, you'll need to install anaconda or miniconda, such that `conda` is visible in your PATH, with the following configuation settings to activate `conda-forge`:

```
$ conda config --add channels conda-forge
$ conda config --set channel_priority strict
```

Then create a new conda environment using this file and activate it:

```
$ conda env create -n csp -f dev-environment.yml
$ conda activate csp
```

And then build and install `csp` into conda's python environment as discussed in the wiki.

Note that users on macs will still need to get `gcc` from homebrew and manually specify homebrew's g++ in their `make build` command since conda-forge doesn't provide g++ except on linux.

If this is OK as-is and it can be merged, I'll update the build instructions on the wiki to suggest starting with a conda environment and to use this file. I'll go ahead and leave the OS-specific non-conda instructions as well, but move them to a less prominent place.