### PR TITLE
Add postprocess_to_dict hook for to_dict method in structs

### DIFF
--- a/cpp/csp/python/PyStructToDict.cpp
+++ b/cpp/csp/python/PyStructToDict.cpp
@@ -108,6 +108,14 @@ PyObjectPtr parseStructToDictRecursive( const StructPtr& self, PyObject * callab
             } );
         PyDict_SetItemString( new_dict.get(), key.c_str(), py_obj.get() );
     }
+
+    // Optional postprocess hook in python to allow caller to customize to_dict behavior for struct
+    PyObject * py_type = ( PyObject * ) meta -> pyType();
+    if( PyObject_HasAttrString( py_type, "postprocess_to_dict" ) )
+    {
+        auto postprocess_dict_callable = PyObjectPtr::own( PyObject_GetAttrString( py_type, "postprocess_to_dict" ) );
+        new_dict = PyObjectPtr::check( PyObject_CallFunction( postprocess_dict_callable.get(), "(O)", new_dict.get() ) );
+    }
     return new_dict;
 }
 

--- a/csp/impl/struct.py
+++ b/csp/impl/struct.py
@@ -165,6 +165,16 @@ class Struct(_csptypesimpl.PyStruct, metaclass=StructMeta):
         res = self._obj_to_python(self)
         return res
 
+    @classmethod
+    def postprocess_to_dict(self, obj):
+        """Postprocess hook for to_dict method
+
+        This method is invoked by to_dict after converting a struct to a dict
+        as an additional hook for users to modify the dict before it is returned
+        by the to_dict method
+        """
+        return obj
+
     def to_dict(self, callback=None):
         """Create a dictionary representation of the struct
 


### PR DESCRIPTION
This PR adds `postprocess_to_dict` hook to the `structs`.
This hook is invoked by the `to_dict` method on the `dict` obtained from parsing a `struct`. It will allows users to customize the final `dict` generated by the `to_dict` method for each struct.

```
class A(Struct):
    replace_me: str
    data: int = 0
    def postprocess_to_dict(self, obj_dict):
        obj_dict['replace_me'] = 'replace_me'
        obj_dict['postprocess_invoked'] = True
        return obj_dict

a = A(replace_me='Dummy', data=1)
a.to_dict() == {'replace_me': 'replace_me', 'data': 1, 'postprocess_invoked': True}
```