### PR TITLE
Fix second typo in pyproject.toml for python versions link

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 [![PyPI](https://img.shields.io/pypi/v/csp.svg?style=flat)](https://pypi.python.org/pypi/csp)
 [![License](https://img.shields.io/badge/license-Apache--2.0-green)](https://github.com/Point72/csp/LICENSE)
 [![Build Status](https://github.com/Point72/csp/actions/workflows/build.yml/badge.svg)](https://github.com/Point72/csp/actions/workflows/build.yml)
-[![Python Versions](https://img.shields.io/badge/python-3.8_%7C_3.9_%7C_3.10_%7C_3.11-blue)](https://github.com/Point72/csp/blob/pyproject.toml)
+[![Python Versions](https://img.shields.io/badge/python-3.8_%7C_3.9_%7C_3.10_%7C_3.11-blue)](https://github.com/Point72/csp/blob/main/pyproject.toml)
 
 <br/>
 


### PR DESCRIPTION
https://github.com/Point72/csp/pull/120#discussion_r1504949399 did not mention that the link is BROKEN 😆 

Fixes that.

