### PR TITLE
[WIP] attempt to reenable boolean vectors

### DIFF
--- a/cpp/csp/adapters/utils/JSONMessageWriter.h
+++ b/cpp/csp/adapters/utils/JSONMessageWriter.h
@@ -63,14 +63,14 @@ public:
     }
 
 private:
-    void processTickImpl( const OutputDataMapper & dataMapper, const TimeSeriesProvider * sourcets )
+    void processTickImpl( const OutputDataMapper & dataMapper, const TimeSeriesProvider * sourcets ) override
     {
         dataMapper.apply( *this, sourcets );
     }
 
     template<typename T>
     inline auto convertValue( const T & value )
-    { 
+    {
         return value;
     }
 
@@ -92,13 +92,13 @@ private:
 template<>
 inline auto JSONMessageWriter::convertValue( const std::string & value )
 {
-    return rapidjson::StringRef( value.c_str() ); 
+    return rapidjson::StringRef( value.c_str() );
 }
 
 template<>
 inline auto JSONMessageWriter::convertValue( const csp::Date & value )
 {
-    return rapidjson::Value( value.asYYYYMMDD().c_str(), m_doc.GetAllocator() ); 
+    return rapidjson::Value( value.asYYYYMMDD().c_str(), m_doc.GetAllocator() );
 }
 
 template<>
@@ -123,7 +123,7 @@ inline auto JSONMessageWriter::convertValue( const csp::DateTime & value )
 template<>
 inline auto JSONMessageWriter::convertValue( const csp::TimeDelta & value )
 {
-    return rapidjson::Value( value.asNanoseconds() ); 
+    return rapidjson::Value( value.asNanoseconds() );
 }
 
 template<>
@@ -159,7 +159,7 @@ inline auto JSONMessageWriter::convertValue( const StructPtr & struct_, const Cs
         if( !nestedEntry.sField -> isSet( struct_.get() ) )
             continue;
 
-        
+
         SupportedCspTypeSwitch::template invoke<SupportedArrayCspTypeSwitch>(
             nestedEntry.sField -> type().get(),
             [ & ]( auto tag )

--- a/cpp/csp/engine/CspType.h
+++ b/cpp/csp/engine/CspType.h
@@ -217,7 +217,6 @@ template<> template<> struct CspType::Type::toCType<CspType::Type::STRING,void> 
 template<> template<> struct CspType::Type::toCType<CspType::Type::STRUCT,void>          { using type = StructPtr;            };
 template<> template<> struct CspType::Type::toCType<CspType::Type::DIALECT_GENERIC,void> { using type = DialectGenericType;   };
 template<> template<typename T> struct CspType::Type::toCType<CspType::Type::ARRAY,T>    { using type = std::vector<T>;       };
-template<> template<> struct CspType::Type::toCType<CspType::Type::ARRAY,bool>           { using type = std::vector<uint8_t>; };
 
 template<> struct CspType::fromCType<bool>                 { static CspTypePtr & type() { return CspType::BOOL();      } };
 template<> struct CspType::fromCType<int8_t>               { static CspTypePtr & type() { return CspType::INT8();      } };

--- a/cpp/csp/engine/InputAdapter.cpp
+++ b/cpp/csp/engine/InputAdapter.cpp
@@ -13,4 +13,53 @@ InputAdapter::InputAdapter( Engine *engine, const CspTypePtr &type, PushMode pus
         init( type );
 }
 
+
+template<>
+bool InputAdapter::consumeTick( const bool & value )
+{
+    switch( pushMode() )
+    {
+        case PushMode::LAST_VALUE:
+        {
+            if( unlikely( rootEngine() -> cycleCount() == lastCycleCount() ) )
+                m_timeseries -> lastValueTyped<bool>() = value;
+            else
+                this -> outputTickTyped<bool>( rootEngine() -> now(), value );
+            return true;
+        }
+
+        case PushMode::BURST:
+        {
+            CSP_ASSERT( type() -> type() == CspType::Type::ARRAY );
+            CSP_ASSERT( static_cast<const CspArrayType * >( type() ) -> elemType() -> type() == CspType::Type::fromCType<bool>::type );
+
+            using ArrayT = typename CspType::Type::toCType<CspType::Type::ARRAY, bool>::type;
+            if( likely( rootEngine() -> cycleCount() != lastCycleCount() ) )
+            {
+                //ensure we reuse vector memory in our buffer by using reserve api and
+                //clearing existing value if any
+                reserveTickTyped<ArrayT>( rootEngine() -> cycleCount(), rootEngine() -> now() ).clear();
+            }
+
+            m_timeseries -> lastValueTyped<ArrayT>().push_back( value );
+            return true;
+        }
+
+        case PushMode::NON_COLLAPSING:
+        {
+            if( unlikely( rootEngine() -> cycleCount() == lastCycleCount() ) )
+                return false;
+
+            this -> outputTickTyped<bool>( rootEngine() -> now(), value );
+            return true;
+        }
+
+        default:
+            CSP_THROW( NotImplemented, pushMode() << " mode is not yet supported" );
+            break;
+    }
+
+    return true;
+}
+
 }

--- a/cpp/csp/engine/InputAdapter.h
+++ b/cpp/csp/engine/InputAdapter.h
@@ -70,7 +70,7 @@ bool InputAdapter::consumeTick( const T & value )
             using ArrayT = typename CspType::Type::toCType<CspType::Type::ARRAY,T>::type;
             if( likely( rootEngine() -> cycleCount() != lastCycleCount() ) )
             {
-                //ensure we reuse vector memory in our buffer by using reserve api and 
+                //ensure we reuse vector memory in our buffer by using reserve api and
                 //clearing existing value if any
                 reserveTickTyped<ArrayT>( rootEngine() -> cycleCount(), rootEngine() -> now() ).clear();
             }
@@ -97,5 +97,4 @@ bool InputAdapter::consumeTick( const T & value )
 }
 
 };
-
 #endif


### PR DESCRIPTION
This PR builds on https://github.com/Point72/csp/pull/83 and attempts to reenable `vector<bool>` by targeted specialization of functions that would've resulted in bit references.

It fails the same tests as #83 , but is probably closer to the end solution. The failing tests are almost all pandas related

```python
FAILED csp/tests/impl/test_dateframe.py::TestCspDataFrame::test_math_ops - AssertionError: False is not true
FAILED csp/tests/impl/test_pandas_ext_type.py::TestBooleanReduce::test_reduce_series_boolean[all-True] - AssertionError: Input are different
FAILED csp/tests/impl/test_pandas_ext_type.py::TestBooleanReduce::test_reduce_series_boolean[all-False] - AssertionError: Input are different
FAILED csp/tests/impl/test_pandas_ext_type.py::TestBooleanReduce::test_reduce_series_boolean[any-True] - AssertionError: Input are different
FAILED csp/tests/impl/test_pandas_ext_type.py::TestBooleanReduce::test_reduce_series_boolean[any-False] - AssertionError: Input are different
FAILED csp/tests/impl/test_pandas_perspective.py::TestCspPerspectiveTable::test_run_types - AssertionError: Series are different
FAILED csp/tests/test_history.py::TestHistory::test_range_access - AssertionError: dtype('int8') != dtype('bool')
FAILED csp/tests/test_type_checking.py::TestTypeChecking::test_runtime_type_check - AssertionError: TypeError not raised
```