### PR TITLE
Drop macos-12 (x86) build in frequent CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -224,13 +224,6 @@ jobs:
             # avoid unnecessary use of mac resources
             - is-full-run: false
               os: macos-12
-              python-version: "3.8"
-            - is-full-run: false
-              os: macos-12
-              python-version: "3.9"
-            - is-full-run: false
-              os: macos-12
-              python-version: "3.10"
             - is-full-run: false
               os: macos-14
               python-version: "3.8"


### PR DESCRIPTION
As per title, it seems like the `macos-12` build is intermittently refusing to detect our various caches, and I've observed it failing to acquire a GitHub runner at least once. Since these are the steps we run on every PR, we want them to be as fast as possible. Furthermore, since our maintainers are using M1-based Macs exclusively (at this time), it's not strictly necessary for us to produce x86 wheels to test on each PR. 