### PR TITLE
Add python3.8 linux wheel builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -223,11 +223,6 @@ jobs:
             - os: macos-14
               python-version: "3.9"
 
-            # minimize CI resource usage
-            - is-full-run: false
-              os: ubuntu-22.04
-              python-version: "3.8"
-
             # windows is slow, so dont build unless its a full run
             # - is-full-run: false
             #   os: windows-2022


### PR DESCRIPTION
Doing this on top of #53 because of a fix in that PR. That should be merged first.

I got a request from @robambalu to add python3.8 linux wheels since there are some users who need that. There's a comment that we're not running these builds except on full runs to reduce CI usage. Opening this PR to see what the additional impact of these builds are now that we have caching fully working.