### PR TITLE
mkdocs setup

### DIFF
--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -1,0 +1,57 @@
+site_name: CSP
+
+docs_dir: wiki
+
+theme:
+  name: material
+  features:
+    - navigation.tabs
+
+exclude_docs: |
+  _Sidebar.md
+  _Footer.md
+
+nav:
+  - Home: Home.md
+  - User guide:
+    - Get Started (Tutorials):
+      - get-started/Installation.md
+      - get-started/First-Steps.md
+    - Concepts:
+      - concepts/CSP-Node.md
+      - concepts/CSP-Graph.md
+      - concepts/Historical-Buffers.md
+      - concepts/Execution-Modes.md
+      - concepts/Adapters.md
+    - How-to guides:
+      - how-tos/Use-Statistical-Nodes.md
+      - how-tos/Use-Adapters.md
+      - how-tos/Add-Cycles-in-Graphs.md
+      - how-tos/Create-Dynamic-Baskets.md
+      - Write Adapters:
+        - how-tos/Write-Historical-Input-Adapters.md
+        - how-tos/Write-Realtime-Input-Adapters.md
+        - how-tos/Write-Output-Adapters.md
+      - how-tos/Profile-CSP-Code.md
+    - References:
+      - API Reference:
+        - api-references/Base-Nodes-API.md
+        - api-references/Base-Adapters-API.md
+        - api-references/Math-and-Logic-Nodes-API.md
+        - api-references/Statistical-Nodes-API.md
+        - api-references/Functional-Methods-API.md
+        - Adapters (Kafka, Parquet, DBReader) API: api-references/Input-Output-Adapters-API.md
+        - api-references/Random-Time-Series-Generators-API.md
+        - api-references/csp.Struct-API.md
+        - api-references/csp.dynamic-API.md
+        - api-references/csp.profiler-API.md
+      - references/Examples.md
+      - Glossary of Terms: references/Glossary.md
+
+  - Developer Guide:
+    - Contributing: dev-guides/Contribute.md
+    - Development Setup: dev-guides/Local-Development-Setup.md
+    - dev-guides/Build-CSP-from-Source.md
+    - GitHub Conventions (for maintainers): dev-guides/GitHub-Conventions.md
+    - Release Process (for maintainers): dev-guides/Release-Process.md
+    - dev-guides/Roadmap.md

--- a/docs/wiki/Home.md
+++ b/docs/wiki/Home.md
@@ -19,9 +19,9 @@ CSP (Composable Stream Processing) is a library for high-performance real-time e
 
 ## Get Started
 
-- [Install CSP](Installation) and [write your first CSP program](First-Steps)
-- Learn more about [nodes](CSP-Node), [graphs](CSP-Graph), and [execution modes](Execution-Modes)
-- Learn to extend CSP with [adapters](Adapters)
+- [Install CSP](get-started/Installation.md) and [write your first CSP program](get-started/First-Steps.md)
+- Learn more about [nodes](concepts/CSP-Node.md), [graphs](concepts/CSP-Graph.md), and [execution modes](concepts/Execution-Modes.md)
+- Learn to extend CSP with [adapters](concepts/Adapters.md)
 
 <!-- - Check out the [examples](Examples) for various CSP features and use cases -->
 
@@ -30,8 +30,8 @@ CSP (Composable Stream Processing) is a library for high-performance real-time e
 
 ## Community
 
-- [Contribute](Contribute) to CSP and help improve the project
-- Read about future plans in the [project roadmap](Roadmap)
+- [Contribute](dev-guides/Contribute.md) to CSP and help improve the project
+- Read about future plans in the [project roadmap](dev-guides/Roadmap.md)
 
 ## License
 

--- a/docs/wiki/api-references/Base-Adapters-API.md
+++ b/docs/wiki/api-references/Base-Adapters-API.md
@@ -79,7 +79,7 @@ This allows you to connect an edge as a "graph output".
 All edges added as outputs will be returned to the caller from `csp.run` as a dictionary of `key: [(datetime, value)]`
 (list of datetime, values that ticked on the edge) or if `csp.run` is passed `output_numpy=True`, as a dictionary of
 `key: (array, array)` (tuple of two numpy arrays, one with datetimes and one with values).
-See [Collecting Graph Outputs](CSP-Graph#collecting-graph-outputs)
+See [Collecting Graph Outputs](../concepts/CSP-Graph.md#collecting-graph-outputs)
 
 Args:
 

--- a/docs/wiki/api-references/Base-Nodes-API.md
+++ b/docs/wiki/api-references/Base-Nodes-API.md
@@ -299,7 +299,7 @@ csp.dynamic_demultiplex(
 ) → {ts['K']: ts['T']}
 ```
 
-Similar to `csp.demultiplex`, this version will return a [Dynamic Basket](Create-Dynamic-Baskets) output that will dynamically add new keys as they are seen.
+Similar to `csp.demultiplex`, this version will return a [Dynamic Basket](../how-tos/Create-Dynamic-Baskets.md) output that will dynamically add new keys as they are seen.
 
 ## `csp.dynamic_collect`
 
@@ -309,7 +309,7 @@ csp.dynamic_collect(
 ) → ts[{'K': 'T'}]
 ```
 
-Similar to `csp.collect`, this function takes a [Dynamic Basket](Create-Dynamic-Baskets) input and returns a dictionary of the key-value pairs corresponding to the values that ticked.
+Similar to `csp.collect`, this function takes a [Dynamic Basket](../how-tos/Create-Dynamic-Baskets.md) input and returns a dictionary of the key-value pairs corresponding to the values that ticked.
 
 ## `csp.drop_nans`
 

--- a/docs/wiki/concepts/CSP-Graph.md
+++ b/docs/wiki/concepts/CSP-Graph.md
@@ -84,7 +84,7 @@ result:
 
 Note that the result is a list of `(datetime, value)` tuples.
 
-You can also use [csp.add_graph_output](Base-Adapters-API#cspadd_graph_output) to add outputs.
+You can also use [csp.add_graph_output](../api-references/Base-Adapters-API.md#cspadd_graph_output) to add outputs.
 These do not need to be in the top-level graph called directly from `csp.run`.
 
 This gives the same result:

--- a/docs/wiki/concepts/CSP-Node.md
+++ b/docs/wiki/concepts/CSP-Node.md
@@ -155,7 +155,7 @@ basket and react to it as well as access its current value
 ## **Node Outputs**
 
 Nodes can return any number of outputs (including no outputs, in which case it is considered an "output" or sink node,
-see [Graph Pruning](CSP-Graph#graph-pruning)).
+see [Graph Pruning](CSP-Graph.md#graph-pruning)).
 Nodes with single outputs can return the output as an unnamed output.
 Nodes returning multiple outputs must have them be named.
 When a node is called at graph building time, if it is a single unnamed node the return variable is an edge representing the output which can be passed into other nodes.

--- a/docs/wiki/dev-guides/Contribute.md
+++ b/docs/wiki/dev-guides/Contribute.md
@@ -4,6 +4,6 @@ For **bug reports** or **small feature requests**, please open an issue on our [
 
 For **questions** or to discuss **larger changes or features**, please use our [discussions page](https://github.com/Point72/csp/discussions).
 
-For **contributions**, please see our [developer documentation](Local-Development-Setup). We have `help wanted` and `good first issue` tags on our issues page, so these are a great place to start.
+For **contributions**, please see our [developer documentation](Local-Development-Setup.md). We have `help wanted` and `good first issue` tags on our issues page, so these are a great place to start.
 
 For **documentation updates**, make PRs that update the pages in `/docs/wiki`. The documentation is pushed to the GitHub wiki automatically through a GitHub workflow. Note that direct updates to this wiki will be overwritten.

--- a/docs/wiki/dev-guides/Local-Development-Setup.md
+++ b/docs/wiki/dev-guides/Local-Development-Setup.md
@@ -12,7 +12,7 @@
 ## Step 1: Build CSP from Source
 
 To work on CSP, you are going to need to build it from source. See
-[Build CSP from Source](Build-CSP-from-Source) for
+[Build CSP from Source](Build-CSP-from-Source.md) for
 detailed build instructions.
 
 Once you've built CSP from a `git` clone, you will also need to
@@ -80,7 +80,7 @@ key](https://docs.github.com/en/authentication/connecting-to-github-with-ssh/add
 
 ## Guidelines
 
-After developing a change locally, ensure that both [lints](Build-CSP-from-Source#lint-and-autoformat) and [tests](Build-CSP-from-Source#testing) pass. Commits should be squashed into logical units, and all commits must be signed (e.g. with the `-s` git flag). CSP requires [Developer Certificate of Origin](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) for all contributions.
+After developing a change locally, ensure that both [lints](Build-CSP-from-Source.md#lint-and-autoformat) and [tests](Build-CSP-from-Source.md#testing) pass. Commits should be squashed into logical units, and all commits must be signed (e.g. with the `-s` git flag). CSP requires [Developer Certificate of Origin](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) for all contributions.
 
 If your work is still in-progress, open a [draft pull request](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests#draft-pull-requests). Otherwise, open a normal pull request. It might take a few days for a maintainer to review and provide feedback, so please be patient. If a maintainer asks for changes, please make said changes and squash your commits if necessary. If everything looks good to go, a maintainer will approve and merge your changes for inclusion in the next release.
 

--- a/docs/wiki/get-started/Installation.md
+++ b/docs/wiki/get-started/Installation.md
@@ -17,4 +17,4 @@ conda install csp -c conda-forge
 ## Source installation
 
 For other platforms, follow the instructions to [build CSP from
-source](Build-CSP-from-Source).
+source](../dev-guides/Build-CSP-from-Source.md).

--- a/docs/wiki/how-tos/Use-Adapters.md
+++ b/docs/wiki/how-tos/Use-Adapters.md
@@ -1,0 +1,1 @@
+# Use Adapters (coming soon)

--- a/docs/wiki/index.md
+++ b/docs/wiki/index.md
@@ -1,0 +1,1 @@
+<meta http-equiv=refresh content="0;url=/Home">

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -84,6 +84,10 @@ symphony = [
 slack = [
     "slack-sdk>=3",
 ]
+docs = [
+    "mkdocs",
+    "mkdocs-material",
+]
 
 [tool.check-manifest]
 ignore = []


### PR DESCRIPTION
Will allow **local** documentation set up with `mkdocs serve --clean` 

Also fixes a few broken links resulting from the documentation restructure.