### PR TITLE
Fix copy-paste error with missing inputs block

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,7 +16,8 @@ on:
       - LICENSE
       - README.md
   workflow_dispatch:
-    ci-full:
+    inputs:
+      ci-full:
         description: "Run Full CI"
         required: false
         type: boolean


### PR DESCRIPTION
Really minor copy-paste error, i dropped a keyword to allow for manual runs to do a full build. 