### PR TITLE
Add to_json method for structs

### DIFF
--- a/cpp/csp/python/CMakeLists.txt
+++ b/cpp/csp/python/CMakeLists.txt
@@ -10,8 +10,10 @@ add_library(csptypesimpl
             CspTypeFactory.cpp
             PyCspEnum.cpp
             PyCspType.cpp
-            PyStruct.cpp)
+            PyStruct.cpp
+            PyStructToJson.cpp)
 set_target_properties(csptypesimpl PROPERTIES PUBLIC_HEADER "${CSPTYPESIMPL_PUBLIC_HEADERS}")
+target_compile_definitions(csptypesimpl PUBLIC RAPIDJSON_HAS_STDSTRING=1)
 target_link_libraries(csptypesimpl csp_core csp_types)
 
 set(CSPIMPL_PUBLIC_HEADERS
@@ -36,7 +38,8 @@ set(CSPIMPL_PUBLIC_HEADERS
         PyObjectPtr.h
         PyOutputAdapterWrapper.h
         PyOutputProxy.h
-        PyConstants.h)
+        PyConstants.h
+        PyStructToJson.h)
 
 add_library(cspimpl SHARED
         cspimpl.cpp

--- a/cpp/csp/python/PyStructToJson.cpp
+++ b/cpp/csp/python/PyStructToJson.cpp
@@ -1,0 +1,396 @@
+#include <csp/python/PyStructToJson.h>
+#include <rapidjson/document.h>
+#include <rapidjson/writer.h>
+
+namespace csp::python
+{
+
+// Helper function to convert csp Structs into json objects recursively
+rapidjson::Value toJsonRecursive( const StructPtr& self, rapidjson::Document& doc, PyObject * callable );
+
+// Helper function to parse some python objects in cpp, this should not be used extensively.
+// instead add support for those python types to csp so that they can be handled more generically
+// and in a language agnostic way
+rapidjson::Value pyObjectToJson( PyObject * value, rapidjson::Document& doc, PyObject * callable, bool is_recursing );
+
+// Helper fallback function to convert any type into json format recursively
+template<typename T>
+inline rapidjson::Value toJson( const T& val, const CspType& typ, rapidjson::Document& doc, PyObject * callable )
+{
+    // Default handler for any unknown T
+    return rapidjson::Value( val );
+}
+
+// Helper function to convert Enums into json format recursively
+template<>
+inline rapidjson::Value toJson( const CspEnum& val, const CspType& typ, rapidjson::Document& doc, PyObject * callable )
+{
+    // NOTE: Assume that passed enum has greater lifetime than the json object
+    return rapidjson::Value( rapidjson::StringRef( val.name() ) );
+}
+
+// Helper function to convert strings into json format recursively
+template<>
+inline rapidjson::Value toJson( const std::string& val, const CspType& typ, rapidjson::Document& doc, PyObject * callable )
+{
+    // NOTE: Assume that passed string has greater lifetime than the json object
+    return rapidjson::Value( rapidjson::StringRef( val ) );
+}
+
+// Helper function to convert TimeDelta into json format recursively
+template<>
+inline rapidjson::Value toJson( const TimeDelta& val, const CspType& typ, rapidjson::Document& doc, PyObject * callable )
+{
+    // Convert TimeDelta to <sign><seconds>.<microseconds>
+    // sign( 1 ) + seconds ( 18 ) + '.'( 1 ) + microseconds( 9 ) + '\0'( 1 )
+    char buf[32] = {};
+    auto seconds = val.abs().asSeconds();
+    auto microseconds = static_cast<unsigned>( val.abs().nanoseconds() / NANOS_PER_MICROSECOND );
+    auto len = sprintf( buf, "%c%ld.%06u", ( val.sign() >= 0 ) ? '+' : '-', seconds, microseconds );
+    rapidjson::Value res;
+    res.SetString( buf, len, doc.GetAllocator() );
+    return res;
+}
+
+// Helper function to convert Date into json format recursively
+template<>
+inline rapidjson::Value toJson( const Date& val, const CspType& typ, rapidjson::Document& doc, PyObject * callable )
+{
+    // Convert Date to <year>-<month>-<day>
+    // year( 4 ) + '-'( 1 ) + month( 2 ) + '-'( 1 ) + day( 2 ) + '\0'( 1 )
+    char buf[32] = {};
+    auto len = sprintf( buf, "%04u-%02u-%02u", val.year(), val.month(), val.day() );
+    rapidjson::Value res;
+    res.SetString( buf, len, doc.GetAllocator() );
+    return res;
+}
+
+// Helper function to convert Time into json format recursively
+template<>
+inline rapidjson::Value toJson( const Time& val, const CspType& typ, rapidjson::Document& doc, PyObject * callable )
+{
+    // Convert the Time to <hours>:<minutes>:<seconds>.<microseconds>
+    // hours( 2 ) + ':'( 1 ) + minutes( 2 ) + ':'( 1 ) + seconds( 2 ) + '.'( 1 ) + micros( 6 ) + '\0'( 1 )
+    char buf[48] = {};
+    auto micros = static_cast<unsigned>( val.nanosecond() / NANOS_PER_MICROSECOND );
+    auto len = sprintf( buf, "%02u:%02u:%02u.%06u", val.hour(), val.minute(), val.second(), micros );
+    rapidjson::Value res;
+    res.SetString( buf, len, doc.GetAllocator() );
+    return res;
+}
+
+// Helper function to convert DateTime into json format recursively
+template<>
+inline rapidjson::Value toJson( const DateTime& val, const CspType& typ, rapidjson::Document& doc, PyObject * callable )
+{
+    // Convert the datetime value into an ISO 8601 formatted string
+    DateTimeEx dtx( val );
+
+    char iso_str[80] = {};
+    static const std::string utc_offset = "+00:00";
+    auto micros = static_cast<unsigned>( dtx.nanoseconds() / NANOS_PER_MICROSECOND );
+    // Hardcode UTC since all times in csp are UTC
+    // NOTE: Python's datetime.fromisoformat() API does not support nanoseconds in the string
+    // Hence we truncate from nanos to micros to allow easy conversion to python datetime objects
+    auto len = sprintf( iso_str, "%04u-%02u-%02uT%02u:%02u:%02u.%06u%s",
+            dtx.year(), dtx.month(), dtx.day(),
+            dtx.hour(), dtx.minute(), dtx.second(), micros, utc_offset.c_str() );
+    rapidjson::Value res;
+    res.SetString( iso_str, len, doc.GetAllocator() );
+    return res;
+}
+
+// Helper function to convert csp Structs into json format recursively
+template<>
+inline rapidjson::Value toJson( const StructPtr& val, const CspType& typ, rapidjson::Document& doc, PyObject * callable )
+{
+    return toJsonRecursive( val, doc, callable );
+}
+
+// Helper function to convert python objects in csp Structs into json format recursively
+template<>
+inline rapidjson::Value toJson( const DialectGenericType& val, const CspType& typ, rapidjson::Document& doc, PyObject * callable )
+{
+    auto py_obj = toPython<DialectGenericType>( val );
+    return pyObjectToJson( py_obj, doc, callable, false );
+}
+
+// Helper function to convert arrays in csp Structs into json lists recursively
+template<typename StorageT>
+inline rapidjson::Value toJson( const std::vector<StorageT>& val, const CspType& typ, rapidjson::Document& doc, PyObject * callable )
+{
+    using ElemT = typename CspType::Type::toCArrayElemType<StorageT>::type;
+
+    auto const * arrayType = static_cast<const CspArrayType*>( &typ );
+    const CspType * elemType = arrayType -> elemType().get();
+    rapidjson::Value new_list;
+    new_list.SetArray();
+
+    for( size_t idx = 0; idx < val.size(); ++idx )
+    {
+        auto sub_json = toJson<ElemT>( val[idx], *elemType, doc, callable );
+        new_list.PushBack( sub_json, doc.GetAllocator() );
+    }
+    return new_list;
+}
+
+rapidjson::Value toJsonRecursive( const StructPtr& self, rapidjson::Document& doc, PyObject * callable )
+{
+    auto * struct_ptr = self.get();
+    if( struct_ptr == nullptr )
+    {
+        CSP_THROW( ValueError, "Cannot call to_json on NULL struct object" );
+    }
+    auto * meta = static_cast<const DialectStructMeta *>( self -> meta() );
+    rapidjson::Value new_dict;
+    new_dict.SetObject();
+
+    auto& fields = meta -> fields();
+    for( const auto& field: fields )
+    {
+        if( !field -> isSet( struct_ptr ) )
+        {
+            continue;
+        }
+        auto& key = field -> fieldname();
+        auto sub_json = switchCspType( field -> type(), [field, struct_ptr, callable, &doc]( auto tag )
+            {
+            using CType = typename decltype( tag )::type;
+            auto *typedField = static_cast<const typename StructField::upcast<CType>::type *>( field.get() );
+            return toJson( typedField -> value( struct_ptr ), *field -> type(), doc, callable );
+            } );
+        new_dict.AddMember( rapidjson::StringRef( key ), sub_json, doc.GetAllocator() );
+    }
+    return new_dict;
+}
+
+rapidjson::Value pyDictKeyToName( PyObject * py_key, rapidjson::Document& doc )
+{
+    // Only support strings, ints, and floats as keys
+    // JSON encoding requires all names to be strings so convert them to strings
+    rapidjson::Value val;
+    if( PyUnicode_Check( py_key ) )
+    {
+        Py_ssize_t len;
+        auto str = PyUnicode_AsUTF8AndSize( py_key, &len );
+        val.SetString( str, len, doc.GetAllocator() );
+    }
+    else if( PyLong_Check( py_key ) )
+    {
+        auto key = PyLong_AsLong( py_key );
+        val.SetString( std::to_string( key ), doc.GetAllocator() );
+    }
+    else if( PyFloat_Check( py_key ) )
+    {
+        auto key = PyFloat_AsDouble( py_key );
+        val.SetString( std::to_string( key ), doc.GetAllocator() );
+    }
+    else
+    {
+        CSP_THROW( ValueError, "Cannot serialize key of type: " + std::string( Py_TYPE( py_key ) -> tp_name ) );
+        // Never reaches here
+    }
+    return val;
+}
+
+// Helper function to parse python lists into json arrays recursively
+rapidjson::Value pyListToJson( PyObject * py_list, rapidjson::Document& doc, PyObject * callable )
+{
+    size_t size = PyList_GET_SIZE( py_list );
+    rapidjson::Value new_list;
+    new_list.SetArray();
+
+    for( size_t idx = 0; idx < size; ++idx )
+    {
+        auto * item = PyList_GET_ITEM( py_list, idx );
+        auto res = pyObjectToJson( item, doc, callable, false );
+        new_list.PushBack( res, doc.GetAllocator() );
+    }
+    return new_list;
+}
+
+// Helper function to parse python tuples into json arrays recursively
+rapidjson::Value pyTupleToJson( PyObject * py_tuple, rapidjson::Document& doc, PyObject * callable )
+{
+    size_t size = PyTuple_GET_SIZE( py_tuple );
+    rapidjson::Value new_list;
+    new_list.SetArray();
+
+    for( size_t idx = 0; idx < size; ++idx )
+    {
+        auto * item = PyTuple_GetItem( py_tuple, idx );
+        auto res = pyObjectToJson( item, doc, callable, false );
+        new_list.PushBack( res, doc.GetAllocator() );
+    }
+    return new_list;
+}
+
+// Helper function to parse python dicts into json objects recursively
+rapidjson::Value pyDictToJson( PyObject * py_dict, rapidjson::Document& doc, PyObject * callable )
+{
+    PyObject * py_key = NULL;
+    PyObject * py_value = NULL;
+    Py_ssize_t pos = 0;
+    rapidjson::Value new_dict;
+    new_dict.SetObject();
+
+    while( PyDict_Next( py_dict, &pos, &py_key, &py_value ) )
+    {
+        auto key = pyDictKeyToName( py_key, doc );
+        auto res = pyObjectToJson( py_value, doc, callable, false );
+        new_dict.AddMember( key, res, doc.GetAllocator() );
+    }
+    return new_dict;
+}
+
+rapidjson::Value pyObjectToJson( PyObject * value, rapidjson::Document& doc, PyObject * callable, bool is_recursing )
+{
+    if( PyBool_Check( value ) )
+    {
+        return rapidjson::Value( fromPython<bool>( value ) );
+    }
+    else if( PyLong_Check( value ) )
+    {
+        return rapidjson::Value( fromPython<int64_t>( value ) );
+    }
+    else if( PyFloat_Check( value ) )
+    {
+        return rapidjson::Value( fromPython<double>( value ) );
+    }
+    else if( PyUnicode_Check( value ) )
+    {
+        Py_ssize_t len;
+        auto str = PyUnicode_AsUTF8AndSize( value , &len );
+        rapidjson::Value str_val;
+        str_val.SetString( str, len, doc.GetAllocator() );
+        return str_val;
+    }
+    else if( PyBytes_Check( value ) )
+    {
+        Py_ssize_t len = PyBytes_Size( value );
+        auto str = PyBytes_AsString( value );
+        rapidjson::Value str_val;
+        str_val.SetString( str, len, doc.GetAllocator() );
+        return str_val;
+    }
+    else if( PyTime_CheckExact( value ) )
+    {
+        auto v = fromPython<Time>( value );
+        return toJson( v, CspType( CspType::Type::TIME ), doc, callable );
+    }
+    else if( PyDate_CheckExact( value ) )
+    {
+        auto v = fromPython<Date>( value );
+        return toJson( v, CspType( CspType::Type::DATE ), doc, callable );
+    }
+    else if( PyDateTime_CheckExact( value ) )
+    {
+        auto v = fromPython<DateTime>( value );
+        return toJson( v, CspType( CspType::Type::DATETIME ), doc, callable );
+    }
+    else if( PyDelta_CheckExact( value ) )
+    {
+        auto v = fromPython<TimeDelta>( value );
+        return toJson( v, CspType( CspType::Type::TIMEDELTA ), doc, callable );
+    }
+    else if( PyTuple_CheckExact( value ) )
+    {
+        // NOTE: Remove this logic when generic python tuples are supported as an internal type in csp
+        return pyTupleToJson( value, doc, callable );
+    }
+    else if( PyList_CheckExact( value ) )
+    {
+        // NOTE: Remove this logic when generic python lists are supported as an internal type in csp
+        return pyListToJson( value, doc, callable );
+    }
+    else if( PyDict_CheckExact( value ) )
+    {
+        // NOTE: Remove this logic when generic python dicts are supported as an internal type in csp
+        return pyDictToJson( value, doc, callable );
+    }
+    else if( PyType_IsSubtype( Py_TYPE( value ), &PyStruct::PyType ) )
+    {
+        auto struct_ptr = static_cast<PyStruct *>( value ) -> struct_;
+        return toJsonRecursive( struct_ptr, doc, callable );
+    }
+    else if( PyType_IsSubtype( Py_TYPE( value ), &PyCspEnum::PyType ) )
+    {
+        auto enum_ptr = static_cast<PyCspEnum *>( value ) -> enum_;
+        return toJson( enum_ptr, CspType( CspType::Type::ENUM ), doc, callable );
+    }
+    else
+    {
+        if( is_recursing )
+        {
+            // Looks like we are recursively calling pyObjectToJson for a generic unsupported type
+            // just return the object since we don't know how to jsonify it
+            CSP_THROW( ValueError, "Cannot serialize value of type: " + std::string( Py_TYPE( value ) -> tp_name ) );
+            // Never reaches here
+        }
+        else
+        {
+            // Not a known type
+            auto arglist = Py_BuildValue( "(O)", value );
+            // We expect callback to return a py object consisting of either csp types or dicts and lists
+            PyObject * res_py_obj = PyObject_CallObject( callable, arglist );
+            if( res_py_obj )
+            {
+                // NOTE: We could add checks to verify the returned py object is jsonified,
+                // but that would have performance implications
+                return pyObjectToJson( res_py_obj, doc, callable, true );
+            }
+            else
+            {
+                // The callback failed, just pass the error back up to the caller
+                CSP_THROW( PythonPassthrough, "" );
+            }
+        }
+    }
+}
+
+// Note: This class provides a way to write the rapidjson to a string stored in the holder
+// This can help avoid creating an extra copy of the string that StringBuffer would cause since
+// StringBuffer returns a char* instead of a string object
+class StringHolder
+{
+public:
+    typedef char Ch;
+    StringHolder( std::string& s ) : s_( s )
+    {
+        s_.reserve( DEFAULT_BUFFER_SIZE );
+    }
+    void Put( char c )
+    {
+        s_.push_back( c );
+    }
+    void Clear()
+    {
+        s_.clear();
+    }
+    void Flush()
+    {
+        return;
+    }
+    size_t Size() const
+    {
+        return s_.length();
+    }
+    const size_t DEFAULT_BUFFER_SIZE = 4096;
+private:
+    std::string& s_;
+};
+
+std::string structToJson( const StructPtr& struct_ptr, PyObject * callable )
+{
+    // Need this just for the Allocator
+    rapidjson::Document placeholder_doc;
+    auto json = toJsonRecursive( struct_ptr, placeholder_doc, callable );
+    std::string output;
+    StringHolder holder( output );
+    rapidjson::Writer<StringHolder> writer( holder );
+    json.Accept( writer );
+    placeholder_doc.GetAllocator().Clear();
+    return output;
+}
+
+}

--- a/cpp/csp/python/PyStructToJson.h
+++ b/cpp/csp/python/PyStructToJson.h
@@ -1,0 +1,14 @@
+#ifndef _IN_CSP_PYSTRUCT_TOJSON_H
+#define _IN_CSP_PYSTRUCT_TOJSON_H
+
+#include <csp/python/Conversions.h>
+
+namespace csp::python
+{
+
+// Entry point for converting structs into a json string
+std::string structToJson( const StructPtr& struct_ptr, PyObject * callable );
+
+}
+
+#endif

--- a/csp/impl/struct.py
+++ b/csp/impl/struct.py
@@ -164,6 +164,9 @@ class Struct(_csptypesimpl.PyStruct, metaclass=StructMeta):
     def to_dict(self):
         return self._obj_to_python(self)
 
+    def to_json(self, callback=lambda x: x):
+        return super().to_json(callback)
+
     def to_yaml(self):
         string_io = io.StringIO()
         g_YAML.dump(self.to_dict(), string_io)

--- a/csp/tests/impl/test_struct.py
+++ b/csp/tests/impl/test_struct.py
@@ -1,4 +1,6 @@
+import json
 import numpy as np
+import pytz
 import typing
 import unittest
 from datetime import date, datetime, time, timedelta
@@ -1217,6 +1219,477 @@ class TestCspStruct(unittest.TestCase):
 
         r = repr(a)
         self.assertTrue(repr(raw) in r)
+
+    def test_to_json_primitives(self):
+        class MyStruct(csp.Struct):
+            b: bool = True
+            i: int = 123
+            f: float = 3.14
+            s: str = "456"
+
+        test_struct = MyStruct()
+        result_dict = {"b": True, "i": 123, "f": 3.14, "s": "456"}
+        self.assertEqual(json.loads(test_struct.to_json()), result_dict)
+
+        test_struct = MyStruct(b=False, i=456, f=1.73, s="789")
+        result_dict = {"b": False, "i": 456, "f": 1.73, "s": "789"}
+        self.assertEqual(json.loads(test_struct.to_json()), result_dict)
+
+    def test_to_json_enums(self):
+        from enum import Enum as PyEnum
+
+        class MyPyEnum(PyEnum):
+            PyEnumA = 1
+            PyEnumB = 2
+            PyEnumC = 3
+            NumPyEnum = 4
+
+        def callback(obj):
+            if isinstance(obj, PyEnum):
+                return obj.name
+            raise RuntimeError("Invalid type for callback")
+
+        class MyCspEnum(csp.Enum):
+            CspEnumA = 1
+            CspEnumB = 2
+            CspEnumC = 3
+            NumCspEnum = 4
+
+        class MyStruct(csp.Struct):
+            i: int = 123
+            csp_e: MyCspEnum
+            py_e: MyPyEnum
+
+        test_struct = MyStruct()
+        result_dict = {"i": 123}
+        self.assertEqual(json.loads(test_struct.to_json()), result_dict)
+
+        test_struct = MyStruct(i=456, csp_e=MyCspEnum.CspEnumC)
+        result_dict = {"i": 456, "csp_e": "CspEnumC"}
+        self.assertEqual(json.loads(test_struct.to_json()), result_dict)
+        self.assertEqual(json.loads(test_struct.to_json(callback)), result_dict)
+
+        test_struct = MyStruct(i=456, py_e=MyPyEnum.PyEnumC)
+        result_dict = {"i": 456, "py_e": "PyEnumC"}
+        self.assertEqual(json.loads(test_struct.to_json(callback)), result_dict)
+
+        test_struct = MyStruct(i=456, csp_e=MyCspEnum.CspEnumA, py_e=MyPyEnum.PyEnumB)
+        result_dict = {"i": 456, "csp_e": "CspEnumA", "py_e": "PyEnumB"}
+        self.assertEqual(json.loads(test_struct.to_json(callback)), result_dict)
+
+    def test_to_json_datetime(self):
+        class MyStruct(csp.Struct):
+            i: int = 123
+            dt: datetime
+            d: date
+            t: time
+            td: timedelta
+
+        test_struct = MyStruct()
+        result_dict = {"i": 123}
+        self.assertEqual(json.loads(test_struct.to_json()), result_dict)
+
+        dt = datetime(2024, 3, 8)
+        dt_utc = datetime(2024, 3, 8, tzinfo=pytz.utc)
+        test_struct = MyStruct(i=456, dt=dt)
+        result_dict = json.loads(test_struct.to_json())
+        self.assertEqual(datetime.fromisoformat(result_dict["dt"]), dt_utc)
+
+        dt = datetime.now(tz=pytz.utc)
+        test_struct = MyStruct(i=456, dt=dt)
+        result_dict = json.loads(test_struct.to_json())
+        self.assertEqual(datetime.fromisoformat(result_dict["dt"]), dt)
+
+        dt = datetime.now(tz=pytz.timezone("America/New_York"))
+        dt_utc = dt.astimezone(pytz.utc)
+        test_struct = MyStruct(i=456, dt=dt)
+        result_dict = json.loads(test_struct.to_json())
+        self.assertEqual(datetime.fromisoformat(result_dict["dt"]), dt_utc)
+        self.assertEqual(datetime.fromisoformat(result_dict["dt"]), dt)
+
+        d = date(2024, 3, 8)
+        test_struct = MyStruct(i=456, d=d)
+        result_dict = {"i": 456, "d": "2024-03-08"}
+        self.assertEqual(json.loads(test_struct.to_json()), result_dict)
+
+        t = time(5, 10, 12, 500)
+        test_struct = MyStruct(i=456, t=t)
+        result_dict = {"i": 456, "t": "05:10:12.000500"}
+        self.assertEqual(json.loads(test_struct.to_json()), result_dict)
+
+        td = timedelta(days=1, seconds=68400.05)
+        seconds = td.total_seconds()
+        microseconds = round((seconds - int(seconds)) * 1e6)
+        test_struct = MyStruct(i=456, td=td)
+        result_dict = {"i": 456, "td": f"{int(seconds):+}.{microseconds:06}"}
+        self.assertEqual(json.loads(test_struct.to_json()), result_dict)
+
+        td = timedelta(days=-1, seconds=68400.05)
+        seconds = td.total_seconds()
+        microseconds = abs(round((seconds - int(seconds)) * 1e6))
+        test_struct = MyStruct(i=456, td=td)
+        result_dict = {"i": 456, "td": f"{int(seconds):+}.{microseconds:06}"}
+        self.assertEqual(json.loads(test_struct.to_json()), result_dict)
+
+    def test_to_json_list(self):
+        class MyStruct(csp.Struct):
+            i: int = 123
+            l_i: typing.List[int]
+            l_b: typing.List[bool]
+            l_dt: typing.List[datetime]
+            l_l_i: typing.List[typing.List[int]]
+            l_tuple: typing.Tuple[int, float, str]
+            l_any: list
+
+        test_struct = MyStruct()
+        result_dict = {"i": 123}
+        self.assertEqual(json.loads(test_struct.to_json()), result_dict)
+
+        l_i = [1, 2, 3]
+        test_struct = MyStruct(i=456, l_i=l_i)
+        result_dict = {"i": 456, "l_i": l_i}
+        self.assertEqual(json.loads(test_struct.to_json()), result_dict)
+
+        l_b = [True, True, False]
+        test_struct = MyStruct(i=456, l_b=l_b)
+        result_dict = {"i": 456, "l_b": l_b}
+        self.assertEqual(json.loads(test_struct.to_json()), result_dict)
+
+        dt = datetime.now(tz=pytz.timezone("Europe/London"))
+        l_dt = [dt, dt]
+        test_struct = MyStruct(i=456, l_dt=l_dt)
+        result_dict = json.loads(test_struct.to_json())
+        self.assertEqual([datetime.fromisoformat(d_str) for d_str in result_dict["l_dt"]], l_dt)
+
+        l_l_i = [[1, 2], [3, 4]]
+        test_struct = MyStruct(i=456, l_l_i=l_l_i)
+        result_dict = {"i": 456, "l_l_i": l_l_i}
+        self.assertEqual(json.loads(test_struct.to_json()), result_dict)
+
+        l_tuple = (1, 3.14, "hello world")
+        test_struct = MyStruct(i=456, l_tuple=l_tuple)
+        result_dict = {"i": 456, "l_tuple": list(l_tuple)}
+        self.assertEqual(json.loads(test_struct.to_json()), result_dict)
+
+        l_i = [1, 2, 3]
+        test_struct = MyStruct(i=456, l_any=l_i)
+        result_dict = {"i": 456, "l_any": l_i}
+        self.assertEqual(json.loads(test_struct.to_json()), result_dict)
+
+        dt = datetime.now(tz=pytz.timezone("Europe/London"))
+        l_dt = [dt, dt]
+        test_struct = MyStruct(i=456, l_any=l_dt)
+        result_dict = json.loads(test_struct.to_json())
+        self.assertEqual([datetime.fromisoformat(d_str) for d_str in result_dict["l_any"]], l_dt)
+
+        l_l_i = [[1, 2], [3, 4]]
+        test_struct = MyStruct(i=456, l_any=l_l_i)
+        result_dict = {"i": 456, "l_any": l_l_i}
+        self.assertEqual(json.loads(test_struct.to_json()), result_dict)
+
+        l_any = [[1, 2], "hello", [4, 3.2, [6, [7], (8, True, 10.5, (11, [12, False]))]]]
+        l_any_result = [[1, 2], "hello", [4, 3.2, [6, [7], [8, True, 10.5, [11, [12, False]]]]]]
+        test_struct = MyStruct(i=456, l_any=l_any)
+        result_dict = {"i": 456, "l_any": l_any_result}
+        self.assertEqual(json.loads(test_struct.to_json()), result_dict)
+
+    def test_to_json_dict(self):
+        class MyStruct(csp.Struct):
+            i: int = 123
+            d_i: typing.Dict[int, int]
+            d_dt: typing.Dict[str, datetime]
+            d_d_s: typing.Dict[str, typing.Dict[str, str]]
+            d_any: dict
+
+        test_struct = MyStruct()
+        result_dict = {"i": 123}
+        self.assertEqual(json.loads(test_struct.to_json()), result_dict)
+
+        d_i = {1: 2, 3: 4, 5: 6}
+        d_i_res = {str(k): v for k, v in d_i.items()}
+        test_struct = MyStruct(i=456, d_i=d_i)
+        result_dict = {"i": 456, "d_i": d_i_res}
+        self.assertEqual(json.loads(test_struct.to_json()), result_dict)
+
+        dt = datetime.now(tz=pytz.utc)
+        d_dt = {"d1": dt, "d2": dt}
+        test_struct = MyStruct(i=456, d_dt=d_dt)
+        result_dict = json.loads(test_struct.to_json())
+        self.assertEqual({k: datetime.fromisoformat(d) for k, d in result_dict["d_dt"].items()}, d_dt)
+
+        d_d_s = {"b1": {"d1": "k1", "d2": "k2"}, "b2": {"d3": "k3", "d4": "k4"}}
+        test_struct = MyStruct(i=456, d_d_s=d_d_s)
+        result_dict = {"i": 456, "d_d_s": d_d_s}
+        self.assertEqual(json.loads(test_struct.to_json()), result_dict)
+
+        d_i = {1: 2, 3: 4, 5: 6}
+        d_i_res = {str(k): v for k, v in d_i.items()}
+        test_struct = MyStruct(i=456, d_any=d_i)
+        result_dict = {"i": 456, "d_any": d_i_res}
+        self.assertEqual(json.loads(test_struct.to_json()), result_dict)
+
+        dt = datetime.now(tz=pytz.utc)
+        d_dt = {"d1": dt, "d2": dt}
+        test_struct = MyStruct(i=456, d_any=d_dt)
+        result_dict = json.loads(test_struct.to_json())
+        self.assertEqual({k: datetime.fromisoformat(d) for k, d in result_dict["d_any"].items()}, d_dt)
+
+        d_any = {"b1": {1: "k1", "d2": {4: 5.5}}, "b2": {"d3": {}, "d4": {"d5": {"d6": {"d7": {}}}}}}
+        d_any_res = {"b1": {"1": "k1", "d2": {"4": 5.5}}, "b2": {"d3": {}, "d4": {"d5": {"d6": {"d7": {}}}}}}
+        test_struct = MyStruct(i=456, d_any=d_any)
+        result_dict = {"i": 456, "d_any": d_any_res}
+        self.assertEqual(json.loads(test_struct.to_json()), result_dict)
+
+    def test_to_json_struct(self):
+        class MySubSubStruct(csp.Struct):
+            b: bool = True
+            i: int = 123
+            f: float = 3.14
+            s: str = "MySubSubStruct"
+
+        class MySubStruct(csp.Struct):
+            b: bool = True
+            i: int = 456
+            f: float = 2.71
+            s: str = "MySubStruct"
+            msss: MySubSubStruct = MySubSubStruct()
+
+        class MyStruct(csp.Struct):
+            i: int = 789
+            s: str = "MyStruct"
+            mss: MySubStruct = MySubStruct()
+            msss: MySubSubStruct
+
+        test_struct = MySubSubStruct()
+        result_dict = {"b": True, "i": 123, "f": 3.14, "s": "MySubSubStruct"}
+        self.assertEqual(json.loads(test_struct.to_json()), result_dict)
+
+        test_struct = MySubStruct()
+        result_dict = {
+            "b": True,
+            "i": 456,
+            "f": 2.71,
+            "s": "MySubStruct",
+            "msss": {"b": True, "i": 123, "f": 3.14, "s": "MySubSubStruct"},
+        }
+        self.assertEqual(json.loads(test_struct.to_json()), result_dict)
+
+        test_struct = MyStruct()
+        result_dict = {
+            "i": 789,
+            "s": "MyStruct",
+            "mss": {
+                "b": True,
+                "i": 456,
+                "f": 2.71,
+                "s": "MySubStruct",
+                "msss": {"b": True, "i": 123, "f": 3.14, "s": "MySubSubStruct"},
+            },
+        }
+        self.assertEqual(json.loads(test_struct.to_json()), result_dict)
+
+        msss = MySubSubStruct(s="MySubSubStructNew")
+        mss = MySubStruct(s="MySubStructNew", msss=msss)
+        ms = MyStruct(s="MyStructNew", mss=mss, msss=msss)
+
+        result_dict = {"b": True, "i": 123, "f": 3.14, "s": "MySubSubStructNew"}
+        self.assertEqual(json.loads(msss.to_json()), result_dict)
+
+        result_dict = {
+            "b": True,
+            "i": 456,
+            "f": 2.71,
+            "s": "MySubStructNew",
+            "msss": {"b": True, "i": 123, "f": 3.14, "s": "MySubSubStructNew"},
+        }
+        self.assertEqual(json.loads(mss.to_json()), result_dict)
+
+        result_dict = {
+            "i": 789,
+            "s": "MyStructNew",
+            "mss": {
+                "b": True,
+                "i": 456,
+                "f": 2.71,
+                "s": "MySubStructNew",
+                "msss": {"b": True, "i": 123, "f": 3.14, "s": "MySubSubStructNew"},
+            },
+            "msss": {"b": True, "i": 123, "f": 3.14, "s": "MySubSubStructNew"},
+        }
+        self.assertEqual(json.loads(ms.to_json()), result_dict)
+
+    def test_to_json_all(self):
+        class MyEnum(csp.Enum):
+            A = 1
+            B = 2
+            C = 3
+            NUM = 4
+
+        class NonCspStruct:
+            pass
+
+        class MySubSubStruct(csp.Struct):
+            ncsp: NonCspStruct
+            nparray: np.ndarray
+            myenum: MyEnum
+
+        class MySubStruct(csp.Struct):
+            d_s_msss: dict
+            l_ncsp: typing.List[NonCspStruct]
+            py_l_ncsp: list
+
+        class MyStruct(csp.Struct):
+            i: int = 789
+            s: str = "MyStruct"
+            ts: datetime
+            l_mss: typing.List[MySubStruct]
+            l_msss: list
+            d_i_ncsp: dict
+
+        def custom_jsonifier(obj):
+            if isinstance(obj, np.ndarray):
+                return obj.tolist()
+            elif isinstance(obj, NonCspStruct):
+                return {"ncsp_key": "ncsp_value", "ncsp_arr": np.array(["ncsp_arr_val1", "ncsp_arr_val2"])}
+            else:
+                return obj
+
+        test_struct = MyStruct()
+        result_dict = {"i": 789, "s": "MyStruct"}
+        self.assertEqual(json.loads(test_struct.to_json()), result_dict)
+
+        enum1 = MyEnum.A
+        enum2 = MyEnum.C
+        enum3 = MyEnum.NUM
+
+        ncsp1 = NonCspStruct()
+        ncsp2 = NonCspStruct()
+        ncsp3 = NonCspStruct()
+
+        msss1 = MySubSubStruct(ncsp=ncsp1, myenum=enum1)
+        msss2 = MySubSubStruct(myenum=enum2)
+        msss3 = MySubSubStruct(nparray=np.array([1, 9]), myenum=enum3)
+        msss4 = MySubSubStruct(ncsp=ncsp2, nparray=np.array([1, 9]))
+
+        mss1 = MySubStruct(d_s_msss={"msss1": msss1}, l_ncsp=[ncsp1, ncsp2], py_l_ncsp=[ncsp2, ncsp3])
+        mss2 = MySubStruct(d_s_msss={"msss2": msss2}, l_ncsp=[ncsp2], py_l_ncsp=[ncsp3])
+
+        dt = datetime.now(tz=pytz.utc)
+        ms = MyStruct(
+            i=123456789,
+            s="NewMyStruct",
+            ts=dt,
+            l_mss=[mss2, mss1],
+            l_msss=[msss3, msss1, msss2, msss4],
+            d_i_ncsp={1: ncsp1, 2: ncsp2, 3: ncsp3},
+        )
+        test_struct = ms
+        result_dict_ncsp1 = {"ncsp_key": "ncsp_value", "ncsp_arr": ["ncsp_arr_val1", "ncsp_arr_val2"]}
+        result_dict_ncsp2 = {"ncsp_key": "ncsp_value", "ncsp_arr": ["ncsp_arr_val1", "ncsp_arr_val2"]}
+        result_dict_ncsp3 = {"ncsp_key": "ncsp_value", "ncsp_arr": ["ncsp_arr_val1", "ncsp_arr_val2"]}
+        result_dict_msss1 = {"ncsp": result_dict_ncsp1, "myenum": "A"}
+        result_dict_msss2 = {"myenum": "C"}
+        result_dict_msss3 = {"nparray": [1, 9], "myenum": "NUM"}
+        result_dict_msss4 = {"ncsp": result_dict_ncsp2, "nparray": [1, 9]}
+
+        result_dict_mss1 = {
+            "d_s_msss": {"msss1": result_dict_msss1},
+            "l_ncsp": [result_dict_ncsp1, result_dict_ncsp2],
+            "py_l_ncsp": [result_dict_ncsp2, result_dict_ncsp3],
+        }
+        result_dict_mss2 = {
+            "d_s_msss": {"msss2": result_dict_msss2},
+            "l_ncsp": [result_dict_ncsp2],
+            "py_l_ncsp": [result_dict_ncsp3],
+        }
+        result_dict_ms = {
+            "i": 123456789,
+            "s": "NewMyStruct",
+            "ts": dt,
+            "l_mss": [result_dict_mss2, result_dict_mss1],
+            "l_msss": [result_dict_msss3, result_dict_msss1, result_dict_msss2, result_dict_msss4],
+            "d_i_ncsp": {"1": result_dict_ncsp1, "2": result_dict_ncsp2, "3": result_dict_ncsp3},
+        }
+
+        self.assertEqual(json.loads(msss1.to_json(custom_jsonifier)), result_dict_msss1)
+        self.assertEqual(json.loads(msss2.to_json(custom_jsonifier)), result_dict_msss2)
+        self.assertEqual(json.loads(msss3.to_json(custom_jsonifier)), result_dict_msss3)
+        self.assertEqual(json.loads(msss4.to_json(custom_jsonifier)), result_dict_msss4)
+
+        self.assertEqual(json.loads(mss1.to_json(custom_jsonifier)), result_dict_mss1)
+        self.assertEqual(json.loads(mss2.to_json(custom_jsonifier)), result_dict_mss2)
+
+        result = json.loads(test_struct.to_json(custom_jsonifier))
+        result["ts"] = datetime.fromisoformat(result["ts"])
+        self.assertEqual(result, result_dict_ms)
+
+    def test_to_json_callback(self):
+        class MyExceptionNonCspStruct:
+            pass
+
+        class MyExceptionStruct(csp.Struct):
+            e: MyExceptionNonCspStruct
+
+        class MyNonCspStruct:
+            s: str = "NonCspStruct"
+
+        class MyStruct(csp.Struct):
+            i: int = 123
+            narray: np.ndarray
+            mncsps: MyNonCspStruct
+
+        def custom_jsonifier(obj):
+            if isinstance(obj, np.ndarray):
+                a = obj.tolist()
+                return a
+            elif isinstance(obj, MyNonCspStruct):
+                return {"s": obj.s}
+            elif isinstance(obj, MyExceptionNonCspStruct):
+                raise TypeError("Testing exceptions in callback")
+            else:
+                raise Exception("Obj type cannot be jsonified")
+
+        test_struct = MyStruct()
+        result_dict = {"i": 123}
+        self.assertEqual(json.loads(test_struct.to_json()), result_dict)
+
+        narray = np.array([1, 9])
+        test_struct = MyStruct(narray=narray)
+        result_dict = {"i": 123, "narray": narray}
+        result_dict_custom = {"i": 123, "narray": narray.tolist()}
+        self.assertEqual(json.loads(test_struct.to_json(custom_jsonifier)), result_dict_custom)
+        with self.assertRaises(ValueError):
+            test_struct.to_json()
+
+        narray = np.eye(10)
+        test_struct = MyStruct(narray=narray)
+        result_dict = {"i": 123, "narray": narray}
+        result_dict_custom = {"i": 123, "narray": narray.tolist()}
+        with self.assertRaises(ValueError):
+            self.assertEqual(json.loads(test_struct.to_json()), result_dict)
+        self.assertEqual(json.loads(test_struct.to_json(custom_jsonifier)), result_dict_custom)
+
+        mncsps = MyNonCspStruct()
+        test_struct = MyStruct(mncsps=mncsps)
+        result_dict = {"i": 123, "mncsps": mncsps}
+        result_dict_custom = {"i": 123, "mncsps": {"s": mncsps.s}}
+        with self.assertRaises(ValueError):
+            self.assertEqual(json.loads(test_struct.to_json()), result_dict)
+        self.assertEqual(json.loads(test_struct.to_json(custom_jsonifier)), result_dict_custom)
+
+        mncsps = MyNonCspStruct()
+        mncsps.s = "NewNonCspStruct"
+        mncsps.s_dynamic = "DynamicMetadata"
+        test_struct = MyStruct(mncsps=mncsps)
+        result_dict = {"i": 123, "mncsps": mncsps}
+        result_dict_custom = {"i": 123, "mncsps": {"s": mncsps.s}}
+        with self.assertRaises(ValueError):
+            self.assertEqual(json.loads(test_struct.to_json()), result_dict)
+        self.assertEqual(json.loads(test_struct.to_json(custom_jsonifier)), result_dict_custom)
+
+        test_struct = MyExceptionStruct(e=MyExceptionNonCspStruct())
+        with self.assertRaises(TypeError):
+            json.loads(test_struct.to_json(custom_jsonifier))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This PR adds the `to_json` method for structs.

With this, we can efficiently convert struct objects into json strings and communicate with other third-party endpoints using the JSON protocol.
For example,
```
class EmptyCspStruct(csp.Struct):
class CspStruct(csp.Struct):
    a: int = 0
    b: str = "str"
    c: list = 3.14
    d: EmptyCspStruct = EmptyCspStruct()
obj = CspStruct()
obj.to_json() # "{'a': 0, 'b': 'str', 'c': 3.14, 'd': {}}"
```

This change also supports parsing some Python specific `DialectGenericType` objects when converting structs into json strings. The list of Python specific types supported is `list, dict, and tuple`. In addition, Python's datetime types (`datetime, date, time, timedelta`) are also supported as they are natively supported by csp. 
```
class CspStruct(csp.Struct):
    a: dict = {'k': 'v'}
    b: list = ['l1', 'l2']
    c: tuple = ('t1', 't2', 't3')
obj = CspStruct()
obj.to_json() # "{'a': {'k': 'v'}, 'b': ['l1', 'l2'], 'c': ['t1', 't2', 't3']}"
```