### PR TITLE
Build librdkafka with ssl support

### DIFF
--- a/vcpkg.json
+++ b/vcpkg.json
@@ -7,7 +7,10 @@
       "brotli",
       "exprtk",
       "gtest",
-      "librdkafka",
+        {
+            "name": "librdkafka",
+            "features": ["ssl"]
+        },
       "lz4",
       "parquet",
       "protobuf",


### PR DESCRIPTION
cc @robambalu, he says this solves the error he was running into.

I have a test script for this but it look like it will be a pain to get kerberos and `cyrus-sasl` installed on the github actions runners, so punting on that for now.