### PR TITLE
Drop py3.8 and py3.9 from macos-14

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -214,13 +214,21 @@ jobs:
             ##############################################
             # Things to exclude if not a full matrix run #
             ##############################################
+            # mac arm builds support py3.10+
+            - os: macos-14
+              python-version: "3.8"
+            - os: macos-14
+              python-version: "3.9"
+
             # minimize CI resource usage
             - is-full-run: false
               os: ubuntu-22.04
               python-version: "3.8"
+
             # windows is slow, so dont build unless its a full run
-            - is-full-run: false
-              os: windows-2022
+            # - is-full-run: false
+            #   os: windows-2022
+
             # avoid unnecessary use of mac resources
             - is-full-run: false
               os: macos-12
@@ -391,9 +399,15 @@ jobs:
             ##############################################
             # Things to exclude if not a full matrix run #
             ##############################################
+            # mac arm builds support py3.10+
+            - os: macos-14
+              python-version: "3.8"
+            - os: macos-14
+              python-version: "3.9"
+
             # Exclude windows builds
-            - is-full-run: false
-              os: windows-2022
+            # - is-full-run: false
+            #   os: windows-2022
 
             # Exclude macOS builds for now
             - is-full-run: false


### PR DESCRIPTION
These are not available according to:
https://raw.githubusercontent.com/actions/python-versions/main/versions-manifest.json

So we will skip building wheels on these for now. `cibuildwheel` might still work, we can reenable support later if necessary. 