### PR TITLE
Clean up metadata and email references

### DIFF
--- a/.github/CODE_OF_CONDUCT.md
+++ b/.github/CODE_OF_CONDUCT.md
@@ -59,8 +59,7 @@ representative at an online or offline event.
 ## Enforcement
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
-reported to the community leaders responsible for enforcement at
-t.paine154@gmail.com.
+reported to the community leaders responsible for enforcement at CSPOpenSource@point72.com.
 All complaints will be reviewed and investigated promptly and fairly.
 
 All community leaders are obligated to respect the privacy and security of the

--- a/csp/examples/e_23_cpp_example/pyproject.toml
+++ b/csp/examples/e_23_cpp_example/pyproject.toml
@@ -4,8 +4,8 @@ build-backend="setuptools.build_meta"
 
 [project]
 name = "csp-example-piglatin"
-authors = [{name = "the csp authors", email = "t.paine154@gmail.com"}]
-description="CSP stream processing library"
+authors = [{name = "the csp authors", email = "CSPOpenSource@point72.com"}]
+description="csp example of C++ node"
 readme = "README.md"
 version = "0.0.1"
 requires-python = ">=3.8"

--- a/csp/examples/e_24_cpp_struct_example/pyproject.toml
+++ b/csp/examples/e_24_cpp_struct_example/pyproject.toml
@@ -4,8 +4,8 @@ build-backend="setuptools.build_meta"
 
 [project]
 name = "csp-example-struct"
-authors = [{name = "the csp authors", email = "t.paine154@gmail.com"}]
-description="CSP stream processing library"
+authors = [{name = "the csp authors", email = "CSPOpenSource@point72.com"}]
+description="csp example of C++ node with csp.Structs"
 readme = "README.md"
 version = "0.0.1"
 requires-python = ">=3.8"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,8 +10,8 @@ build-backend="setuptools.build_meta"
 
 [project]
 name = "csp"
-authors = [{name = "the csp authors", email = "t.paine154@gmail.com"}]
-description="CSP stream processing library"
+authors = [{name = "the csp authors", email = "CSPOpenSource@point72.com"}]
+description="csp is a high performance reactive stream processing library, written in C++ and Python"
 readme = "README.md"
 version = "0.1.0"
 requires-python = ">=3.8"
@@ -41,7 +41,10 @@ classifiers = [
 file = "LICENSE"
 
 [project.urls]
-repository = "https://github.com/point72/csp"
+Repository = "https://github.com/point72/csp"
+Homepage = "https://github.com/Point72/csp"
+Documentation = "https://github.com/Point72/csp/wiki"
+Tracker = "https://github.com/point72/csp/issues"
 
 [project.optional-dependencies]
 develop = [
@@ -109,7 +112,7 @@ testpaths = 'tests'
 [tool.ruff]
 line-length = 120
 
-[tool.ruff.per-file-ignores]
+[tool.ruff.lint.per-file-ignores]
 "__init__.py" = ["F401", "F403"]
 "csp/impl/__*.py" = ["F401"]
 "csp/tests/*.py" = ["F401", "F403", "F811", "F821", "F841", "F842", "E731", "E741"]


### PR DESCRIPTION
Fix up metadata in `pyproject.toml` and update email addresses across the codebase to use the central one instead of personal ones.

fixes #16