### PR TITLE
Make tag info a more prominent note

### DIFF
--- a/docs/wiki/dev-guides/Release-Process.md
+++ b/docs/wiki/dev-guides/Release-Process.md
@@ -75,6 +75,7 @@ Follow these steps when it's time to tag a new release. Before doing
 this, you will need to ensure `bump2version` is installed into your
 development environment.
 
+> \[!NOTE\]
 > The following steps assume you are pushing to the main `Point72/csp`
 > repo. If you are working from a personal fork, use the corresponding
 > remote (e.g. `upstream`) instead of `origin` in all git commands.


### PR DESCRIPTION
slight tweak on https://github.com/Point72/csp/pull/249 which I didn't notice, this makes it a more prominent note:

<img width="1268" alt="Screenshot 2024-06-04 at 18 18 54" src="https://github.com/Point72/csp/assets/3105306/7e6bc68c-9b5e-4722-86d0-84e82e3ee33d">

vs

<img width="1173" alt="Screenshot 2024-06-04 at 18 19 04" src="https://github.com/Point72/csp/assets/3105306/13207089-90b4-4ea9-9015-6f67e5a6e2f8">
