### PR TITLE
Skip graphviz tests if not installed locally

### DIFF
--- a/csp/tests/test_showgraph.py
+++ b/csp/tests/test_showgraph.py
@@ -1,7 +1,20 @@
+import pytest
+
 import csp
 from csp.showgraph import _build_graphviz_graph
 
 
+def _cant_find_graphviz():
+    try:
+        from graphviz import Digraph
+
+        Digraph().pipe()
+    except BaseException:
+        return True
+    return False
+
+
+@pytest.mark.skipif(_cant_find_graphviz(), reason="cannot find graphviz installation")
 def test_showgraph_names():
     # Simple test to assert that node names
     # are properly propagated into graph viewer


### PR DESCRIPTION
Graphviz is not a required dependency, and we plan on enabling interactive graph viewing with something like [ipydagred3](https://github.com/timkpaine/ipydagred3) as an alternative shortly anyway