### PR TITLE
Optimize halflife-based EMA's in csp.stats

### DIFF
--- a/cpp/csp/cppnodes/statsimpl.h
+++ b/cpp/csp/cppnodes/statsimpl.h
@@ -1728,7 +1728,7 @@ class AlphaDebiasEMA
                     w0 = 1.0;
                 else
                     w0 = 1 - m_decay;
-                m_sqsum += pow( w0, 2 );
+                m_sqsum += w0 * w0;
                 m_wsum += w0;
             }
             else
@@ -1746,7 +1746,7 @@ class AlphaDebiasEMA
                 double wh = pow( m_decay, lookback );
                 if( !m_adjust )
                     wh *= ( 1- m_decay );
-                m_sqsum -= pow( wh, 2 );
+                m_sqsum -= wh * wh;
                 m_wsum -= wh;
                 if( m_wsum < EPSILON || m_sqsum < EPSILON )
                 {
@@ -1767,7 +1767,7 @@ class AlphaDebiasEMA
 
         double compute() const
         {
-            double wsum_sq = pow( m_wsum, 2 );
+            double wsum_sq = m_wsum * m_wsum;
             if( abs( wsum_sq - m_sqsum ) > EPSILON )
                 return wsum_sq / ( wsum_sq - m_sqsum );
             else
@@ -1794,7 +1794,7 @@ class HalflifeEMA
 
         HalflifeEMA( TimeDelta halflife, DateTime start )
         {
-            m_halflife = halflife;
+            m_decay_factor = log( 0.5 ) / halflife.asNanoseconds();
             m_last_tick = start;
             reset();
         }
@@ -1808,12 +1808,9 @@ class HalflifeEMA
             if( likely( !isnan( x ) ) )
             {
                 TimeDelta delta_t = now - m_last_tick;
-                double decay_duration = ( double )( delta_t.asNanoseconds() ) / ( m_halflife.asNanoseconds() );
-                double decay = exp( -( decay_duration ) * log( 2 ) );
-                m_ema *= decay;
-                m_norm *= decay;
-                m_ema += x;
-                m_norm++;
+                double decay = exp( m_decay_factor * delta_t.asNanoseconds() );
+                m_ema = decay * m_ema + x;
+                m_norm = decay * m_norm + 1.0;
                 m_last_tick = now;
             }
         }
@@ -1832,7 +1829,7 @@ class HalflifeEMA
 
         double m_ema;
         double m_norm;
-        TimeDelta m_halflife;
+        double m_decay_factor;
         DateTime m_last_tick;
 
 };
@@ -1844,7 +1841,7 @@ class HalflifeDebiasEMA
 
         HalflifeDebiasEMA( TimeDelta halflife, DateTime start )
         {
-            m_halflife = halflife;
+            m_decay_factor = log( 0.5 ) / halflife.asNanoseconds();
             m_last_tick = start;
             reset();
         }
@@ -1858,11 +1855,9 @@ class HalflifeDebiasEMA
             if( likely( !isnan( x ) ) )
             {
                 TimeDelta delta_t = now - m_last_tick;
-                double decay = exp( -( delta_t/m_halflife ) * log( 2 ) );
-                m_sqsum *= pow( decay, 2 );
-                m_wsum *= decay;
-                m_sqsum++;
-                m_wsum++;
+                double decay = exp( m_decay_factor * delta_t.asNanoseconds() );
+                m_sqsum = decay * decay * m_sqsum + 1.0;
+                m_wsum = decay * m_wsum + 1.0;
                 m_last_tick = now;
             }
         }
@@ -1874,7 +1869,7 @@ class HalflifeDebiasEMA
 
         double compute() const
         {
-            double wsum_sq = pow( m_wsum, 2 );
+            double wsum_sq = m_wsum * m_wsum;
             if( wsum_sq != m_sqsum )
                 return wsum_sq / ( wsum_sq - m_sqsum );
             else
@@ -1885,7 +1880,7 @@ class HalflifeDebiasEMA
 
         double m_wsum;
         double m_sqsum;
-        TimeDelta m_halflife;
+        double m_decay_factor;
         DateTime m_last_tick;
 };
 


### PR DESCRIPTION
the decay multiplier can be pre-computed saving a call to log() [note that log( 2.0 ) is currently resulting in a call to log as it is not constexpr until C++26] and division per update

also prefer x*x vs pow( x, 2 ) to avoid relying on compiler to optimize this