### PR TITLE
Fix invalid access to a struct meta name when the struct is a base struct

### DIFF
--- a/cpp/csp/python/Conversions.h
+++ b/cpp/csp/python/Conversions.h
@@ -422,7 +422,13 @@ inline StructPtr fromPython( PyObject * o, const CspType & type )
         ( static_cast<const CspStructType &>( type ).meta() && //could be csp.Struct as a type annotation which is allowed
           !StructMeta::isDerivedType( static_cast<PyStruct *>( o ) -> structMeta(),
                                       static_cast<const CspStructType &>( type ).meta().get() ) ) )
-        CSP_THROW( TypeError, "Invalid struct type, expected struct " << static_cast<const CspStructType &>( type ).meta() -> name() << " got " << Py_TYPE( o ) -> tp_name );
+    {
+        std::string name;
+        auto meta = static_cast<const CspStructType &>( type ).meta();
+        if( meta )
+            name = " " + meta -> name();
+        CSP_THROW( TypeError, "Invalid struct type, expected struct" << name << " got " << Py_TYPE( o ) -> tp_name );
+    }
 
     return static_cast<PyStruct *>( o ) -> struct_;
 }

--- a/csp/tests/impl/test_struct.py
+++ b/csp/tests/impl/test_struct.py
@@ -1078,6 +1078,20 @@ class TestCspStruct(unittest.TestCase):
             repr(all)
             all = all[:100]
 
+    def test_python_conversion_on_nested_base_struct(self):
+        ''' Was a BUG due to the error message in fromPython trying to access the meta name of a base struct class'''
+        class A(csp.Struct):
+            a: csp.Struct
+
+        # 1) in constructor
+        with self.assertRaises(TypeError) as e:
+            my_a = A(a=None)
+        
+        # 2) setting the member
+        with self.assertRaises(TypeError) as e:
+            my_a = A()
+            my_a.a = None
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Previously, the following code would result in a seg fault:

```
import csp

class StructOfGenericStruct(csp.Struct):
    a: csp.Struct

if _name_ == "_main_":
    ms = StructOfGenericStruct()
    ms.a = None
```

This change fixes that issue so that we gracefully throw an error with a useful message. 

```
TypeError: PyStruct.cpp:setattr:449:TypeError: on field 'a' : Invalid struct type, expected struct got NoneType
```