### PR TITLE
Maintain the type of a list-derived object when converting a struct in to_dict

### DIFF
--- a/cpp/csp/python/PyStructList.hi
+++ b/cpp/csp/python/PyStructList.hi
@@ -394,6 +394,16 @@ static PyMappingMethods py_struct_list_as_mapping = {
     py_struct_list_ass_subscript<StorageT>
 };
 
+static PyObject *
+PyStructList_new( PyTypeObject *type, PyObject *args, PyObject *kwds )
+{
+    // Since the PyStructList has no real meaning when created from Python, we can reconstruct the PSL's value
+    // by just treating it as a list. Thus, we simply override the tp_new behaviour to return a list object here.
+    // Again, since we don't have tp_init for the PSL, we need to rely on the Python list's tp_init function.
+
+    return PyObject_Call( ( PyObject * ) &PyList_Type, args, kwds ); // Calls both tp_new and tp_init for a Python list
+}
+
 template<typename StorageT>
 static int
 PyStructList_tp_clear( PyStructList<StorageT> * self )
@@ -437,7 +447,7 @@ template<typename StorageT> PyTypeObject PyStructList<StorageT>::PyType = {
     .tp_clear = ( inquiry ) PyStructList_tp_clear<StorageT>,
     .tp_methods = PyStructList_methods<StorageT>,
     .tp_alloc = PyType_GenericAlloc,
-    .tp_new   = PyType_GenericNew,
+    .tp_new   = PyStructList_new,
     .tp_free  = PyObject_GC_Del,
 };
 

--- a/csp/impl/struct.py
+++ b/csp/impl/struct.py
@@ -108,9 +108,7 @@ class Struct(_csptypesimpl.PyStruct, metaclass=StructMeta):
             )
         elif isinstance(obj, dict):
             return {k: cls._obj_to_python(v) for k, v in obj.items()}
-        elif isinstance(obj, list):
-            return list(cls._obj_to_python(v) for v in obj)
-        elif isinstance(obj, (tuple, set)):
+        elif isinstance(obj, (list, tuple, set)):
             return type(obj)(cls._obj_to_python(v) for v in obj)
         elif isinstance(obj, csp.Enum):
             return obj.name  # handled in _obj_from_python

--- a/csp/tests/impl/test_struct.py
+++ b/csp/tests/impl/test_struct.py
@@ -697,6 +697,19 @@ class TestCspStruct(unittest.TestCase):
         struct = StructWithDefaults.from_dict({"e": MyEnum.A})
         self.assertEqual(MyEnum.A, getattr(struct, "e"))
 
+    def test_from_dict_with_list_derived_type(self):
+        class ListDerivedType(list):
+            def __init__(self, iterable=None):
+                super().__init__(iterable)
+
+        class StructWithListDerivedType(csp.Struct):
+            ldt: ListDerivedType
+
+        s1 = StructWithListDerivedType(ldt=ListDerivedType([1,2]))
+        self.assertTrue(isinstance(s1.to_dict()['ldt'], ListDerivedType))
+        s2 = StructWithListDerivedType.from_dict(s1.to_dict())
+        self.assertEqual(s1, s2)
+
     def test_from_dict_loop_no_defaults(self):
         looped = StructNoDefaults.from_dict(StructNoDefaults(a1=[9, 10]).to_dict())
         self.assertEqual(looped, StructNoDefaults(a1=[9, 10]))


### PR DESCRIPTION
Also make the newly implemented `PyStructList` type constructible as a list.