### PR TITLE
csp.stats.list_to_numpy should return a 1DArray, not an NDArray

### DIFF
--- a/csp/stats.py
+++ b/csp/stats.py
@@ -193,7 +193,7 @@ def _np_exp(x: ts[np.ndarray]) -> ts[np.ndarray]:
 
 
 @csp.node(cppimpl=_cspnpstatsimpl._list_to_np)
-def list_to_numpy(x: [ts[float]], fillna: bool = False) -> ts[np.ndarray]:
+def list_to_numpy(x: [ts[float]], fillna: bool = False) -> ts[csp.typing.Numpy1DArray[float]]:
     """
     x: listbasket of floats
     fillna: if True, unticked values will hold their previous value in the array.

--- a/csp/tests/test_stats.py
+++ b/csp/tests/test_stats.py
@@ -2628,6 +2628,10 @@ class TestStats(unittest.TestCase):
     def test_listbasket(self):
         st = datetime(2020, 1, 1)
 
+        @csp.node
+        def takes_1darray( x: csp.ts[csp.typing.Numpy1DArray[float]] ) -> csp.ts[csp.typing.Numpy1DArray[float]]:
+            return x
+        
         @csp.graph
         def graph():
             x_np = csp.curve(
@@ -2643,7 +2647,7 @@ class TestStats(unittest.TestCase):
             as_np = csp.stats.list_to_numpy([x_list1, x_list2])
             as_list = csp.stats.numpy_to_list(x_np, 2)
 
-            csp.add_graph_output("as_np", as_np)
+            csp.add_graph_output("as_np", takes_1darray( as_np ) )
             csp.add_graph_output("as_list0", as_list[0])
             csp.add_graph_output("as_list1", as_list[1])
 


### PR DESCRIPTION
The csp.stats function list_to_numpy should return a 1DArray type since it only produces 1-dimensional array outputs. This can lead to downstream issues when users explicitly type their nodes to accept Numpy1DArray time-series inputs.