### PR TITLE
Set minimum numpy version to avoid ABI mismatch error

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -582,7 +582,8 @@ jobs:
           package:
             - "sqlalchemy>=2"
             - "sqlalchemy<2"
-
+            - "numpy==1.19.5"
+            
       runs-on: ${{ matrix.os }}
 
       steps:
@@ -619,6 +620,10 @@ jobs:
         - name: Python Test Steps
           run: make test TEST_ARGS="-k TestDBReader"
           if: ${{ contains( 'sqlalchemy', matrix.package )}}
+
+        - name: Python Test Steps
+          run: make test
+          if: ${{ contains( 'numpy', matrix.package )}}
 
     #############################
     #~~~~~~~~~~~~~~~~~~~~~~~~~~~#

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [build-system]
 requires = [
     "cmake",
-    "numpy",
+    "oldest-supported-numpy",
     "pyarrow>=7.0.0",
     "ruamel.yaml",
     "scikit-build",


### PR DESCRIPTION
This fixes an error reported by @AdamGlustein:

<details>

```
RuntimeError: module compiled against API version 0x10 but this version of numpy is 0xe . Check the section C-API incompatibility at the Troubleshooting ImportError section at https://numpy.org/devdocs/user/troubleshooting-importerror.html#c-api-incompatibility for indications on how to solve this problem .
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/data01/home/user/hfalgo_ext/python/Python-3.8.12/lib/python3.8/site-packages/csp/__init__.py", line 3, in <module>
    from csp.baselib import *
  File "/data01/home/user/hfalgo_ext/python/Python-3.8.12/lib/python3.8/site-packages/csp/baselib.py", line 18, in <module>
    from csp.impl.wiring import DelayedEdge, Edge, OutputsContainer, graph, input_adapter_def, node
  File "/data01/home/user/hfalgo_ext/python/Python-3.8.12/lib/python3.8/site-packages/csp/impl/wiring/__init__.py", line 3, in <module>
    from csp.impl.wiring.delayed_edge import DelayedEdge
  File "/data01/home/user/hfalgo_ext/python/Python-3.8.12/lib/python3.8/site-packages/csp/impl/wiring/delayed_edge.py", line 8, in <module>
    from .graph import graph
  File "/data01/home/user/hfalgo_ext/python/Python-3.8.12/lib/python3.8/site-packages/csp/impl/wiring/graph.py", line 15, in <module>
    from csp.impl.wiring.cache_support.dataset_partition_cached_data import DataSetCachedData, DatasetPartitionCachedData
  File "/data01/home/user/hfalgo_ext/python/Python-3.8.12/lib/python3.8/site-packages/csp/impl/wiring/cache_support/dataset_partition_cached_data.py", line 12, in <module>
    from csp.adapters.output_adapters.parquet import resolve_array_shape_column_name
  File "/data01/home/user/hfalgo_ext/python/Python-3.8.12/lib/python3.8/site-packages/csp/adapters/output_adapters/parquet.py", line 13, in <module>
    from csp.lib import _parquetadapterimpl
ImportError: numpy.core.multiarray failed to import
```

</details>

According to https://numpy.org/doc/stable/dev/depending_on_numpy.html#build-time-dependency, we can build against numpy 1.25 or newer and numpy 1.19 or newer should be able to import the build. However, numpy 1.25 isn't supported on python 3.8, so I've decided to set a lower bound on an older version of numpy on the build host, which should also avoid ABI mismatch errors.