### PR TITLE
Feature/rba vcpkg update baseline

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ if CSP_USE_VCPKG:
         subprocess.call(["git", "pull"], cwd="vcpkg")
         args = ["install"]
         if VCPKG_TRIPLET is not None:
-            args.append( f"--triplet={VCPKG_TRIPLET}" );
+            args.append( f"--triplet={VCPKG_TRIPLET}" )
         if os.name == "nt":
             subprocess.call(["bootstrap-vcpkg.bat"], cwd="vcpkg", shell=True)
             subprocess.call(["vcpkg.bat"] + args, cwd="vcpkg", shell=True)

--- a/setup.py
+++ b/setup.py
@@ -22,6 +22,11 @@ CMAKE_OPTIONS = (
     # - omit coverage/gprof, not implemented
 )
 
+if sys.platform == "linux":
+    VCPKG_TRIPLET="x64-linux"
+else:
+    VCPKG_TRIPLET=None
+
 # This will be used for e.g. the sdist
 if CSP_USE_VCPKG:
     if not os.path.exists("vcpkg"):
@@ -30,12 +35,15 @@ if CSP_USE_VCPKG:
         subprocess.call(["git", "submodule", "update", "--init", "--recursive"])
     if not os.path.exists("vcpkg/buildtrees"):
         subprocess.call(["git", "pull"], cwd="vcpkg")
+        args = ["install"]
+        if VCPKG_TRIPLET is not None:
+            args.append( f"--triplet={VCPKG_TRIPLET}" );
         if os.name == "nt":
             subprocess.call(["bootstrap-vcpkg.bat"], cwd="vcpkg", shell=True)
-            subprocess.call(["vcpkg.bat", "install"], cwd="vcpkg", shell=True)
+            subprocess.call(["vcpkg.bat"] + args, cwd="vcpkg", shell=True)
         else:
             subprocess.call(["./bootstrap-vcpkg.sh"], cwd="vcpkg")
-            subprocess.call(["./vcpkg", "install"], cwd="vcpkg")
+            subprocess.call(["./vcpkg"] + args, cwd="vcpkg")
 
 
 python_version = f"{sys.version_info.major}.{sys.version_info.minor}"
@@ -54,6 +62,9 @@ if CSP_USE_VCPKG and os.path.exists(vcpkg_toolchain_file):
             "-DCSP_USE_VCPKG=ON",
         ]
     )
+
+    if VCPKG_TRIPLET is not None:
+        cmake_args.append( f"-DVCPKG_TARGET_TRIPLET={VCPKG_TRIPLET}" )
 else:
     cmake_args.append("-DCSP_USE_VCPKG=OFF")
 

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -1,27 +1,32 @@
 {
-    "name": "main",
-    "version-string": "latest",
-    "dependencies": [
-      "abseil",
-      "arrow",
-      "brotli",
-      "exprtk",
-      "gtest",
-        {
-            "name": "librdkafka",
-            "features": ["ssl"]
-        },
-      "lz4",
-      "openssl",
-      "parquet",
-      "protobuf",
-      "rapidjson",
-      "thrift",
-      "utf8proc",
-      "websocketpp"
-    ],
-    "overrides": [
-      { "name": "arrow", "version": "15.0.0"}
-    ],
-    "builtin-baseline": "288e8bebf4ca67c1f8ebd49366b03650cfd9eb7d"
-  }
+  "name": "main",
+  "version-string": "latest",
+  "dependencies": [
+    "abseil",
+    "arrow",
+    "brotli",
+    "exprtk",
+    "gtest",
+    {
+      "name": "librdkafka",
+      "features": [
+        "ssl"
+      ]
+    },
+    "lz4",
+    "openssl",
+    "parquet",
+    "protobuf",
+    "rapidjson",
+    "thrift",
+    "utf8proc",
+    "websocketpp"
+  ],
+  "overrides": [
+    {
+      "name": "arrow",
+      "version": "15.0.0"
+    }
+  ],
+  "builtin-baseline": "04b0cf2b3fd1752d3c3db969cbc10ba0a4613cee"
+}


### PR DESCRIPTION
Update vcpkg baseline so that we can grab the latest arrow cmake fix for the windows build.
Also allow specifying the target vcpkg triplet.  Set to x86-linux for linux explicitly ( for some reason its picking up x86-linux-dynamic, which fails to build boost libraries ).  Will use the same mechanism to set the windows triplet