### PR TITLE
Clang support

### DIFF
--- a/.github/actions/setup-dependencies/action.yml
+++ b/.github/actions/setup-dependencies/action.yml
@@ -37,16 +37,6 @@ runs:
       run: make dependencies-mac
       if: ${{ runner.os == 'macOS' }}
 
-    # - name: Setup vcpkg cache in shell
-    #   shell: bash
-    #   run: |
-    #     which -a gcc-12
-    #     echo "CC=/usr/local/bin/gcc-12" >> $GITHUB_ENV
-    #     echo "CMAKE_C_COMPILER=/usr/local/bin/gcc-12" >> $GITHUB_ENV
-    #     echo "CXX=/usr/local/bin/g++-12" >> $GITHUB_ENV
-    #     echo "CMAKE_CXX_COMPILER=/usr/local/bin/g++-12" >> $GITHUB_ENV
-    #   if: ${{ runner.os == 'macOS' }}
-
     ################
     # Windows
     - name: Windows init steps (vc143)

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -280,11 +280,11 @@ jobs:
 
         ########
         # Macos
-        - name: Python Build Steps (Macos x86)
+        - name: Python Build Steps (Macos - cibuildwheel)
           run: make dist-py-cibw
           env:
             CIBW_BUILD: "${{ matrix.cibuildwheel }}-macos*"
-            CIBW_ENVIRONMENT_MACOS: CC="/usr/local/bin/gcc-13" CXX="/usr/local/bin/g++-13" CCACHE_DIR="/Users/runner/work/csp/csp/.ccache" VCPKG_DEFAULT_BINARY_CACHE="${{ env.VCPKG_DEFAULT_BINARY_CACHE }}" VCPKG_DOWNLOADS="${{ env.VCPKG_DOWNLOADS }}"
+            CIBW_ENVIRONMENT_MACOS: CCACHE_DIR="/Users/runner/work/csp/csp/.ccache" VCPKG_DEFAULT_BINARY_CACHE="${{ env.VCPKG_DEFAULT_BINARY_CACHE }}" VCPKG_DOWNLOADS="${{ env.VCPKG_DOWNLOADS }}"
             CIBW_ARCHS_MACOS: x86_64
             CIBW_BUILD_VERBOSITY: 3
           if: ${{ matrix.os == 'macos-12' }}
@@ -293,7 +293,7 @@ jobs:
           run: make dist-py-cibw
           env:
             CIBW_BUILD: "${{ matrix.cibuildwheel }}-macos*"
-            CIBW_ENVIRONMENT_MACOS: PATH="/opt/homebrew/opt/bison/bin/:$PATH" CC="/opt/homebrew/bin/gcc-13" CXX="/opt/homebrew/bin/g++-13" LDFLAGS="-Wl,-ld_classic" CCACHE_DIR="/Users/runner/work/csp/csp/.ccache" VCPKG_DEFAULT_BINARY_CACHE="${{ env.VCPKG_DEFAULT_BINARY_CACHE }}" VCPKG_DOWNLOADS="${{ env.VCPKG_DOWNLOADS }}"
+            CIBW_ENVIRONMENT_MACOS: PATH="/opt/homebrew/opt/bison/bin/:$PATH" LDFLAGS="-Wl,-ld_classic" CCACHE_DIR="/Users/runner/work/csp/csp/.ccache" VCPKG_DEFAULT_BINARY_CACHE="${{ env.VCPKG_DEFAULT_BINARY_CACHE }}" VCPKG_DOWNLOADS="${{ env.VCPKG_DOWNLOADS }}"
             CIBW_ARCHS_MACOS: arm64
             CIBW_BUILD_VERBOSITY: 3
           if: ${{ matrix.os == 'macos-14' }}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -170,18 +170,16 @@ endif()
 # RPath #
 #########
 if(MACOS)
-    set(CMAKE_INSTALL_RPATH "@loader_path/:@loader_path/../lib")
+    set(CMAKE_INSTALL_RPATH "@loader_path/")
 elseif(LINUX)
-    set(CMAKE_INSTALL_RPATH "\$ORIGIN:\$ORIGIN/../lib")
+    set(CMAKE_INSTALL_RPATH "\$ORIGIN")
 endif()
 
 ###################################################################################################################################################
 # Flags #
 #########
 # Compiler version flags
-if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++17")
-endif()
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++17")
 
 
 # Optimization Flags
@@ -230,9 +228,13 @@ else()
         -Wall \
         -Wno-deprecated-declarations \
         -Wno-deprecated \
-        -Wno-maybe-uninitialized \
         ")
         add_definitions(-DNDEBUG)
+        if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+            set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} \
+            -Wno-maybe-uninitialized \
+            ")
+        endif()
     endif()
 endif()
 

--- a/cpp/csp/adapters/parquet/ArrowSingleColumnArrayBuilder.h
+++ b/cpp/csp/adapters/parquet/ArrowSingleColumnArrayBuilder.h
@@ -304,7 +304,7 @@ public:
 protected:
     void pushValueToArray()
     {
-        this -> m_builderPtr -> Append( *this -> m_value );
+        (void) this -> m_builderPtr -> Append( *this -> m_value );
     }
 };
 

--- a/cpp/csp/adapters/parquet/ParquetReader.h
+++ b/cpp/csp/adapters/parquet/ParquetReader.h
@@ -12,6 +12,7 @@
 #include <csp/engine/Struct.h>
 #include <arrow/type.h>
 #include <arrow/table.h>
+#include <arrow/type_traits.h>
 #include <memory>
 #include <parquet/arrow/reader.h>
 #include <string>
@@ -240,7 +241,7 @@ public:
                         using ArrowArrayType = typename arrow::TypeTraits<typename arrow::CTypeTraits<T>::ArrowType>::ArrayType;
                         auto &listAdapter = dynamic_cast<ListColumnAdapter<ArrowArrayType> &>(*columnAdapterReference);
                         listAdapter.addSubscriber( inputAdapter, symbol,
-                                                     listReaderInterface );
+                                                    listReaderInterface );
                     } );
         }
     }
@@ -376,7 +377,7 @@ public:
                                     const std::optional<utils::Symbol> &symbol, const DialectGenericListReaderInterface::Ptr &listReaderInterface ) override
     {
         ParquetReader::addListSubscriber( column, inputAdapter, symbol, listReaderInterface);
-        m_columnSubscriptionContainer.m_listColumnSubscriptions[column].push_back(ListColumnSubscriberInfo{inputAdapter, symbol, listReaderInterface});
+        m_columnSubscriptionContainer.m_listColumnSubscriptions[column].push_back(ListColumnSubscriberInfo{{inputAdapter, symbol}, listReaderInterface});
     }
 
 protected:

--- a/cpp/csp/adapters/parquet/ParquetReaderColumnAdapter.h
+++ b/cpp/csp/adapters/parquet/ParquetReaderColumnAdapter.h
@@ -134,7 +134,7 @@ public:
 
     bool isMissingColumn() const override{ return true; }
 
-    virtual CspTypePtr getNativeCspType() const
+    virtual CspTypePtr getNativeCspType() const override
     {
         CSP_THROW( csp::RuntimeException, "Trying to get native type of a missing column " << getColumnName() );
     }
@@ -190,8 +190,7 @@ template< typename ValueType, typename ArrowArrayType >
 class NativeTypeColumnAdapter : public BaseTypedColumnAdapter<ValueType, ArrowArrayType>
 {
 public:
-    using BASE = BaseTypedColumnAdapter<ValueType, ArrowArrayType>;
-    using BASE::BaseTypedColumnAdapter;
+    using BaseTypedColumnAdapter<ValueType, ArrowArrayType>::BaseTypedColumnAdapter;
     virtual CspTypePtr getNativeCspType() const override {return CspType::fromCType<ValueType>::type();}
 
 protected:

--- a/cpp/csp/adapters/utils/JSONMessageStructConverter.h
+++ b/cpp/csp/adapters/utils/JSONMessageStructConverter.h
@@ -3,6 +3,7 @@
 
 #include <csp/adapters/utils/MessageStructConverter.h>
 #include <csp/core/Hash.h>
+#include <csp/engine/CspType.h>
 #include <csp/engine/Dictionary.h>
 #include <rapidjson/document.h>
 #include <list>
@@ -53,7 +54,11 @@ private:
     template<typename T>
     std::vector<T> convertJSON( const char * fieldname, const CspType & type, const FieldEntry & entry, const rapidjson::Value & v, std::vector<T> * );
 
-    
+    #ifdef __clang__
+    template<>
+    boost::container::vector<bool> convertJSON( const char * fieldname, const CspType & type, const FieldEntry & entry, const rapidjson::Value & v, boost::container::vector<bool> * );
+    #endif
+
     Fields           m_fields;
     DateTimeWireType m_datetimeType;
     std::list<std::string> m_jsonkeys; //intentionally stored as list so they dont invalidate on push

--- a/cpp/csp/cppnodes/statsimpl.h
+++ b/cpp/csp/cppnodes/statsimpl.h
@@ -1263,7 +1263,7 @@ class Quantile
         }
 
     private:
-    
+
     #ifndef __clang__
         ost<std::less_equal<double>> m_tree;
     #else

--- a/cpp/csp/engine/ConstInputAdapter.h
+++ b/cpp/csp/engine/ConstInputAdapter.h
@@ -1,4 +1,4 @@
-#ifndef _IN_CSP_ENGINE_ALARMINPUTADAPTER_H
+#ifndef _IN_CSP_ENGINE_CONSTINPUTADAPTER_H
 #define _IN_CSP_ENGINE_CONSTINPUTADAPTER_H
 
 #include <csp/engine/InputAdapter.h>
@@ -10,14 +10,14 @@ template<typename T>
 class ConstInputAdapter final : public InputAdapter
 {
 public:
-    ConstInputAdapter( Engine * engine, CspTypePtr & type, const T & value, 
+    ConstInputAdapter( Engine * engine, CspTypePtr & type, const T & value,
                        TimeDelta delay ) : InputAdapter( engine, type, PushMode::LAST_VALUE ), m_delay( delay ), m_value( value )
     {
     }
 
     void start( DateTime start, DateTime end ) override
     {
-        m_timerHandle = rootEngine() -> scheduleCallback( m_delay, 
+        m_timerHandle = rootEngine() -> scheduleCallback( m_delay,
                                                           [this]
                                                           {
                                                               this -> outputTickTyped<T>( rootEngine() -> now(), m_value );
@@ -25,7 +25,7 @@ public:
                                                           } );
     }
 
-    void stop() override 
+    void stop() override
     {
         rootEngine() -> cancelCallback( m_timerHandle );
     }

--- a/cpp/csp/engine/CppNode.h
+++ b/cpp/csp/engine/CppNode.h
@@ -161,9 +161,9 @@ protected:
         using InputWrapper::InputWrapper;
 
         operator const T &() { return lastValue(); }
-        const T & lastValue() const { return ts() -> lastValueTyped<T>(); }
+        const T & lastValue() const { return ts() -> template lastValueTyped<T>(); }
 
-        const T & valueAtIndex( int32_t index ) const { return ts() -> valueAtIndex<T>( index ); }
+        const T & valueAtIndex( int32_t index ) const { return ts() -> template valueAtIndex<T>( index ); }
     };
 
     template<typename ElemWrapperT>
@@ -379,7 +379,7 @@ protected:
 
         T & reserveSpace()
         {
-            return ts() -> reserveTickTyped<T>( m_node.cycleCount(), m_node.now() );
+            return ts() -> template reserveTickTyped<T>( m_node.cycleCount(), m_node.now() );
         }
     };
 

--- a/cpp/csp/engine/CspType.h
+++ b/cpp/csp/engine/CspType.h
@@ -9,6 +9,10 @@
 #include <memory>
 #include <string>
 
+#ifdef __clang__
+#include <boost/container/vector.hpp>
+#endif
+
 namespace csp
 {
 
@@ -21,7 +25,7 @@ public:
     struct TypeTraits
     {
     public:
-        
+
         enum _enum : uint8_t
         {
             UNKNOWN,
@@ -53,6 +57,8 @@ public:
 
             NUM_TYPES
         };
+
+        constexpr TypeTraits() : m_value(_enum::UNKNOWN) {}
 
         template< typename T >
         struct fromCType;
@@ -149,7 +155,7 @@ public:
     CspStructType( const std::shared_ptr<StructMeta> & meta ) : CspType( CspType::Type::STRUCT ),
                                                                 m_meta( meta )
     {}
-    
+
     const std::shared_ptr<StructMeta> & meta() const { return m_meta; }
 
 private:
@@ -173,47 +179,55 @@ private:
     CspTypePtr m_elemType;
 };
 
+#ifndef __clang__
 template<> struct CspType::Type::fromCType<std::_Bit_reference>      { static constexpr CspType::Type type = CspType::Type::BOOL;            };
-template<> struct CspType::Type::fromCType<bool>                     { static constexpr CspType::Type type = CspType::Type::BOOL;            };
-template<> struct CspType::Type::fromCType<int8_t>                   { static constexpr CspType::Type type = CspType::Type::INT8;            };
-template<> struct CspType::Type::fromCType<uint8_t>                  { static constexpr CspType::Type type = CspType::Type::UINT8;           };
-template<> struct CspType::Type::fromCType<int16_t>                  { static constexpr CspType::Type type = CspType::Type::INT16;           };
-template<> struct CspType::Type::fromCType<uint16_t>                 { static constexpr CspType::Type type = CspType::Type::UINT16;          };
-template<> struct CspType::Type::fromCType<int32_t>                  { static constexpr CspType::Type type = CspType::Type::INT32;           };
-template<> struct CspType::Type::fromCType<uint32_t>                 { static constexpr CspType::Type type = CspType::Type::UINT32;          };
-template<> struct CspType::Type::fromCType<int64_t>                  { static constexpr CspType::Type type = CspType::Type::INT64;           };
-template<> struct CspType::Type::fromCType<uint64_t>                 { static constexpr CspType::Type type = CspType::Type::UINT64;          };
-template<> struct CspType::Type::fromCType<double>                   { static constexpr CspType::Type type = CspType::Type::DOUBLE;          };
-template<> struct CspType::Type::fromCType<DateTime>                 { static constexpr CspType::Type type = CspType::Type::DATETIME;        };
-template<> struct CspType::Type::fromCType<TimeDelta>                { static constexpr CspType::Type type = CspType::Type::TIMEDELTA;       };
-template<> struct CspType::Type::fromCType<Date>                     { static constexpr CspType::Type type = CspType::Type::DATE;            };
-template<> struct CspType::Type::fromCType<Time>                     { static constexpr CspType::Type type = CspType::Type::TIME;            };
-template<> struct CspType::Type::fromCType<CspEnum>                  { static constexpr CspType::Type type = CspType::Type::ENUM;            };
-template<> struct CspType::Type::fromCType<CspType::StringCType>     { static constexpr CspType::Type type = CspType::Type::STRING;          };
-template<> struct CspType::Type::fromCType<StructPtr>                { static constexpr CspType::Type type = CspType::Type::STRUCT;          };
-template<typename T> struct CspType::Type::fromCType<TypedStructPtr<T>> { static constexpr CspType::Type type = CspType::Type::STRUCT;       };
-template<> struct CspType::Type::fromCType<DialectGenericType>       { static constexpr CspType::Type type = CspType::Type::DIALECT_GENERIC; };
-template<typename T> struct CspType::Type::fromCType<std::vector<T>> { static constexpr CspType::Type type = CspType::Type::ARRAY; };
+#endif
+template<> template<> struct CspType::Type::fromCType<bool>                     { static constexpr CspType::Type type = CspType::Type::BOOL;            };
+template<> template<> struct CspType::Type::fromCType<int8_t>                   { static constexpr CspType::Type type = CspType::Type::INT8;            };
+template<> template<> struct CspType::Type::fromCType<uint8_t>                  { static constexpr CspType::Type type = CspType::Type::UINT8;           };
+template<> template<> struct CspType::Type::fromCType<int16_t>                  { static constexpr CspType::Type type = CspType::Type::INT16;           };
+template<> template<> struct CspType::Type::fromCType<uint16_t>                 { static constexpr CspType::Type type = CspType::Type::UINT16;          };
+template<> template<> struct CspType::Type::fromCType<int32_t>                  { static constexpr CspType::Type type = CspType::Type::INT32;           };
+template<> template<> struct CspType::Type::fromCType<uint32_t>                 { static constexpr CspType::Type type = CspType::Type::UINT32;          };
+template<> template<> struct CspType::Type::fromCType<int64_t>                  { static constexpr CspType::Type type = CspType::Type::INT64;           };
+template<> template<> struct CspType::Type::fromCType<uint64_t>                 { static constexpr CspType::Type type = CspType::Type::UINT64;          };
+template<> template<> struct CspType::Type::fromCType<double>                   { static constexpr CspType::Type type = CspType::Type::DOUBLE;          };
+template<> template<> struct CspType::Type::fromCType<DateTime>                 { static constexpr CspType::Type type = CspType::Type::DATETIME;        };
+template<> template<> struct CspType::Type::fromCType<TimeDelta>                { static constexpr CspType::Type type = CspType::Type::TIMEDELTA;       };
+template<> template<> struct CspType::Type::fromCType<Date>                     { static constexpr CspType::Type type = CspType::Type::DATE;            };
+template<> template<> struct CspType::Type::fromCType<Time>                     { static constexpr CspType::Type type = CspType::Type::TIME;            };
+template<> template<> struct CspType::Type::fromCType<CspEnum>                  { static constexpr CspType::Type type = CspType::Type::ENUM;            };
+template<> template<> struct CspType::Type::fromCType<CspType::StringCType>     { static constexpr CspType::Type type = CspType::Type::STRING;          };
+template<> template<> struct CspType::Type::fromCType<StructPtr>                { static constexpr CspType::Type type = CspType::Type::STRUCT;          };
+template<> template<typename T> struct CspType::Type::fromCType<TypedStructPtr<T>> { static constexpr CspType::Type type = CspType::Type::STRUCT;       };
+template<> template<> struct CspType::Type::fromCType<DialectGenericType>       { static constexpr CspType::Type type = CspType::Type::DIALECT_GENERIC; };
+template<> template<typename T> struct CspType::Type::fromCType<std::vector<T>> { static constexpr CspType::Type type = CspType::Type::ARRAY;           };
+#ifdef __clang__
+template<> template<> struct CspType::Type::fromCType<boost::container::vector<bool>> { static constexpr CspType::Type type = CspType::Type::ARRAY;     };
+#endif
 
-template<> struct CspType::Type::toCType<CspType::Type::BOOL,void>            { using type = bool;      };
-template<> struct CspType::Type::toCType<CspType::Type::INT8,void>            { using type = int8_t;    };
-template<> struct CspType::Type::toCType<CspType::Type::UINT8,void>           { using type = uint8_t;   };
-template<> struct CspType::Type::toCType<CspType::Type::INT16,void>           { using type = int16_t;   };
-template<> struct CspType::Type::toCType<CspType::Type::UINT16,void>          { using type = uint16_t;  };
-template<> struct CspType::Type::toCType<CspType::Type::INT32,void>           { using type = int32_t;   };
-template<> struct CspType::Type::toCType<CspType::Type::UINT32,void>          { using type = uint32_t;  };
-template<> struct CspType::Type::toCType<CspType::Type::INT64,void>           { using type = int64_t;   };
-template<> struct CspType::Type::toCType<CspType::Type::UINT64,void>          { using type = uint64_t;  };
-template<> struct CspType::Type::toCType<CspType::Type::DOUBLE,void>          { using type = double;    };
-template<> struct CspType::Type::toCType<CspType::Type::DATETIME,void>        { using type = DateTime;  };
-template<> struct CspType::Type::toCType<CspType::Type::TIMEDELTA,void>       { using type = TimeDelta; };
-template<> struct CspType::Type::toCType<CspType::Type::DATE,void>            { using type = Date; };
-template<> struct CspType::Type::toCType<CspType::Type::TIME,void>            { using type = Time; };
-template<> struct CspType::Type::toCType<CspType::Type::ENUM,void>            { using type = CspEnum; };
-template<> struct CspType::Type::toCType<CspType::Type::STRING,void>          { using type = CspType::StringCType; };
-template<> struct CspType::Type::toCType<CspType::Type::STRUCT,void>          { using type = StructPtr; };
-template<> struct CspType::Type::toCType<CspType::Type::DIALECT_GENERIC,void> { using type = DialectGenericType; };
-template<typename T> struct CspType::Type::toCType<CspType::Type::ARRAY,T> { using type = std::vector<T>; };
+template<> template<> struct CspType::Type::toCType<CspType::Type::BOOL,void>            { using type = bool;                 };
+template<> template<> struct CspType::Type::toCType<CspType::Type::INT8,void>            { using type = int8_t;               };
+template<> template<> struct CspType::Type::toCType<CspType::Type::UINT8,void>           { using type = uint8_t;              };
+template<> template<> struct CspType::Type::toCType<CspType::Type::INT16,void>           { using type = int16_t;              };
+template<> template<> struct CspType::Type::toCType<CspType::Type::UINT16,void>          { using type = uint16_t;             };
+template<> template<> struct CspType::Type::toCType<CspType::Type::INT32,void>           { using type = int32_t;              };
+template<> template<> struct CspType::Type::toCType<CspType::Type::UINT32,void>          { using type = uint32_t;             };
+template<> template<> struct CspType::Type::toCType<CspType::Type::INT64,void>           { using type = int64_t;              };
+template<> template<> struct CspType::Type::toCType<CspType::Type::UINT64,void>          { using type = uint64_t;             };
+template<> template<> struct CspType::Type::toCType<CspType::Type::DOUBLE,void>          { using type = double;               };
+template<> template<> struct CspType::Type::toCType<CspType::Type::DATETIME,void>        { using type = DateTime;             };
+template<> template<> struct CspType::Type::toCType<CspType::Type::TIMEDELTA,void>       { using type = TimeDelta;            };
+template<> template<> struct CspType::Type::toCType<CspType::Type::DATE,void>            { using type = Date;                 };
+template<> template<> struct CspType::Type::toCType<CspType::Type::TIME,void>            { using type = Time;                 };
+template<> template<> struct CspType::Type::toCType<CspType::Type::ENUM,void>            { using type = CspEnum;              };
+template<> template<> struct CspType::Type::toCType<CspType::Type::STRING,void>          { using type = CspType::StringCType; };
+template<> template<> struct CspType::Type::toCType<CspType::Type::STRUCT,void>          { using type = StructPtr;            };
+template<> template<> struct CspType::Type::toCType<CspType::Type::DIALECT_GENERIC,void> { using type = DialectGenericType;   };
+template<> template<typename T> struct CspType::Type::toCType<CspType::Type::ARRAY, T>   { using type = std::vector<T>;       };
+#ifdef __clang__
+template<> template<> struct CspType::Type::toCType<CspType::Type::ARRAY, bool>          { using type = boost::container::vector<bool>; };
+#endif
 
 template<> struct CspType::fromCType<bool>                 { static CspTypePtr & type() { return CspType::BOOL();      } };
 template<> struct CspType::fromCType<int8_t>               { static CspTypePtr & type() { return CspType::INT8();      } };

--- a/cpp/csp/engine/DynamicEngine.h
+++ b/cpp/csp/engine/DynamicEngine.h
@@ -1,5 +1,5 @@
 #ifndef _IN_CSP_ENGINE_DYNAMICENGINE_H
-#define _IN_CSP_ENGINE_DUNAMICENGINE_H
+#define _IN_CSP_ENGINE_DYNAMICENGINE_H
 
 #include <csp/engine/Engine.h>
 #include <csp/engine/OutputAdapter.h>

--- a/cpp/csp/engine/Feedback.h
+++ b/cpp/csp/engine/Feedback.h
@@ -14,7 +14,7 @@ template<typename T>
 class FeedbackOutputAdapter final : public OutputAdapter
 {
 public:
-    FeedbackOutputAdapter( csp::Engine * engine, 
+    FeedbackOutputAdapter( csp::Engine * engine,
                            InputAdapter * boundInput );
     ~FeedbackOutputAdapter() {}
 
@@ -40,7 +40,7 @@ public:
 
     void pushTick( const T & value )
     {
-        m_timerHandle = rootEngine() -> scheduleCallback( TimeDelta::ZERO(), [this,value]() 
+        m_timerHandle = rootEngine() -> scheduleCallback( TimeDelta::ZERO(), [this,value]()
                                                           {
                                                               return this -> consumeTick( value ) ? nullptr : this;
                                                           } );
@@ -50,7 +50,7 @@ private:
 };
 
 template<typename T>
-inline FeedbackOutputAdapter<T>::FeedbackOutputAdapter( csp::Engine * engine, 
+inline FeedbackOutputAdapter<T>::FeedbackOutputAdapter( csp::Engine * engine,
                                                         InputAdapter * boundInput ) : OutputAdapter( engine )
 {
     m_boundInput = dynamic_cast<FeedbackInputAdapter<T> *>( boundInput );
@@ -62,7 +62,7 @@ inline FeedbackOutputAdapter<T>::FeedbackOutputAdapter( csp::Engine * engine,
 template<typename T>
 inline void FeedbackOutputAdapter<T>::executeImpl()
 {
-    m_boundInput -> pushTick( input() -> lastValueTyped<T>() );
+    m_boundInput -> pushTick( input() -> template lastValueTyped<T>() );
 }
 
 }

--- a/cpp/csp/engine/InputAdapter.h
+++ b/cpp/csp/engine/InputAdapter.h
@@ -70,7 +70,7 @@ bool InputAdapter::consumeTick( const T & value )
             using ArrayT = typename CspType::Type::toCType<CspType::Type::ARRAY,T>::type;
             if( likely( rootEngine() -> cycleCount() != lastCycleCount() ) )
             {
-                //ensure we reuse vector memory in our buffer by using reserve api and 
+                //ensure we reuse vector memory in our buffer by using reserve api and
                 //clearing existing value if any
                 reserveTickTyped<ArrayT>( rootEngine() -> cycleCount(), rootEngine() -> now() ).clear();
             }

--- a/cpp/csp/engine/PartialSwitchCspType.h
+++ b/cpp/csp/engine/PartialSwitchCspType.h
@@ -149,9 +149,9 @@ private:
     static R_T handleArrayType( const CspType *type, F &&f )
     {
         const auto *arrayType = static_cast<const CspArrayType *>( type );
-
         return ArraySubTypeSwitchT::invoke( arrayType -> elemType().get(), [ &f ]( auto tag )
         {
+
             return f( CspType::Type::toCType<T, typename decltype(tag)::type>());
         } );
     }
@@ -339,6 +339,14 @@ struct ConstructibleTypeSwitchAux<std::vector<T>>
 {
     using type = PartialSwitchCspType<csp::CspType::Type::ARRAY>;
 };
+
+#ifdef __clang__
+template<>
+struct ConstructibleTypeSwitchAux<boost::container::vector<bool>>
+{
+    using type = PartialSwitchCspType<csp::CspType::Type::ARRAY>;
+};
+#endif
 
 template<>
 struct ConstructibleTypeSwitchAux<StructPtr>

--- a/cpp/csp/engine/PendingPushEvents.h
+++ b/cpp/csp/engine/PendingPushEvents.h
@@ -7,7 +7,7 @@
 namespace csp
 {
 
-class PushGroup;
+struct PushGroup;
 class PushInputAdapters;
 
 class PendingPushEvents
@@ -34,7 +34,7 @@ private:
     using GroupEvents     = std::unordered_map<PushGroup*,EventList>;
 
     //Ungrouped events are for NON_COLLAPSING PushInputAdapters that can only process one tick per cycle
-    //we store them by adapter here so that we dont have to rescan all events every cycle to pop a single 
+    //we store them by adapter here so that we dont have to rescan all events every cycle to pop a single
     //backed up input ( if we merged adaptrers into one list we would have to rescan every cycle )
     using UngroupedEvents = std::unordered_map<PushInputAdapter*,EventList>;
 

--- a/cpp/csp/engine/TickBuffer.h
+++ b/cpp/csp/engine/TickBuffer.h
@@ -4,7 +4,7 @@
 /************************************************************************
  ** Tick buffer is the storage for CSP time series ticks
  ** it uses a circular buffer for storage but only allows pushing back
- ** and resizing 
+ ** and resizing
  ***********************************************************************/
 #include <csp/core/System.h>
 #include <csp/core/Time.h>
@@ -21,7 +21,7 @@ class TickBuffer
 public:
     TickBuffer( uint32_t capacity = 1 );
     ~TickBuffer();
-    
+
     void clear()
     {
         m_full = false;
@@ -138,7 +138,7 @@ inline T & TickBuffer<T>::operator[]( uint32_t index )
     int64_t raw_index = int64_t( m_writeIndex ) - index - 1;
     if( unlikely( raw_index < 0 ) )
         raw_index += m_capacity;
-    
+
     return m_buffer[ raw_index ];
 }
 

--- a/cpp/csp/engine/TimeSeries.h
+++ b/cpp/csp/engine/TimeSeries.h
@@ -76,7 +76,7 @@ public:
 
 public:
     TimeSeries();
-    virtual ~TimeSeries() 
+    virtual ~TimeSeries()
     {
     }
 
@@ -127,13 +127,13 @@ public:
     std::pair<int32_t, int32_t> getValueIndexRange(
             DateTime time, DuplicatePolicyEnum duplicatePolicy = DuplicatePolicyEnum::LAST_VALUE) const;
 
-    
+
     virtual void setTickCountPolicy( int32_t tickCount ) = 0;
     virtual void setTickTimeWindowPolicy( TimeDelta window ) = 0;
 
     int32_t   tickCountPolicy() const      { return m_bufferTickCountPolicy; }
     TimeDelta tickTimeWindowPolicy() const { return m_bufferTimeWindowPolicy; }
-    
+
 protected:
     int32_t    m_bufferTickCountPolicy;
     uint32_t   m_count;
@@ -189,7 +189,7 @@ public:
         timeBuffer -> push_back( timestamp );
         return dataBuffer -> prepare_write();
     }
-    
+
     void addTick( DateTime timestamp, const T & value )
     {
         reserveSpaceForTick( timestamp ) = value;
@@ -208,7 +208,7 @@ public:
     const T & lastValue() const                   { return const_cast<TimeSeriesTyped<T>*>( this ) -> lastValue(); }
     const T & valueAtIndex( int32_t index ) const { return const_cast<TimeSeriesTyped<T>*>( this ) -> valueAtIndex( index ); }
     const TickBuffer<T> * dataline() const        { return m_dataline.buffer(); }
-    
+
     void setTickCountPolicy( int32_t tickCount )
     {
         if( tickCount > 1 )
@@ -237,11 +237,11 @@ public:
         m_timeline.setBuffer( capacity, ( bool )m_count );
         m_dataline.setBuffer( capacity, ( bool )m_count );
     }
-    
+
 private:
-    /* 
+    /*
         We only need to use a tick buffer if the buffering policy is greater than 1 or time-based.
-        Since most of the time we only use the last/current value, don't bother allocating the tick buffer until 
+        Since most of the time we only use the last/current value, don't bother allocating the tick buffer until
         we know we actually need it, and instead just store the value in TickBufferAccess.
     */
     TickBufferAccess<T>  m_dataline;
@@ -251,7 +251,7 @@ private:
 TimeSeries
 */
 
-inline TimeSeries::TimeSeries() : 
+inline TimeSeries::TimeSeries() :
     m_bufferTickCountPolicy( 1 ),
     m_count( 0 )
 {
@@ -296,7 +296,7 @@ inline const T & TimeSeries::valueAtIndex( int32_t index ) const
 }
 
 inline DateTime TimeSeries::timeAtIndex( uint32_t index ) const
-{ 
+{
     return m_timeline.valueAtIndex( index );
 }
 
@@ -383,8 +383,6 @@ TimeSeries::getValueIndexRange(DateTime time, DuplicatePolicyEnum duplicatePolic
 
     return std::make_pair(startI.index, endI.index);
 }
-
-
 
 };
 #endif

--- a/cpp/csp/python/InitHelper.h
+++ b/cpp/csp/python/InitHelper.h
@@ -29,7 +29,7 @@ public:
     bool execute( PyObject * module );
 
 private:
-    
+
     InitHelper() {}
 
     using Callbacks = std::vector<InitCallback>;
@@ -77,7 +77,7 @@ inline InitHelper::InitCallback InitHelper::moduleMethodsCallback( PyMethodDef *
 
 inline InitHelper::InitCallback InitHelper::moduleMethod( const char * name, PyCFunction func, int flags, const char * doc )
 {
-    PyMethodDef defs[2]{ { name, func, flags, doc }, nullptr };
+    PyMethodDef defs[2]{ { name, func, flags, doc }, { nullptr } };
 
     //Note that we rely on the lambda closure to keep the lifetime of defs which is kept by ptr
     //m_callbacks will keep the InitCallback around for the life of the program

--- a/cpp/csp/python/PyCspType.h
+++ b/cpp/csp/python/PyCspType.h
@@ -12,6 +12,7 @@ static_assert( alignof( csp::DialectGenericType ) == alignof( csp::python::PyObj
 namespace csp
 {
 template<>
+template<>
 struct CspType::Type::fromCType<csp::python::PyObjectPtr>
 {
     static constexpr csp::CspType::Type type = csp::CspType::Type::DIALECT_GENERIC;

--- a/cpp/csp/python/adapters/parquetadapterimpl.cpp
+++ b/cpp/csp/python/adapters/parquetadapterimpl.cpp
@@ -380,7 +380,7 @@ public:
         return reinterpret_cast<V *>(PyArray_DATA( arrayObject ));
     }
 
-    virtual void setValue(const csp::DialectGenericType& list, int index, const V& value)
+    virtual void setValue(const csp::DialectGenericType& list, int index, const V& value) override
     {
         getRawDataBuffer(list)[index] = value;
     }
@@ -634,7 +634,7 @@ csp::AdapterManager *create_parquet_output_adapter_manager( PyEngine *engine, co
     {
         PyObjectPtr pyFilenameVisitor = PyObjectPtr::own( toPython( pyFilenameVisitorDG ) );
         fileVisitor = [pyFilenameVisitor]( const std::string & filename )
-            { 
+            {
                 PyObjectPtr rv =  PyObjectPtr::own( PyObject_CallFunction( pyFilenameVisitor.get(), "O", PyObjectPtr::own( toPython( filename ) ).get() ) );
                 if( !rv.get() )
                     CSP_THROW( PythonPassthrough, "" );

--- a/cpp/csp/python/cspimpl.cpp
+++ b/cpp/csp/python/cspimpl.cpp
@@ -76,7 +76,7 @@ static PyObject *_create_traceback( PyObject *, PyObject * args )
     int lasti;
     int lineno;
 
-    if( !PyArg_ParseTuple( args, "OO!ii", 
+    if( !PyArg_ParseTuple( args, "OO!ii",
                            &next,
                            &PyFrame_Type, &frame, &lasti, &lineno ) )
         CSP_THROW( PythonPassthrough, "" );
@@ -124,7 +124,7 @@ static PyMethodDef _cspimpl_methods[] = {
     {"create_traceback",            (PyCFunction) _create_traceback,          METH_VARARGS,   "internal"},
     {"_csp_engine_stats",           (PyCFunction) _engine_stats,              METH_O, "engine statistics"},
     {"set_capture_cpp_backtrace",   (PyCFunction) _set_capture_cpp_backtrace, METH_VARARGS,   "internal"},
-    nullptr
+    { nullptr },
 };
 
 static PyModuleDef _cspimpl_module = {

--- a/csp/adapters/parquet.py
+++ b/csp/adapters/parquet.py
@@ -1,7 +1,6 @@
 import datetime
 import io
 import numpy
-import platform
 import pyarrow
 import pyarrow.parquet
 from importlib.metadata import PackageNotFoundError, version as get_package_version
@@ -101,9 +100,6 @@ class ParquetReader:
             self._properties["tz"] = tz.zone
         if binary_arrow:
             self._properties["is_arrow_ipc"] = True
-        if not binary_arrow and platform.system() == "Darwin":
-            # TKP fix parquet reading on darwin
-            raise RuntimeError("Cannot read parquet files on macOS yet")
         if start_time:
             self._properties["start_time"] = start_time
         if end_time:

--- a/csp/tests/adapters/test_parquet.py
+++ b/csp/tests/adapters/test_parquet.py
@@ -2,11 +2,9 @@ import math
 import numpy
 import os
 import pandas
-import platform
 import polars
 import pyarrow
 import pyarrow.parquet
-import pytest
 import pytz
 import tempfile
 import unittest
@@ -34,7 +32,6 @@ parquet_filename = os.path.join(os.path.dirname(__file__), "parquet_test_data.pa
 arrow_filename = os.path.join(os.path.dirname(__file__), "arrow_test_data.arrow")
 
 
-@pytest.mark.skipif(platform.system() == "Darwin", reason="Does not run on macOS")
 class TestParquetReader(unittest.TestCase):
     def do_test_body(self, filename, arrow=False):
         @csp.graph

--- a/csp/tests/test_engine.py
+++ b/csp/tests/test_engine.py
@@ -3,6 +3,7 @@ import gc
 import numpy as np
 import os
 import pickle
+import platform
 import psutil
 import random
 import re
@@ -1333,7 +1334,7 @@ class TestEngine(unittest.TestCase):
             datetime(1969, 5, 6, 2, 3, 4),
             datetime(1969, 5, 6, 2, 3, 4, 123456),
             # Edge cases, DateTime MIN / MAX
-            datetime(1678, 1, 1),
+            datetime(1969, 12, 31, 23, 59, 59) if platform.system() == "Darwin" else datetime(1968, 1, 1),
             datetime(2261, 12, 31, 23, 59, 59, 999999),
             timedelta(days=1, seconds=3600, microseconds=123456),
             timedelta(days=-1, seconds=3600, microseconds=123456),


### PR DESCRIPTION
This PR adds clang support. Right now it does so by:
- adding `template<>` blocks that g++ is comfortable eliding
- adding missing `constexpr` to `TypeTraits` that g++ is comfortable eliding
- tweaking `vector<bool>` specialization on `clang` compiler to rely on `boost::containers::vector` which avoids bitwise specialization that makes life annoying 
- a bunch of miscellaneous fixes to warnings that `g++` does not notice
    - misnamed header guards
    - missing `overrides` 

The mac builds have both been ported to `clang++` and the builds are passing (tests passing locally).

Unblocks https://github.com/Point72/csp/issues/10 and https://github.com/Point72/csp/issues/32
Full Build: https://github.com/Point72/csp/actions/runs/7938321028

TODO
- [x] remove arrow Mac guard in parquet adapter / tests
- [x] double check accessing `bool` fields from structs as `ts`
- [ ] (maybe) consolidate Mac builds now that we can cross-compile to arm64
- [ ] (maybe) build `universal2` binaries
- [ ] update developer docs to remove extra mac steps for `g++` 
