### PR TITLE
Add dependency for python 3.8, reenable sdist

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -413,11 +413,11 @@ jobs:
             #   os: windows-2022
 
             # Exclude macOS builds for now
-            - is-full-run: false
-              os: macos-12
+            - os: macos-12
+              # is-full-run: false  # FIXME https://github.com/Point72/csp/issues/33
 
-            - is-full-run: false
-              os: macos-14
+            - os: macos-14
+              # is-full-run: false  # FIXME https://github.com/Point72/csp/issues/33
 
             # Exclude Python 3.8, 3.10, 3.11 builds
             - is-full-run: false
@@ -466,15 +466,13 @@ jobs:
           run: python -m pip install -U *manylinux2014*.whl --target .
           if: ${{ runner.os == 'Linux' }}
 
-        # Note, on mac we must install the x86 wheel, the arm64 wheel
-        # would need an arm machine to test
-        - name: Install wheel (OSX)
+        - name: Install wheel (OSX x86)
           run: python -m pip install -U *x86*.whl --target .
-          if: ${{ runner.os == 'macOS' && matrix.python-version != '3.11' }}
+          if: ${{ runner.os == 'macOS' && runner.arch == 'X64' }}
 
-        - name: Install wheel (OSX 3.11+)
-          run: python -m pip install -U *universal*.whl --target .
-          if: ${{ runner.os == 'macOS' && matrix.python-version == '3.11' }}
+        - name: Install wheel (OSX arm)
+          run: python -m pip install -U *arm64*.whl --target .
+          if: ${{ runner.os == 'macOS' && runner.arch == 'ARM64' }}
 
         - name: Install wheel (windows)
           run: python -m pip install -U (Get-ChildItem .\*.whl | Select-Object -Expand FullName) --target .
@@ -496,60 +494,59 @@ jobs:
     #~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~#
     # Stage Four - Build / test the SDist  #
     #~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~#
-    # test_sdist:
-    #   needs:
-    #     - initialize
-    #     - build_sdist
+    test_sdist:
+      needs:
+        - initialize
+        - build_sdist
 
-    #   strategy:
-    #     matrix:
-    #       os:
-    #         - ubuntu-22.04
-    #       python-version:
-    #         - 3.9
+      strategy:
+        matrix:
+          os:
+            - ubuntu-22.04
+          python-version:
+            - 3.9
 
-    #   runs-on: ${{ matrix.os }}
+      runs-on: ${{ matrix.os }}
 
-    #   # if: ${{ needs.initialize.outputs.FULL_RUN == 'true' }}
+      if: ${{ needs.initialize.outputs.FULL_RUN == 'true' }}
 
-    #   steps:
-    #     - name: Checkout
-    #       uses: actions/checkout@v4
-    #       with:
-    #         submodules: recursive
+      steps:
+        - name: Checkout
+          uses: actions/checkout@v4
+          with:
+            submodules: recursive
 
-    #     - name: Set up Python ${{ matrix.python-version }}
-    #       uses: ./.github/actions/setup-python
-    #       with:
-    #         version: '${{ matrix.python-version }}'
+        - name: Set up Python ${{ matrix.python-version }}
+          uses: ./.github/actions/setup-python
+          with:
+            version: '${{ matrix.python-version }}'
 
-    #     - name: Set up Caches
-    #       uses: ./.github/actions/setup-caches
-    #       with:
-    #         cibuildwheel: 'cp39'
+        - name: Set up Caches
+          uses: ./.github/actions/setup-caches
+          with:
+            cibuildwheel: 'cp39'
 
-    #     # Python
-    #     - name: Install python dependencies
-    #       run: make requirements
+        # Python
+        - name: Install python dependencies
+          run: make requirements
 
-    #     # Download sdist
-    #     - uses: actions/download-artifact@v4
-    #       with:
-    #         name: csp-sdist
-    #         path: dist/
+        # Download sdist
+        - uses: actions/download-artifact@v4
+          with:
+            name: csp-sdist
+            path: dist/
 
-    #     # Install sdist
-    #     - name: Install sdist
-    #       run: python -m pip install -U dist/csp*.tar.gz --target .
-    #       env:
-    #         CCACHE_DIR: /host/home/runner/work/csp/csp/.ccache
-    #         VCPKG_DEFAULT_BINARY_CACHE: /host/home/runner/vcpkg_cache
+        # Install sdist
+        - name: Install sdist
+          run: python -m pip install -U -vvv dist/csp*.tar.gz --target .
+          env:
+            CCACHE_DIR: /home/runner/work/csp/csp/.ccache
+            VCPKG_DEFAULT_BINARY_CACHE: /home/runner/vcpkg_cache
+            VCPKG_DOWNLOADS: /home/runner/vcpkg_download_cache
 
-    #     # Test sdist
-    #     - name: Run tests against from-scratch sdist build
-    #       run: make test
-
-    ##########################################################################################################################
+        # Test sdist
+        - name: Run tests against from-scratch sdist build
+          run: make test
 
 
     #################################

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -66,6 +66,7 @@ option(CSP_BUILD_GPROF "Hook into gprof for profiling" OFF)
 option(CSP_MANYLINUX "Build for python's manylinux setup" OFF)
 option(CSP_USE_VCPKG "Build with vcpkg dependencies" ON)
 option(CSP_USE_CCACHE "Build with ccache caching" OFF)
+option(CSP_USE_LD_CLASSIC_MAC "On macOS, link with ld_classic" OFF)
 
 # Extension options
 option(CSP_BUILD_KAFKA_ADAPTER "Build kafka adapter" ON)
@@ -115,8 +116,11 @@ if(MACOS)
     set(THREADS_PREFER_PTHREAD_FLAG ON)
 
     # for exception unwinding on macOS
-    check_linker_flag(CXX "-Wl,-ld_classic" HAS_LD_CLASSIC_MAC)
-    if(HAS_LD_CLASSIC_MAC)
+    # TODO this does not work, which would be the
+    # proper cmake way of doing it, so instead we
+    # use a vanilla option
+    # check_linker_flag(CXX "-Wl,-ld_classic" CSP_USE_LD_CLASSIC_MAC)
+    if(CSP_USE_LD_CLASSIC_MAC)
       set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -Wl,-ld_classic")
       set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -Wl,-ld_classic")
     endif()

--- a/csp/tests/test_profiler.py
+++ b/csp/tests/test_profiler.py
@@ -14,6 +14,8 @@ import csp.stats as stats
 from csp import profiler, ts
 from csp.tests.test_dynamic import DynData, gen_basket, random_keys
 
+from .test_showgraph import _cant_find_graphviz
+
 
 @csp.graph
 def stats_graph():
@@ -153,9 +155,10 @@ class TestProfiler(unittest.TestCase):
 
         with profiler.Profiler() as p:
             results = csp.run(graph3, starttime=st, endtime=st + timedelta(seconds=100))
-            with tempfile.NamedTemporaryFile(prefix="foo", suffix=".png", mode="w") as temp_file:
-                temp_file.close()
-                csp.show_graph(graph3, graph_filename=temp_file.name)
+            if not _cant_find_graphviz():
+                with tempfile.NamedTemporaryFile(prefix="foo", suffix=".png", mode="w") as temp_file:
+                    temp_file.close()
+                    csp.show_graph(graph3, graph_filename=temp_file.name)
 
         prof = p.results()
         self.assertEqual(prof.cycle_count, 100)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,7 @@ version = "0.1.0"
 requires-python = ">=3.8"
 
 dependencies = [
+    "backports.zoneinfo; python_version<'3.9'",
     "numpy",
     "pandas",
     "psutil",

--- a/setup.py
+++ b/setup.py
@@ -64,6 +64,9 @@ if platform.system() == "Darwin":
     os.environ["OSX_DEPLOYMENT_TARGET"] = os.environ.get("OSX_DEPLOYMENT_TARGET", "10.13")
     os.environ["MACOSX_DEPLOYMENT_TARGET"] = os.environ.get("OSX_DEPLOYMENT_TARGET", "10.13")
 
+if hasattr(platform, "mac_ver") and platform.mac_ver()[0].startswith("14"):
+    cmake_args.append("-DCSP_USE_LD_CLASSIC_MAC=ON")
+
 if which("ccache"):
     cmake_args.append("-DCSP_USE_CCACHE=On")
 


### PR DESCRIPTION
This PR does three things:
- fix missing runtime dependency for python 3.8
- skip profiling test code if graphviz package missing (xref https://github.com/Point72/csp/pull/30)
- reenable sdist tests on full builds

"Full" build: https://github.com/Point72/csp/actions/runs/7855760939

