### PR TITLE
websocket - raise a clear error is hostname isnt extracted from URI (…

### DIFF
--- a/csp/adapters/websocket.py
+++ b/csp/adapters/websocket.py
@@ -405,6 +405,9 @@ class WebsocketAdapterManager:
         """
         assert reconnect_interval >= timedelta(seconds=1)
         resp = urllib.parse.urlparse(uri)
+        if resp.hostname is None:
+            raise ValueError(f"Failed to parse host from URI: {uri}")
+
         self._properties = dict(
             host=resp.hostname,
             # if no port is explicitly present in the uri, the resp.port is None

--- a/examples/03_using_adapters/websocket/e1_websocket_client.py
+++ b/examples/03_using_adapters/websocket/e1_websocket_client.py
@@ -24,6 +24,10 @@ def g(uri: str):
 
 
 if __name__ == "__main__":
+    if len(sys.argv) != 2:
+        print("Usage: e1_websocket_client <uri>")
+        sys.exit(1)
+
     csp.run(
         g,
         starttime=datetime.utcnow(),


### PR DESCRIPTION
… crashes otherwise ).  Add Usage to example.
