### PR TITLE
Show result of first example in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,8 +38,6 @@ def spread(bid: ts[float], ask: ts[float]) -> ts[float]:
 def my_graph():
     bid = csp.const(1.0)
     ask = csp.const(2.0)
-    bid = csp.multiply( bid, csp.const(4) )
-    ask = csp.multiply( ask, csp.const(3) )
     s = spread(bid, ask)
 
     csp.print('spread', s)
@@ -51,6 +49,12 @@ if __name__ == '__main__':
     csp.run(my_graph, starttime=datetime.utcnow())
 ```
 
+Running this, our output should look like (with some slight variations for current time):
+```raw
+2024-02-07 04:37:13.446548 bid:1.0
+2024-02-07 04:37:13.446548 ask:2.0
+2024-02-07 04:37:13.446548 spread:1.0
+```
 
 ## Getting Started
 See [our wiki!](https://github.com/Point72/csp/wiki)


### PR DESCRIPTION
Tiny change, I think it makes sense to show the output in the first example you see when you visit the site 😅. Also removed the `csp.multiply` to keep it as simple as possible.

<img width="768" alt="Screenshot 2024-02-06 at 23 41 18" src="https://github.com/Point72/csp/assets/3105306/65df65f4-8c0f-442d-abbe-03c3f5ff533d">
