### PR TITLE
Bump version: 0.0.1 → 0.0.2

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.0.1
+current_version = 0.0.2
 commit = True
 tag = False
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@
 # Project Configuration #
 #########################
 cmake_minimum_required(VERSION 3.20.0)
-project(csp VERSION "0.0.1")
+project(csp VERSION "0.0.2")
 set(CMAKE_CXX_STANDARD 17)
 
 ###################################################################################################################################################

--- a/csp/__init__.py
+++ b/csp/__init__.py
@@ -32,7 +32,7 @@ from csp.showgraph import show_graph
 
 from . import cache_support, stats
 
-__version__ = "0.0.1"
+__version__ = "0.0.2"
 
 
 def get_include_path():

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ name = "csp"
 authors = [{name = "the csp authors", email = "CSPOpenSource@point72.com"}]
 description="csp is a high performance reactive stream processing library, written in C++ and Python"
 readme = "README.md"
-version = "0.0.1"
+version = "0.0.2"
 requires-python = ">=3.8"
 
 dependencies = [

--- a/setup.py
+++ b/setup.py
@@ -70,7 +70,7 @@ print(f"CMake Args: {cmake_args}")
 
 setup(
     name="csp",
-    version="0.0.1",
+    version="0.0.2",
     packages=["csp"],
     cmake_install_dir="csp",
     cmake_args=cmake_args,


### PR DESCRIPTION
The full tests passed on my fork: https://github.com/ngoldbaum/csp/actions/runs/8273957567

Once this is merged someone with access will need to tag `v0.0.2` for 781bf7e and manually push the tag to the repo. I should have access so I'll do it if I end up self-merging.