### PR TITLE
Add build-debug option to Makefile so we dont forget the proper incan…

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,6 +24,9 @@ develop: requirements  ## install dependencies and build library
 build:  ## build the library
 	python setup.py build build_ext --inplace -- -- -j$(NPROC)
 
+build-debug:  ## build the library ( DEBUG ) - May need a make clean when switching from regular build to build-debug and vice versa
+	SKBUILD_CONFIGURE_OPTIONS="" DEBUG=1 python setup.py build build_ext --inplace -- -- -j$(NPROC)
+
 build-conda:  ## build the library in Conda
 	CSP_USE_VCPKG=0 python setup.py build build_ext --inplace -- -- -j$(NPROC)
 


### PR DESCRIPTION
…tations

We need to pass DEBUG=1 to pass -DCMAKE_BUILD_TYPE=Debug to our build.
skbuild/setuptools_wrap properly adds these settings after the cmake args pulled from our env ( conda sets CMAKE_ARGS with CMAKE_BUILD_TYPE=Release ):
https://github.com/scikit-build/scikit-build/blob/main/skbuild/setuptools_wrap.py#L555

However, ckmaker.py then re-adds CMAKE args from the env *After* these args unless SKBUILD_CONFIGRE_OPTIONS is set in the env:
https://github.com/scikit-build/scikit-build/blob/main/skbuild/cmaker.py#L321
