### PR TITLE
Remove git and ass cyrus-sasl to dev environment

### DIFF
--- a/dev-environment.yml
+++ b/dev-environment.yml
@@ -4,7 +4,7 @@ channels:
   - nodefaults
 dependencies:
  - compilers
- - git
+ - cyrus-sasl
  - flex
  - cmake
  - ninja


### PR DESCRIPTION
@robambalu hit issues with the self-signed SSL certificates on internal dev machines and conda's git, so let's remove it and just document that people need git installed.

Also adding `cyrus-sasl`, which it turns out is necessary if librdkafka is getting built on a machine with kerberos set up.