### PR TITLE
Re-enable C++ testing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -91,7 +91,7 @@ test-cpp: ## Make C++ unit tests
 coverage-py:
 	python -m pytest -v csp/tests --junitxml=junit.xml --cov=csp --cov-report xml --cov-report html --cov-branch --cov-fail-under=80 --cov-report term-missing $(TEST_ARGS)
 
-test: test-py  ## run the tests
+test: test-cpp test-py  ## run the tests
 
 # Alias
 tests: test

--- a/Makefile
+++ b/Makefile
@@ -79,11 +79,14 @@ checks: check
 #########
 # TESTS #
 #########
-.PHONY: test-py coverage-py test tests
+.PHONY: test-py test-cpp coverage-py test tests
 
 TEST_ARGS :=
 test-py: ## Clean and Make unit tests
 	python -m pytest -v csp/tests --junitxml=junit.xml $(TEST_ARGS)
+
+test-cpp: ## Make C++ unit tests
+	for f in ./csp/tests/bin/*; do $$f; done || (echo "TEST FAILED" && exit 1)
 
 coverage-py:
 	python -m pytest -v csp/tests --junitxml=junit.xml --cov=csp --cov-report xml --cov-report html --cov-branch --cov-fail-under=80 --cov-report term-missing $(TEST_ARGS)

--- a/conda/dev-environment-linux.yml
+++ b/conda/dev-environment-linux.yml
@@ -13,6 +13,7 @@ dependencies:
  - exprtk
  - flex
  - python-graphviz
+ - gtest
  - httpx
  - isort
  - libarrow=15

--- a/cpp/tests/core/CMakeLists.txt
+++ b/cpp/tests/core/CMakeLists.txt
@@ -16,7 +16,7 @@ add_executable(test_tagged_pointer_union test_tagged_pointer_union.cpp )
 target_link_libraries(test_tagged_pointer_union csp_core GTest::gtest GTest::gtest_main)
 
 add_executable(test_time test_time.cpp )
-target_link_libraries(test_time csp_core GTest::gtest GTest::gtest_main rt)
+target_link_libraries(test_time csp_core GTest::gtest GTest::gtest_main)
 
 
 install(TARGETS test_basic_allocator

--- a/cpp/tests/core/CMakeLists.txt
+++ b/cpp/tests/core/CMakeLists.txt
@@ -1,10 +1,10 @@
-find_library(GTest REQUIRED)
+find_package(GTest CONFIG REQUIRED)
 
 add_executable(test_basic_allocator test_basic_allocator.cpp)
 target_link_libraries(test_basic_allocator GTest::gtest GTest::gtest_main)
 
 add_executable(test_dynamicbitset test_dynamicbitset.cpp)
-target_link_libraries(test_dynamicbitset gtest gtest_main)
+target_link_libraries(test_dynamicbitset GTest::gtest GTest::gtest_main)
 
 add_executable(test_enum test_enum.cpp)
 target_link_libraries(test_enum csp_core csp_engine GTest::gtest GTest::gtest_main)

--- a/cpp/tests/engine/CMakeLists.txt
+++ b/cpp/tests/engine/CMakeLists.txt
@@ -1,4 +1,4 @@
-find_library(GTest REQUIRED)
+find_package(GTest CONFIG REQUIRED)
 
 add_executable(test_dictionary test_dictionary.cpp )
 target_link_libraries(test_dictionary csp_engine GTest::gtest GTest::gtest_main rt)
@@ -7,7 +7,7 @@ add_executable(test_tick_buffer test_tick_buffer.cpp)
 target_link_libraries(test_tick_buffer csp_engine GTest::gtest GTest::gtest_main)
 
 add_executable(test_time_series test_time_series.cpp)
-target_link_libraries(test_time_series csp_engine_static gtest gtest_main pthread)
+target_link_libraries(test_time_series csp_engine GTest::gtest GTest::gtest_main pthread)
 
 add_executable(test_partial_switch_csp_type test_partial_switch_csp_type.cpp)
 target_link_libraries(test_partial_switch_csp_type csp_engine GTest::gtest GTest::gtest_main)

--- a/cpp/tests/engine/CMakeLists.txt
+++ b/cpp/tests/engine/CMakeLists.txt
@@ -1,7 +1,7 @@
 find_package(GTest CONFIG REQUIRED)
 
 add_executable(test_dictionary test_dictionary.cpp )
-target_link_libraries(test_dictionary csp_engine GTest::gtest GTest::gtest_main rt)
+target_link_libraries(test_dictionary csp_engine GTest::gtest GTest::gtest_main)
 
 add_executable(test_tick_buffer test_tick_buffer.cpp)
 target_link_libraries(test_tick_buffer csp_engine GTest::gtest GTest::gtest_main)

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ from skbuild import setup
 CSP_USE_VCPKG = os.environ.get("CSP_USE_VCPKG", "1").lower() in ("1", "on")
 CMAKE_OPTIONS = (
     ("CSP_BUILD_NO_CXX_ABI", "0"),
-    ("CSP_BUILD_TESTS", "0"),
+    ("CSP_BUILD_TESTS", "1"),
     ("CSP_MANYLINUX", "0"),
     ("CSP_BUILD_KAFKA_ADAPTER", "1"),
     ("CSP_BUILD_PARQUET_ADAPTER", "1"),


### PR DESCRIPTION
Depends on https://github.com/Point72/csp/pull/162 to avoid conflicts
- Re-enable C++ tests
- Build C++ tests by default
- Run C++ tests by default via `make build` command

Note: I was lazy and used a bash for loop. Windows will probably be unhappy. 
