### PR TITLE
Add channel selection to dev-environment.yml file

### DIFF
--- a/dev-environment.yml
+++ b/dev-environment.yml
@@ -1,3 +1,7 @@
+name: csp-dev
+channels:
+  - conda-forge
+  - nodefaults
 dependencies:
  - compilers
  - git


### PR DESCRIPTION
Using micromamba, the commands to use conda-forge are slightly different than https://github.com/Point72/csp/wiki/99.-Developer#conda

To make the workflow more robust, we can include the channel selection (and optionally, the dev environment name) in the environment.yml file itself.