### PR TITLE
Update codeowners for license check

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,16 +2,19 @@
 * @robambalu @AdamGlustein @svatasoiu @alexddobkin
 
 # Packaging code
-CMakeLists.txt @robambalu @AdamGlustein @svatasoiu @alexddobkin @timkpaine @czgdp1807
-setup.py @robambalu @AdamGlustein @svatasoiu @alexddobkin @timkpaine @czgdp1807
-pyproject.toml @robambalu @AdamGlustein @svatasoiu @alexddobkin @timkpaine @czgdp1807
-Makefile @robambalu @AdamGlustein @svatasoiu @alexddobkin @timkpaine @czgdp1807
-MANIFEST.in @robambalu @AdamGlustein @svatasoiu @alexddobkin @timkpaine @czgdp1807
-.bumpversion.cfg @robambalu @AdamGlustein @svatasoiu @alexddobkin @timkpaine @czgdp1807
+.bumpversion.cfg @robambalu @AdamGlustein @svatasoiu @alexddobkin @ptomecek @timkpaine @czgdp1807
+CMakeLists.txt @robambalu @AdamGlustein @svatasoiu @alexddobkin @ptomecek @timkpaine @czgdp1807
+Makefile @robambalu @AdamGlustein @svatasoiu @alexddobkin @ptomecek @timkpaine @czgdp1807
+MANIFEST.in @robambalu @AdamGlustein @svatasoiu @alexddobkin @ptomecek @timkpaine @czgdp1807
+pyproject.toml @robambalu @AdamGlustein @svatasoiu @alexddobkin @ptomecek @timkpaine @czgdp1807
+setup.py @robambalu @AdamGlustein @svatasoiu @alexddobkin @ptomecek @timkpaine @czgdp1807
+vcpkg.json @robambalu @AdamGlustein @svatasoiu @alexddobkin @ptomecek @timkpaine @czgdp1807
 
 # CI/CD
-.github @robambalu @AdamGlustein @svatasoiu @alexddobkin @timkpaine @czgdp1807
-ci @robambalu @AdamGlustein @svatasoiu @alexddobkin @timkpaine @czgdp1807
+.github @robambalu @AdamGlustein @svatasoiu @alexddobkin @ptomecek @timkpaine @czgdp1807
+ci @robambalu @AdamGlustein @svatasoiu @alexddobkin @ptomecek @timkpaine @czgdp1807
 
 # Administrative
 .github/CODEOWNERS @robambalu
+LICENSE @ptomecek @timkpaine
+NOTICE @ptomecek @timkpaine


### PR DESCRIPTION
This just makes 2 changes.

1. Alphabetize the packaging block, add `vcpkg.json`


2. I almost missed in https://github.com/Point72/csp/pull/152 so adding @ptomecek so there's another set of eyes/notifications, changes to `vcpkg.json` need to yield changes in `NOTICE` (via [`make notice`](https://github.com/Point72/csp/blob/47ec0dc4ae842d245910ac929b014018397815bb/Makefile#L163)) due to our use of statically linked packages, and nothing should modify `LICENSE` 

