### PR TITLE
Remove homebrew cache, too large (~5GB) and most things we need are preinstalled

### DIFF
--- a/.github/actions/setup-caches/action.yml
+++ b/.github/actions/setup-caches/action.yml
@@ -29,18 +29,6 @@ runs:
       # TODO windows
 
     ################
-    # Homebrew Cache
-    - name: Setup homebrew cache
-      uses: actions/cache@v4
-      with:
-          path: |
-              ~/Library/Caches/Homebrew/*
-              ~/Library/Caches/Homebrew/downloads/*
-          key: brew-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('Makefile') }}
-          restore-keys: brew-${{ runner.os }}-${{ runner.arch }}-
-      if: ${{ runner.os == 'macOS' }}
-
-    ################
     # vcpkg Cache
     - name: Setup vcpkg cache in shell
       shell: bash


### PR DESCRIPTION
As per title, the homebrew caching is quite large as we're caching all the preinstalled stuff. Since we're not really installing anything large, we should be able to remove to save room for vcpkg, ccache, and pip caching.
![Screenshot 2024-02-06 at 12 03 30](https://github.com/Point72/csp/assets/3105306/d17c878a-171a-4833-b199-e67cd707ee16)
