### PR TITLE
Add developer guide and move build instructions to their own page

### DIFF
--- a/docs/wiki/98.-Building-From-Source.md
+++ b/docs/wiki/98.-Building-From-Source.md
@@ -1,0 +1,378 @@
+`csp` is written in Python and C++ with Python and C++ build dependencies. While prebuilt wheels are provided for end users, it is also straightforward to build `csp` from either the Python [source distribution](https://packaging.python.org/en/latest/specifications/source-distribution-format/) or the GitHub repository.
+
+As a convenience, `csp` uses a `Makefile` for commonly used commands. You can print the main available commands by running `make` with no arguments
+
+```bash
+> make
+
+build                          build the library
+clean                          clean the repository
+fix                            run autofixers
+install                        install library
+lint                           run lints
+test                           run the tests
+```
+
+
+# Prerequisites
+`csp` has a few system-level dependencies which you can install from your machine package manager. Other package managers like `conda`, `nix`, etc, should also work fine. Currently, `csp` relies on the `GNU` compiler toolchain only.
+
+# Building with Conda on Linux
+
+The easiest way to get started on a Linux machine is by installing the necessary dependencies in a self-contained conda environment.
+
+Tweak this script to create a conda environment, install the build dependencies, build, and install a development version of `csp` into the environment.
+
+## Install conda
+```bash
+mkdir ~/github
+cd ~/github
+
+# this downloads a Linux x86_64 build, change your architecture to match your development machine
+# see https://conda-forge.org/miniforge/ for alternate download links
+
+wget https://github.com/conda-forge/miniforge/releases/download/23.3.1-1/Mambaforge-23.3.1-1-Linux-x86_64.sh
+chmod 755 Mambaforge-23.3.1-1-Linux-x86_64.sh
+./Mambaforge-23.3.1-1-Linux-x86_64.sh -b -f -u -p csp_venv
+
+. ~/github/csp_venv/etc/profile.d/conda.sh
+
+# optionally, run this if you want to set up conda in your .bashrc
+# conda init bash
+
+conda config --add channels conda-forge
+conda config --set channel_priority strict
+conda activate base
+```
+
+## Clone
+```bash
+git clone https://github.com/Point72/csp.git
+cd csp
+git submodule update --init --recursive
+```
+
+## Install build dependencies
+```bash
+mamba env create -n csp -f dev-environment.yml
+
+# uncomment below if the build fails because git isn't new enough
+#
+# mamba install -y -n csp git
+
+# uncomment below if the build fails because perl-ipc-system is missing
+# (this happens on some RHEL7 systems)
+#
+# mamba install -y -n csp perl-ipc-system-simple
+
+conda activate csp
+```
+
+## Build
+```bash
+make build
+
+# on aarch64 linux, comment the above command and use this instead
+# VCPKG_FORCE_SYSTEM_BINARIES=1 make build
+
+# finally install into the csp_venv conda environment
+make develop
+```
+
+If you didn’t do `conda init bash` you’ll need to re-add conda to your shell environment and activate the `csp` environment to use it:
+
+```bash
+. ~/github/csp_venv/etc/profile.d/conda.sh
+conda activate csp
+
+# make sure everything works
+cd ~/github/csp
+make test
+```
+
+# Building with a system package manager
+
+## Clone
+Clone the repo and submodules with:
+
+```bash
+git clone https://github.com/Point72/csp.git
+cd csp
+git submodule update --init --recursive
+```
+
+## Install build dependencies
+### Linux
+
+**Debian/Ubuntu/etc**
+
+```bash
+# for vcpkg
+sudo make dependencies-debian
+# or
+# sudo apt-get install -y automake bison cmake curl flex ninja-build tar unzip zip
+
+# for g++
+sudo apt install build-essential
+```
+
+**Fedora/RedHat/Centos/Rocky/Alma/etc**
+
+```bash
+# for vcpkg
+sudo make dependencies-fedora
+# or
+# yum install -y automake bison cmake curl flex perl-IPC-Cmd tar unzip zip
+
+# for g++
+sudo dnf group install "Development Tools"
+```
+
+### MacOS
+
+**Homebrew**
+
+```bash
+# for vcpkg
+make dependencies-mac
+# or
+# brew install bison cmake flex make ninja
+
+# for g++
+brew install gcc
+```
+
+## Install Python dependencies
+Python build and develop dependencies are specified in the `pyproject.toml`, but you can manually install them:
+
+```bash
+make requirements
+
+# or
+# python -m pip install toml
+# python -m pip install `python -c 'import toml; c = toml.load("pyproject.toml"); print("\n".join(c["build-system"]["requires"]))'`
+# python -m pip install `python -c 'import toml; c = toml.load("pyproject.toml"); print("\n".join(c["project"]["optional-dependencies"]["develop"]))'`
+```
+
+Note that these dependencies would otherwise be installed normally as part of [PEP517](https://peps.python.org/pep-0517/) / [PEP518](https://peps.python.org/pep-0518/).
+
+
+## Build
+
+Build the python project in the usual manner:
+
+```bash
+make build
+
+# or
+# python setup.py build build_ext --inplace
+```
+
+### Building on `macOS`
+
+**NOTE** On `macOS`, we need to use `g++`. Complicating this, `g++` is often aliased to `clang++`, so we need to be explicit:
+
+Apple Silicon (ARM):
+
+```bash
+CXX=/opt/homebrew/bin/g++-13 make build
+
+# or
+# CXX=/opt/homebrew/bin/g++-13 python setup.py build build_ext --inplace 
+```
+
+Intel:
+
+```bash
+CXX=/usr/local/bin/g++-13 make build
+
+# or
+# CXX=/usr/local/bin/g++-13 python setup.py build build_ext --inplace 
+```
+
+Substitute your installed version of `g++` as necessary.
+
+### Building on `aarch64` Linux
+
+On `aarch64` Linux the VCPKG_FORCE_SYSTEM_BINARIES environment variable must be set before running `make build`:
+
+```bash
+VCPKG_FORCE_SYSTEM_BINARIES=1 make build
+```
+
+# Lint and Autoformat
+`csp` has listing and auto formatting.
+
+| Language | Linter | Autoformatter | Description |
+| :------- | :----- | :------------ | :---------- |
+| C++      | `clang-format` | `clang-format` | Style |
+| Python   | `ruff`         | `ruff` | Style |
+| Python   | `isort`         | `isort` | Imports |
+
+**C++ Linting**
+```bash
+make lint-cpp
+# or
+# clang-format --dry-run -Werror -i -style=file `find ./cpp/ -name "*.*pp"`
+```
+
+**C++ Autoformatting**
+```bash
+make fix-cpp
+# or
+# clang-format -i -style=file `find ./cpp/ -name "*.*pp"`
+```
+
+**Python Linting**
+```bash
+make lint-py
+# or
+# python -m isort --check csp/ setup.py
+# python -m ruff csp/ setup.py
+```
+
+**Python Autoformatting**
+```bash
+make fix-py
+# or
+# python -m isort csp/ setup.py
+# python -m ruff format csp/ setup.py
+```
+
+# Testing
+`csp` has both Python and C++ tests. The bulk of the functionality is tested in Python, which can be run via `pytest`. First, install the Python development dependencies with
+
+```bash
+make develop
+```
+
+For full test coverage including certain adapters and integration/regression tests, you will need to install some additional dependencies and spin up some services. These dependencies include:
+
+- [Graphviz](https://graphviz.org/): for generating static diagrams of graph structure
+- [Docker Compose](https://docs.docker.com/compose/): for spinning up self-contained services against which to integration-test adapters
+
+On Debian/Ubuntu Linux, run
+
+```bash
+sudo apt-get install -y graphviz
+```
+
+On Fedora/RedHat/Centos/Rocky/Alma/etc, run
+
+```bash
+yum install -y graphviz
+```
+
+On MacOS using Homebrew, run
+
+```bash
+brew install graphviz
+```
+
+**Python**
+
+```bash
+make test-py
+# or
+# python -m pytest -v csp/tests --junitxml=junit.xml
+
+make coverage-py
+# or python -m pytest -v csp/tests --junitxml=junit.xml --cov=csp --cov-report xml --cov-report html --cov-branch --cov-fail-under=80 --cov-report term-missing
+```
+
+Adapters might rely on external services. For example, the `kafka` adapter requires a cluster against which to test. We rely on [docker compose](https://docs.docker.com/compose/) for these services. We store docker compose files in the `ci` directory, and convenience `Makefile` commands are available:
+
+```bash
+make dockerup ADAPTER=kafka
+# or
+# docker compose -f ci/kafka/docker-compose.yml up -d
+
+make dockerps ADAPTER=kafka
+# or
+# docker compose -f ci/kafka/docker-compose.yml ps
+
+make dockerdown ADAPTER=kafka
+# or
+# docker compose -f ci/kafka/docker-compose.yml down
+```
+
+Note that tests may be skipped by default, so run with:
+
+```bash
+CSP_TEST_KAFKA=1 make test
+# or
+# CSP_TEST_KAFKA=1 python -m pytest -v csp/tests --junitxml=junit.xml
+```
+
+There are a few test flags available:
+- **`CSP_TEST_KAFKA`**
+- **`CSP_TEST_SKIP_EXAMPLES`**: skip tests of examples folder
+
+# Contributing
+After developing a change locally, ensure that both lints and tests pass. Commits should be squashed into logical units, and all commits must be signed (e.g. with the `-s` git flag). `csp` requires [Developer Certificate of Origin](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) for all contributions.
+
+If your work is still in-progress, open a [draft pull request](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests#draft-pull-requests). Otherwise, open a normal pull request. It might take a few days for a maintainer to review and provide feedback, so please be patient. If a maintainer asks for changes, please make said changes and squash your commits if necessary. If everything looks good to go, a maintainer will approve and merge your changes for inclusion in the next release.
+
+Please note that non substantive changes, large changes without prior discussion, etc, are not accepted and pull requests may be closed.
+
+
+# Troubleshooting
+
+## MacOS
+
+### vcpkg install failed
+
+Check the `vcpkg-manifest-install.log` files, and install the corresponding packages if needed. 
+
+For example, you may need to `brew install pkg-config`.
+
+### Building thrift:arm64-osx/thrift:x64-osx failed
+
+```
+Thrift requires bison > 2.5, but the default `/usr/bin/bison` is version 2.3.
+```
+
+Ensure the homebrew-installed bison (version >= 3.8) is **before** `/usr/bin/bison` on $PATH
+
+On ARM: `export PATH="/opt/homebrew/opt/bison/bin:$PATH"`
+
+On Intel: `export PATH="/usr/local/opt/bison/bin:$PATH"`
+
+### CMake was unable to find a build program corresponding to "Unix Makefiles".
+
+Complete error message:
+
+```bash
+CMake Error: CMake was unable to find a build program corresponding to "Unix Makefiles".  CMAKE_MAKE_PROGRAM is not set.  You probably need to select a different build tool.
+CMake Error: CMAKE_C_COMPILER not set, after EnableLanguage
+```
+
+`vcpkg-manifest-install.log`:
+
+```bash
+CMake Error at scripts/cmake/vcpkg_execute_build_process.cmake:134
+```
+
+`install-arm64-osx-dbg-out.log`:
+
+```bash
+ld: Assertion failed: (resultIndex < sectData.atoms.size()), function findAtom, file Relocations.cpp, line 1336.
+collect2: error: ld returned 1 exit status
+```
+
+This is a known bug: https://github.com/Homebrew/homebrew-core/issues/145991
+
+Retry the build with `CXXFLAGS='-Wl,-ld_classic'`.
+
+Apple Silicon (ARM):
+
+```bash
+CXX=/opt/homebrew/bin/g++-13 CXXFLAGS='-Wl,-ld_classic' make build
+```
+
+Intel:
+
+```bash
+CXX=/usr/local/opt/gcc/bin/g++-13 CXXFLAGS='-Wl,-ld_classic' make build
+```
+

--- a/docs/wiki/99.-Developer.md
+++ b/docs/wiki/99.-Developer.md
@@ -1,378 +1,397 @@
-`csp` is written in Python and C++ with Python and C++ build dependencies. While prebuilt wheels are provided for end users, it is also straightforward to build `csp` from either the Python [source distribution](https://packaging.python.org/en/latest/specifications/source-distribution-format/) or the GitHub repository.
+### Setting up a development environment
 
-As a convenience, `csp` uses a `Makefile` for commonly used commands. You can print the main available commands by running `make` with no arguments
+To work on `csp`, you are going to need to build it from source. See
+https://github.com/Point72/csp/wiki/98.-Building-From-Source for
+detailed build instructions.
+
+Once you've built `csp` from a `git` clone, you will also need to
+configure `git` and your GitHub account for `csp` development.
+
+#### Configuring Git and GitHub for Development
+
+##### Create your fork
+
+The first step is to create a personal fork of `csp`. To do so, click
+the "fork" button at https://github.com/Point72/csp, or just navigate
+[here](https://github.com/Point72/csp/fork) in your browser. Set the
+owner of the repository to your personal GitHub account if it is not
+already set that way and click "Create fork".
+
+##### Configure remotes
+
+Next, you should set some names for the `git` remotes corresponding to
+main Point72 repository and your fork. If you started with a clone of
+the main `Point72` repository, you could do something like:
 
 ```bash
-> make
-
-build                          build the library
-clean                          clean the repository
-fix                            run autofixers
-install                        install library
-lint                           run lints
-test                           run the tests
-```
-
-
-# Prerequisites
-`csp` has a few system-level dependencies which you can install from your machine package manager. Other package managers like `conda`, `nix`, etc, should also work fine. Currently, `csp` relies on the `GNU` compiler toolchain only.
-
-# Building with Conda on Linux
-
-The easiest way to get started on a Linux machine is by installing the necessary dependencies in a self-contained conda environment.
-
-Tweak this script to create a conda environment, install the build dependencies, build, and install a development version of `csp` into the environment.
-
-## Install conda
-```bash
-mkdir ~/github
-cd ~/github
-
-# this downloads a Linux x86_64 build, change your architecture to match your development machine
-# see https://conda-forge.org/miniforge/ for alternate download links
-
-wget https://github.com/conda-forge/miniforge/releases/download/23.3.1-1/Mambaforge-23.3.1-1-Linux-x86_64.sh
-chmod 755 Mambaforge-23.3.1-1-Linux-x86_64.sh
-./Mambaforge-23.3.1-1-Linux-x86_64.sh -b -f -u -p csp_venv
-
-. ~/github/csp_venv/etc/profile.d/conda.sh
-
-# optionally, run this if you want to set up conda in your .bashrc
-# conda init bash
-
-conda config --add channels conda-forge
-conda config --set channel_priority strict
-conda activate base
-```
-
-## Clone
-```bash
-git clone https://github.com/Point72/csp.git
 cd csp
-git submodule update --init --recursive
+git remote rename origin upstream
+
+# for SSH authentication
+git remote add origin git@github.com:<username>/csp.git
+
+# for HTTP authentication
+git remote add origin https://github.com/<username>/csp.git
 ```
 
-## Install build dependencies
-```bash
-mamba env create -n csp -f dev-environment.yml
+##### Authenticating with GitHub
 
-# uncomment below if the build fails because git isn't new enough
-#
-# mamba install -y -n csp git
+If you have not already configured `ssh` access to GitHub, you can find
+instructions to do so
+[here](https://docs.github.com/en/authentication/connecting-to-github-with-ssh),
+including instructions to create an SSH key if you have not done
+so. Authenticating with SSH is usually the easiest route. If you are working in
+an environment that does not allow SSH connections to GitHub, you can look into
+[configuring a hardware
+passkey](https://docs.github.com/en/authentication/authenticating-with-a-passkey/about-passkeys)
+or adding a [personal access
+token](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens)
+to avoid the need to type in your password every time you push to your fork.
 
-# uncomment below if the build fails because perl-ipc-system is missing
-# (this happens on some RHEL7 systems)
-#
-# mamba install -y -n csp perl-ipc-system-simple
+##### Configure commit signing
 
-conda activate csp
-```
+Additionally, you will need to configure your local `git` setup and
+GitHub account to use [commit
+signing](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification). All
+commits to the `csp` repository must be signed to increase the
+difficulty of a supply-chain attack against the `csp` codebase. The
+easiest way to do this is to [configure `git` to sign commits with your
+SSH
+key](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification#ssh-commit-signature-verification). You
+can also use a [GPG
+key](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification#gpg-commit-signature-verification)
+to sign commits.
 
-## Build
-```bash
-make build
+In either case, you must also add your public key to your github account
+as a signing key. Note that if you have already added an SSH key as an
+authentication key, you will need to add it again [as a signing
+key](https://docs.github.com/en/authentication/connecting-to-github-with-ssh/adding-a-new-ssh-key-to-your-github-account).
 
-# on aarch64 linux, comment the above command and use this instead
-# VCPKG_FORCE_SYSTEM_BINARIES=1 make build
+### Github for maintainers
 
-# finally install into the csp_venv conda environment
-make develop
-```
+#### Triaging Issues
 
-If you didn’t do `conda init bash` you’ll need to re-add conda to your shell environment and activate the `csp` environment to use it:
+The bug tracker is both a venue for users to communicate to the
+developers about defects and a database of known defects. It's up to the
+maintainers to ensure issues are high quality.
 
-```bash
-. ~/github/csp_venv/etc/profile.d/conda.sh
-conda activate csp
+We have a number of labels that can be applied to sort issues into
+categories. If you notice newly created issues that are poorly labeled,
+consider adding or removing some labels that do not apply to the issue.
 
-# make sure everything works
-cd ~/github/csp
-make test
-```
+The issue template encourages users to write bug reports that clearly
+describe the problem they are having and include steps to reproduce the
+issue. However, users sometimes ignore the template or are not used to
+GitHub and make mistakes in formatting or communication.
 
-# Building with a system package manager
+If you are able to infer what they meant and are able to understand the
+issue, feel free to edit their issue description to fix formatting or
+correct issues with a script demonstrating the issue.
 
-## Clone
-Clone the repo and submodules with:
+If there is still not enough information or if the issue is unclear,
+request more information from the submitter. If they do not respond or
+do not clarify sufficiently, close the issue. Try to be polite and have
+empathy for inexperienced issue authors.
 
-```bash
-git clone https://github.com/Point72/csp.git
-cd csp
-git submodule update --init --recursive
-```
+#### How to check out a PR locally
 
-## Install build dependencies
-### Linux
+This workflow is described in the [GitHub
+docs](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/checking-out-pull-requests-locally#modifying-an-inactive-pull-request-locally).
 
-**Debian/Ubuntu/etc**
+1. Identify the pull request ID. This is the number of the pull request
+   in the GitHub UI, which shows up in the URL for the pull request. For
+   example, https://github.com/Point72/csp/pull/98 has PR ID 98.
 
-```bash
-# for vcpkg
-sudo make dependencies-debian
-# or
-# sudo apt-get install -y automake bison cmake curl flex ninja-build tar unzip zip
+2. Fetch the pull request ref and assign it to a local branch name.
 
-# for g++
-sudo apt install build-essential
-```
+    ```bash
+    git fetch upstream pull/<ID>/HEAD/:LOCAL_BRANCH_NAME
+    ```
 
-**Fedora/RedHat/Centos/Rocky/Alma/etc**
-
-```bash
-# for vcpkg
-sudo make dependencies-fedora
-# or
-# yum install -y automake bison cmake curl flex perl-IPC-Cmd tar unzip zip
-
-# for g++
-sudo dnf group install "Development Tools"
-```
-
-### MacOS
-
-**Homebrew**
-
-```bash
-# for vcpkg
-make dependencies-mac
-# or
-# brew install bison cmake flex make ninja
-
-# for g++
-brew install gcc
-```
-
-## Install Python dependencies
-Python build and develop dependencies are specified in the `pyproject.toml`, but you can manually install them:
-
-```bash
-make requirements
-
-# or
-# python -m pip install toml
-# python -m pip install `python -c 'import toml; c = toml.load("pyproject.toml"); print("\n".join(c["build-system"]["requires"]))'`
-# python -m pip install `python -c 'import toml; c = toml.load("pyproject.toml"); print("\n".join(c["project"]["optional-dependencies"]["develop"]))'`
-```
-
-Note that these dependencies would otherwise be installed normally as part of [PEP517](https://peps.python.org/pep-0517/) / [PEP518](https://peps.python.org/pep-0518/).
+    where `<ID>` is the PR ID number and `LOCAL_BRANCH_NAME` is a name
+    chosen for the PR branch in your local checkout of `csp`.
 
 
-## Build
+3. Switch to the PR branch
 
-Build the python project in the usual manner:
+    ```bash
+    git switch LOCAL_BRANCH_NAME
+    ```
+
+4. Rebuild `csp`
+
+#### Pushing Fixups to Pull Requests
+
+Sometimes pull requests don't quite make it across the finish line. In
+cases where only a small fixup is required to make a PR mergeable and
+the author of the pull request is unresponsive to requests, the best
+course of action is often to push to the pull request directly to
+resolve the issues.
+
+To do this, check out the pull request locally using the above
+instructions. Then make the changes needed for the pull request and push
+the local branch back to GitHub:
 
 ```bash
-make build
-
-# or
-# python setup.py build build_ext --inplace
+git push upstream LOCAL_BRANCH_NAME
 ```
 
-### Building on `macOS`
+Where `LOCAL_BRANCH_NAME` is the name you gave to the PR branch when you
+fetched it from GitHub.
 
-**NOTE** On `macOS`, we need to use `g++`. Complicating this, `g++` is often aliased to `clang++`, so we need to be explicit:
+Note that if the user who created the pull request selected the option
+to forbid pushes to their pull request, you will instead need to
+recreate the pull request by pushing the PR branch to your fork and
+making a pull request like normal.
 
-Apple Silicon (ARM):
+## Release Manual
+
+### Doing a "normal" release
+
+Making regular releases allows users to test code as it gets added and
+allows developers to quickly get feedback on changes and new features. A
+release announcement is the primary way projects communicate with the
+majority of users, so you should think of the release and accompanying
+notes as a way to communicate expectations for users.
+
+#### Choosing a version number
+
+The clearest signal you can send to users about what to expect from a
+release is the version number you choose. Most users expect version
+numbers to follow [semantic versioning](https://semver.org/) or semver,
+where the version number indicates the sorts of changes to expect.
+
+With semver, There are three kinds of releases, each of which have a
+different potential impact on users.
+
+* ##### Patch release
+
+    This is the most common kind of release. A patch release should only
+    include fixes for bugs or other changes that cannot impact code a
+    user writes with the `csp` package. A user should be able to safely
+    upgrade `csp` from the previous version to a new patch release with
+    no changes to the output of their code and no new errors being
+    raised, except for fixed bugs. Whether or not a bug fix is
+    sufficiently impactful to break backward compatibility is a
+    judgement call. It is best to err on the side of safety and do a
+    major release if you are unsure.
+
+* ##### Minor releases
+
+    This indicates a new feature has been added to the library in a
+    backward incompatible. Minor releases can include bugfixes as well
+    but should not include backward incompatible changes. For example,
+    adding a new keyword argument to a Python function is a backward
+    compatible change but removing an argument or changing its name is
+    backwards incompatible.
+
+* ##### Major releases
+
+    A major release indicates that there are changes in the release that
+    are not backward compatible, and users may need to update their code
+    to accomadate the change. When possible, efforts should be made to
+    communicate to users how to migrate their code.
+
+Note that the primary concern is user impact. Sometimes a bug fix is so
+disruptive to users that fixing it qualifies as a major
+change. Sometimes a new feature is so big that it fundamentally changes
+the nature of the library and it deserves a major release to indicate
+that, even if there are no breaking changes. Sometimes a change is
+breaking, but only in a very unlikely scenario that can be safely
+ignored in practice. It is best to use your good judgement when choosing
+a new version number and not slavishly follow rules. Be empathetic to
+your users.
+
+
+#### Preparing and tagging a release
+
+Follow these steps when it's time to tag a new release. Before doing
+this, you will need to ensure `bump2version` is installed into your
+development environment.
+
+
+1. Ensure your local clone of `csp` is synced up with GitHub, including
+   any tags that have been pushed since you last synced:
+
+    ```bash
+    git pull upstream main --tags
+    ```
+2. Make a branch and update version numbers in your local clone using
+   the `bump2version` integration in the Makefile.
+
+    First, make a branch that will be pushed to the main `csp`
+    repository. Using a name like `release/v0.3.4` should avoid any
+    conflicts and make it clear what the branch is for.
+
+    ```bash
+    git checkout -b relese/v0.x.x
+    ```
+
+    For example, for a bugfix release, `bump2version` will automatically
+    update the codebase to use the next bugfix version number if you do:
+
+    ```bash
+    make patch
+    ```
+
+    Similarly, `make minor` and `make major` will update the version
+    numbers for minor and major releases, respectively. Double-check
+    that the version numbers have been updated correctly with `git
+    diff`, and then `git commit` the change.
+
+3. Push your branch to GitHub, and trigger a "full" test run on the branch.
+
+    Navigate to the [GitHub Actions "build status"
+    workflow](https://github.com/Point72/csp/actions/workflows/build.yml). Click
+    the white "Run workflow" button, make sure the "Run full CI" radio
+    button is selected, and click the green "Run workflow" button to
+    launch the test run.
+
+4. Propose a pull request from the branch containing the version number updated. Add a link to the successful full test run for reviewers. 
+
+5. Review and merge the pull request. Make sure you delete the branch
+   afterwards.
+
+6. Tag the release
+
+    Use the version number `bump2version` generated and make sure the
+    tag name begins with a `v`.
+
+    ```bash
+    git tag v0.2.0
+    ```
+
+7. Push the tag to GitHub
+
+   ```bash
+   git push upstream main --follow-tags
+   ```
+
+   You will need access in the repository settings to be able to push
+   tags to the repository. Access to merge pull requests is not
+   sufficient to overcome the tag protection settings in the repository.
+
+Pushing a tag name that begins with `v` should automatically trigger a
+full test run that will generate a GitHub release. You can follow along
+with this run in the GitHub actions interface. There should be two
+actions running, one for the push to `main` and one for the new tag. You
+want to inspect the action running for the new tag. Once the run
+finishes, there should be a new release on the ["Releases"
+page](https://github.com/Point72/csp/releases).
+
+#### Releasing to PyPI
+
+##### A developer's first release
+
+If this is your first release, you will need an account on pypi.org and
+your account will need to be added as a maintainer to the `csp` project
+on pypi. You will also need to have two factor authentication enabled on
+your PyPI account.
+
+Once that is set up, navigate to the API token page in your PyPI
+settings and generate an API token scoped to the `csp` project. **Do not**
+navigate away from the page displaying the API token before the next
+step.
+
+Optionally, you can create an account on test.pypi.org if you would like
+to do a dry run of the release. You will also need to set up an API
+token on test.pypi.org.
+
+Create a `.pypirc` file in your home directory, and add the following
+content:
+
+```
+[distutils]
+  index-servers =
+    testpypi
+    csp
+[testpypi]
+  username = __token__
+  password = <your API key, including pypi- prefix>
+[csp]
+  repository = https://upload.pypi.org/legacy/
+  username = __token__
+  password = <your API key, including pypi- prefix>
+```
+
+##### Doing the release
+
+
+##### Download release artifacts from github actions
+
+Make sure you are in the root of the `csp` repository and execute the
+following commands.
 
 ```bash
-CXX=/opt/homebrew/bin/g++-13 make build
-
-# or
-# CXX=/opt/homebrew/bin/g++-13 python setup.py build build_ext --inplace 
+rm -r dist
+mkdir dist
+cd dist
+curl -sL https://api.github.com/repos/Point72/csp/releases/latest | grep browser_download_url | cut -d '"' -f 4 | xargs -I '{}' curl -LO {}
+cd ..
 ```
 
-Intel:
+You should end up with a copy of the wheel files and source distribution
+associated with the GitHub release. You should verify that all files
+were successfully downloaded. Currently there are 6 MacOS wheels and 4
+linux wheels. There should only be one source distribution.
+
+Optionally, you can lint the release artifacts with
+
+```bash=
+twine check --strict dist/*
+```
+
+This happens as part of the CI so this should only be a double-check.
+
+
+##### Optionally upload to testpypi to test "pip install"
+
+```
+twine upload --repository testpypi dist/*
+```
+
+You can check that the wheel installs correctly with `pip` from
+`testpypi` like so:
 
 ```bash
-CXX=/usr/local/bin/g++-13 make build
-
-# or
-# CXX=/usr/local/bin/g++-13 python setup.py build build_ext --inplace 
+pip install --index-url https://test.pypi.org/simple --extra-index-url https://pypi.org/simple csp
 ```
 
-Substitute your installed version of `g++` as necessary.
+Note that `extra-index-url` is necessary to ensure downloading
+dependencies succeeds.
 
-### Building on `aarch64` Linux
+##### Upload to pypi
 
-On `aarch64` Linux the VCPKG_FORCE_SYSTEM_BINARIES environment variable must be set before running `make build`:
+If you are sure the release is ready, you can upload to pypi like so:
 
 ```bash
-VCPKG_FORCE_SYSTEM_BINARIES=1 make build
+twine upload --repository csp dist/*`
 ```
 
-# Lint and Autoformat
-`csp` has listing and auto formatting.
+Note that this assumes you have a `.pypirc` set up as explained above.
 
-| Language | Linter | Autoformatter | Description |
-| :------- | :----- | :------------ | :---------- |
-| C++      | `clang-format` | `clang-format` | Style |
-| Python   | `ruff`         | `ruff` | Style |
-| Python   | `isort`         | `isort` | Imports |
-
-**C++ Linting**
-```bash
-make lint-cpp
-# or
-# clang-format --dry-run -Werror -i -style=file `find ./cpp/ -name "*.*pp"`
-```
-
-**C++ Autoformatting**
-```bash
-make fix-cpp
-# or
-# clang-format -i -style=file `find ./cpp/ -name "*.*pp"`
-```
-
-**Python Linting**
-```bash
-make lint-py
-# or
-# python -m isort --check csp/ setup.py
-# python -m ruff csp/ setup.py
-```
-
-**Python Autoformatting**
-```bash
-make fix-py
-# or
-# python -m isort csp/ setup.py
-# python -m ruff format csp/ setup.py
-```
-
-# Testing
-`csp` has both Python and C++ tests. The bulk of the functionality is tested in Python, which can be run via `pytest`. First, install the Python development dependencies with
-
-```bash
-make develop
-```
-
-For full test coverage including certain adapters and integration/regression tests, you will need to install some additional dependencies and spin up some services. These dependencies include:
-
-- [Graphviz](https://graphviz.org/): for generating static diagrams of graph structure
-- [Docker Compose](https://docs.docker.com/compose/): for spinning up self-contained services against which to integration-test adapters
-
-On Debian/Ubuntu Linux, run
-
-```bash
-sudo apt-get install -y graphviz
-```
-
-On Fedora/RedHat/Centos/Rocky/Alma/etc, run
-
-```bash
-yum install -y graphviz
-```
-
-On MacOS using Homebrew, run
-
-```bash
-brew install graphviz
-```
-
-**Python**
-
-```bash
-make test-py
-# or
-# python -m pytest -v csp/tests --junitxml=junit.xml
-
-make coverage-py
-# or python -m pytest -v csp/tests --junitxml=junit.xml --cov=csp --cov-report xml --cov-report html --cov-branch --cov-fail-under=80 --cov-report term-missing
-```
-
-Adapters might rely on external services. For example, the `kafka` adapter requires a cluster against which to test. We rely on [docker compose](https://docs.docker.com/compose/) for these services. We store docker compose files in the `ci` directory, and convenience `Makefile` commands are available:
-
-```bash
-make dockerup ADAPTER=kafka
-# or
-# docker compose -f ci/kafka/docker-compose.yml up -d
-
-make dockerps ADAPTER=kafka
-# or
-# docker compose -f ci/kafka/docker-compose.yml ps
-
-make dockerdown ADAPTER=kafka
-# or
-# docker compose -f ci/kafka/docker-compose.yml down
-```
-
-Note that tests may be skipped by default, so run with:
-
-```bash
-CSP_TEST_KAFKA=1 make test
-# or
-# CSP_TEST_KAFKA=1 python -m pytest -v csp/tests --junitxml=junit.xml
-```
-
-There are a few test flags available:
-- **`CSP_TEST_KAFKA`**
-- **`CSP_TEST_SKIP_EXAMPLES`**: skip tests of examples folder
-
-# Contributing
-After developing a change locally, ensure that both lints and tests pass. Commits should be squashed into logical units, and all commits must be signed (e.g. with the `-s` git flag). `csp` requires [Developer Certificate of Origin](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) for all contributions.
-
-If your work is still in-progress, open a [draft pull request](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests#draft-pull-requests). Otherwise, open a normal pull request. It might take a few days for a maintainer to review and provide feedback, so please be patient. If a maintainer asks for changes, please make said changes and squash your commits if necessary. If everything looks good to go, a maintainer will approve and merge your changes for inclusion in the next release.
-
-Please note that non substantive changes, large changes without prior discussion, etc, are not accepted and pull requests may be closed.
-
-
-# Troubleshooting
-
-## MacOS
-
-### vcpkg install failed
-
-Check the `vcpkg-manifest-install.log` files, and install the corresponding packages if needed. 
-
-For example, you may need to `brew install pkg-config`.
-
-### Building thrift:arm64-osx/thrift:x64-osx failed
+Assuming the upload completes successfully, you should see a message
+like
 
 ```
-Thrift requires bison > 2.5, but the default `/usr/bin/bison` is version 2.3.
+View at:
+https://pypi.org/project/csp/<version number>/
 ```
 
-Ensure the homebrew-installed bison (version >= 3.8) is **before** `/usr/bin/bison` on $PATH
+### Dealing with release mistakes
 
-On ARM: `export PATH="/opt/homebrew/opt/bison/bin:$PATH"`
-
-On Intel: `export PATH="/usr/local/opt/bison/bin:$PATH"`
-
-### CMake was unable to find a build program corresponding to "Unix Makefiles".
-
-Complete error message:
-
-```bash
-CMake Error: CMake was unable to find a build program corresponding to "Unix Makefiles".  CMAKE_MAKE_PROGRAM is not set.  You probably need to select a different build tool.
-CMake Error: CMAKE_C_COMPILER not set, after EnableLanguage
-```
-
-`vcpkg-manifest-install.log`:
-
-```bash
-CMake Error at scripts/cmake/vcpkg_execute_build_process.cmake:134
-```
-
-`install-arm64-osx-dbg-out.log`:
-
-```bash
-ld: Assertion failed: (resultIndex < sectData.atoms.size()), function findAtom, file Relocations.cpp, line 1336.
-collect2: error: ld returned 1 exit status
-```
-
-This is a known bug: https://github.com/Homebrew/homebrew-core/issues/145991
-
-Retry the build with `CXXFLAGS='-Wl,-ld_classic'`.
-
-Apple Silicon (ARM):
-
-```bash
-CXX=/opt/homebrew/bin/g++-13 CXXFLAGS='-Wl,-ld_classic' make build
-```
-
-Intel:
-
-```bash
-CXX=/usr/local/opt/gcc/bin/g++-13 CXXFLAGS='-Wl,-ld_classic' make build
-```
-
+Sometimes releases go wrong. Here is what to do when that happens. This
+[blog post from Brett
+Cannon](https://snarky.ca/what-to-do-when-you-botch-a-release-on-pypi/)
+covers how to deal with various kinds of release mistakes on PyPI.
+Some things to remember after reading that post:
+* Completely broken releases should be yanked.
+    * A yanked release is *not permanently deleted*
+* Problems with metadata (e.g. the readme or metadata in
+  `pyproject.toml`) can be dealt with by creating a `post` release.
+* A problem with a wheel binary can be fixed by simply replacing the
+  wheel file with a new wheel that has an incremented [build
+  number](https://packaging.python.org/en/latest/specifications/binary-distribution-format/#file-name-convention)
+  with `twine upload`.
+* If private data is published accidentally, a release can be
+  permanently deleted. This should only be used as a last resort option.

--- a/docs/wiki/Home.md
+++ b/docs/wiki/Home.md
@@ -22,6 +22,20 @@ adapters or in realtime mode using realtime input adapters.
 - [8. Profiler](https://github.com/Point72/csp/wiki/8.-Profiler)
 - [9. Caching](https://github.com/Point72/csp/wiki/9.-Caching)
 
+# Installation
+
+We ship binary wheels to install `csp`  on MacOS and Linux via `pip`:
+
+```bash
+pip install csp
+```
+
+Other platforms will need to see the instructions to [build `csp` from
+source](https://github.com/Point72/csp/wiki/98.-Building-From-Source).
+
+We plan to create conda packages on conda-forge and ship binaries for Windows in
+the near future.
+
 # Contributing
 Contributions are welcome on this project. We distribute under the terms of the [Apache 2.0 license](https://github.com/Point72/csp/blob/main/LICENSE).
 


### PR DESCRIPTION
* Moves the instructions that are currently in the "Developer" page into a new "Building from Source" page. 
* Adds the developer guide content from #117 to the "Developer" page.
* Link to both pages from the docs homepage.


Here's how it looks on my fork:

[homepage](https://github.com/ngoldbaum/csp/wiki)
[build instructions](https://github.com/ngoldbaum/csp/wiki/98.-Building-From-Source)
[developer guide](https://github.com/ngoldbaum/csp/wiki/99.-Developer)