### PR TITLE
only automatically publish releases to github

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -653,13 +653,7 @@ jobs:
         - name: Publish to github releases
           uses: softprops/action-gh-release@v1
           with:
-            draft: true
             generate_release_notes: true
             files: dist/*
           env:
             GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-        - name: Publish to testpypi
-          uses: pypa/gh-action-pypi-publish@release/v1
-          with:
-            repository-url: https://test.pypi.org/legacy


### PR DESCRIPTION
Let's not do automatic testpypi uploads as part of the release automation. We can get everything we need from the github releases.

Also in the interest of having less manual intervention, let's publish github releases for new tags without using `--draft`.