### PR TITLE
limit cmake < 3.30 to fix builds

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [build-system]
 requires = [
-    "cmake",
+    "cmake<3.30",
     "oldest-supported-numpy",
     "pyarrow>=7.0.0",
     "ruamel.yaml",


### PR DESCRIPTION
The new cmake 3.30 release is breaking the vcpkg builds