### PR TITLE
Add a windows development environment specification

### DIFF
--- a/dev-environment-win.yml
+++ b/dev-environment-win.yml
@@ -1,0 +1,31 @@
+name: csp-dev
+channels:
+  - conda-forge
+  - nodefaults
+dependencies:
+ - compilers
+ - cmake
+ - numpy
+ - pyarrow>=7.0.0
+ - ruamel.yaml
+ - scikit-build
+ - psutil
+ - sqlalchemy
+ - bump2version>=1.0.0
+ - python-graphviz
+ - httpx
+ - isort
+ - ruff
+ - twine
+ - wheel
+ - pandas
+ - polars
+ - pytz
+ - pytest
+ - pytest-cov
+ - pytest-sugar
+ - pytest-asyncio
+ - python<3.12
+ - tornado
+ - python-rapidjson
+ - pillow


### PR DESCRIPTION
Unfortunately conda environment files don't support classifiers (https://github.com/conda/conda/issues/8089) so I added a second windows-specific environment.yml file.

I was able to get the csp build to start but hit the error described in https://github.com/Point72/csp/issues/109#issuecomment-1970123114, so more work needs to happen to get windows builds working.

Here's how I set up my dev environment:

- Install miniforge using the [windows x86_64 installer](https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-Windows-x86_64.exe).
    - Make sure to select the option to add miniforge to your default PATH. If you don't check this you need to use the miniforge command prompt or activate the miniforge environment manually. I'm not sure how to activate the environment manually, presumably the scripts are buried in the miniforge install somewhere in Program Files.
- Install visual studio 2022.
- Open a visual studio command prompt or run `C:\Program Files\Microsoft Visual Studio\2022\Community\VC\Auxiliary\Build\vcvarsall.bat amd64`. You might need slightly different syntax for powershell.
-  clone csp:
    ```
    $ git clone https://github.com/Point72/csp.git
    $ cd csp
    $ git submodule update --init --recursive
    ```
- Install the windows development environment and activate it
    ```
    $ mamba env create -n csp -f dev-environment-win.yml
    $ conda activate csp
    ```

    Note that you should see some output printed to the terminal after activating, including something at the end printing out how `vcvars64.bat` is getting run. If you don't see that something is wrong with your visual studio install. For me this didn't work until I manually ran `vcvarsall.bat amd64` once.

- Build dependencies using `vcpkg`
    ```
    cd vcpkg && .\bootstrap-vcpkg.bat && .\vcpkg install
    cd ..
    ```
    Note that this is the same as `make dependencies-win` in the makefile, but that doesn't work right now because the path separator is incorrect. There's also a check at the top of the makefile for the number of processors that errors on windows.  So the makefile needs some work if we want to support it on windows.

- Build csp itself
    ```
    python setup.py build build_ext --inplace
    ```

And then you should hit the same error as me.