### PR TITLE
Replace usages of math.exp2 on python older than 3.11

### DIFF
--- a/csp/math.py
+++ b/csp/math.py
@@ -1,5 +1,6 @@
 import math
 import numpy as np
+import sys
 import typing
 from functools import lru_cache
 
@@ -363,7 +364,10 @@ ln = define_unary_op("ln", lambda x: math.log(x))
 log2 = define_unary_op("log2", lambda x: math.log2(x))
 log10 = define_unary_op("log10", lambda x: math.log10(x))
 exp = define_unary_op("exp", lambda x: math.exp(x))
-exp2 = define_unary_op("exp2", lambda x: math.exp2(x))
+if sys.version_info < (3, 11):
+    exp2 = define_unary_op("exp2", lambda x: 2**x)
+else:
+    exp2 = define_unary_op("exp2", lambda x: math.exp2)
 sqrt = define_unary_op("sqrt", lambda x: math.sqrt(x))
 erf = define_unary_op("erf", lambda x: math.erf(x))
 sin = define_unary_op("sin", lambda x: math.sin(x))

--- a/csp/tests/test_math.py
+++ b/csp/tests/test_math.py
@@ -122,7 +122,7 @@ class TestMath(unittest.TestCase):
             csp.log2: lambda x: math.log2(x),
             csp.log10: lambda x: math.log10(x),
             csp.exp: lambda x: math.exp(x),
-            csp.exp2: lambda x: math.exp2(x),
+            csp.exp2: lambda x: 2**x,
             csp.sin: lambda x: math.sin(x),
             csp.cos: lambda x: math.cos(x),
             csp.tan: lambda x: math.tan(x),


### PR DESCRIPTION
This makes `test_sdist` fail on a "full" test run: https://github.com/ngoldbaum/csp/actions/runs/8269123488/job/22623671505

I'm not sure offhand why `test_math_unary_ops` doesn't run in the regular tests.