### PR TITLE
Fixes for examples

### DIFF
--- a/csp/__init__.py
+++ b/csp/__init__.py
@@ -29,7 +29,7 @@ from csp.impl.wiring import (
 from csp.impl.wiring.context import clear_global_context, new_global_context
 from csp.showgraph import show_graph
 
-from . import cache_support
+from . import cache_support, stats
 
 __version__ = "0.1.0"
 

--- a/dev-environment.yml
+++ b/dev-environment.yml
@@ -13,7 +13,7 @@ dependencies:
  - psutil
  - sqlalchemy<2
  - bump2version>=1.0.0
- - graphviz
+ - python-graphviz
  - httpx
  - isort
  - ruff
@@ -23,4 +23,8 @@ dependencies:
  - pytest
  - pytest-cov
  - pytest-sugar
+ - pytest-asyncio
  - python<3.12
+ - tornado
+ - python-rapidjson
+ - pillow

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,10 +57,12 @@ develop = [
     "polars",
     "psutil",
     "pytest",
+    "pytest-asyncio",
     "pytest-cov",
     "pytest-sugar",
     "scikit-build",
     "sqlalchemy<2",
+    "tornado",
 ]
 
 [tool.check-manifest]


### PR DESCRIPTION
This adds and fixes names for dependencies needed by the examples.

It also imports the `stats` module into `csp` since one of the examples used `csp.stats` without explicitly importing it.