### PR TITLE
Deprecate legacy type hints such as [int] and replace with python-standard type hints such as List[int]

### DIFF
--- a/csp/adapters/slack.py
+++ b/csp/adapters/slack.py
@@ -361,7 +361,7 @@ class SlackOutputAdapterImpl(OutputAdapter):
 _slack_input_adapter = py_push_adapter_def(
     name="SlackInputAdapter",
     adapterimpl=SlackInputAdapterImpl,
-    out_type=ts[[SlackMessage]],
+    out_type=ts[List[SlackMessage]],
     manager_type=SlackAdapterManager,
 )
 _slack_output_adapter = py_output_adapter_def(

--- a/csp/baselib.py
+++ b/csp/baselib.py
@@ -6,8 +6,8 @@ import numpy as np
 import pytz
 import queue
 import threading
-import typing
 from datetime import datetime, timedelta
+from typing import Callable, Dict, List, Optional, TypeVar, Union
 
 import csp
 from csp.impl.__cspimpl import _cspimpl
@@ -63,11 +63,11 @@ __all__ = [
     "wrap_feedback",
 ]
 
-T = typing.TypeVar("T")
-K = typing.TypeVar("K")
-V = typing.TypeVar("V")
-Y = typing.TypeVar("Y")
-U = typing.TypeVar("U")
+T = TypeVar("T")
+K = TypeVar("K")
+V = TypeVar("V")
+Y = TypeVar("Y")
+U = TypeVar("U")
 
 const = input_adapter_def("csp.const", _cspimpl._const, ts["T"], value="~T", delay=(timedelta, timedelta()))
 _timer = input_adapter_def(
@@ -156,13 +156,13 @@ class LogSettings:
 
 
 @node
-def _list_basket_to_string_ts(x: [ts["T"]]) -> ts[str]:
+def _list_basket_to_string_ts(x: List[ts["T"]]) -> ts[str]:
     value = ",".join([str(x[i]) if csp.ticked(x[i]) else "" for i in range(len(x))])
     return f"[{value}]"
 
 
 @node
-def _dict_basket_to_string_ts(x: {"K": ts[object]}) -> ts[str]:
+def _dict_basket_to_string_ts(x: Dict["K", ts[object]]) -> ts[str]:
     return str({k: x[k] for k in x.tickedkeys()})
 
 
@@ -204,7 +204,7 @@ def log(
     level: int,
     tag: str,
     x,
-    logger: typing.Optional[logging.Logger] = None,
+    logger: Optional[logging.Logger] = None,
     logger_tz: object = None,
     use_thread: bool = False,
 ):
@@ -243,7 +243,7 @@ def _log_ts(
     level: int,
     tag: str,
     x: ts["T"],
-    logger: typing.Optional[logging.Logger] = None,
+    logger: Optional[logging.Logger] = None,
     logger_tz: object = None,
     use_thread: bool = False,
 ):
@@ -274,8 +274,8 @@ def _log_ts(
 
 
 @graph
-def get_basket_field(dict_basket: {"K": ts["V"]}, field_name: str) -> OutputBasket(
-    {"K": ts[object]}, shape_of="dict_basket"
+def get_basket_field(dict_basket: Dict["K", ts["V"]], field_name: str) -> OutputBasket(
+    Dict["K", ts[object]], shape_of="dict_basket"
 ):
     """Given a dict basket of Struct objects, get a dict basket of the given field of struct for the matching key
 
@@ -343,7 +343,7 @@ def _delay_by_ticks(x: ts["T"], delay: int) -> ts["T"]:
 
 
 @graph
-def delay(x: ts["T"], delay: typing.Union[timedelta, int]) -> ts["T"]:
+def delay(x: ts["T"], delay: Union[timedelta, int]) -> ts["T"]:
     """delay input ticks by given delay"""
     if isinstance(delay, int):
         return _delay_by_ticks(x, delay)
@@ -352,7 +352,7 @@ def delay(x: ts["T"], delay: typing.Union[timedelta, int]) -> ts["T"]:
 
 
 @graph
-def _lag(x: ts["T"], lag: typing.Union[timedelta, int]) -> ts["T"]:
+def _lag(x: ts["T"], lag: Union[timedelta, int]) -> ts["T"]:
     """ticks when input ticks, but with lagged value of input"""
     if isinstance(lag, int):
         return _delay_by_ticks(x, lag)
@@ -361,7 +361,7 @@ def _lag(x: ts["T"], lag: typing.Union[timedelta, int]) -> ts["T"]:
 
 
 @graph
-def diff(x: ts["T"], lag: typing.Union[timedelta, int]) -> ts["T"]:
+def diff(x: ts["T"], lag: Union[timedelta, int]) -> ts["T"]:
     """diff x against itself lag time/ticks ago"""
     return x - _lag(x, lag)
 
@@ -396,7 +396,7 @@ def cast_int_to_float(x: ts[int]) -> ts[float]:
 
 
 @node()
-def apply(x: ts["T"], f: typing.Callable[["T"], "U"], result_type: "U") -> ts["U"]:
+def apply(x: ts["T"], f: Callable[List["T"], "U"], result_type: "U") -> ts["U"]:
     """
     :param x: The time series on which the function should be applied
     :param f: A scalar function that will be applied on each value of x
@@ -461,7 +461,7 @@ def drop_nans(x: ts[float]) -> ts[float]:
 
 
 @node(cppimpl=_cspbaselibimpl.unroll)
-def unroll(x: ts[["T"]]) -> ts["T"]:
+def unroll(x: ts[List["T"]]) -> ts["T"]:
     """ "unrolls" timeseries of lists of type 'T' into individual ticks of type 'T'"""
     with csp.alarms():
         alarm = csp.alarm("T")
@@ -484,14 +484,14 @@ def unroll(x: ts[["T"]]) -> ts["T"]:
 
 
 @node(cppimpl=_cspbaselibimpl.collect)
-def collect(x: [ts["T"]]) -> ts[["T"]]:
+def collect(x: List[ts["T"]]) -> ts[List["T"]]:
     """convert basket of timeseries into timeseries of list of ticked values"""
     if csp.ticked(x):
         return list(x.tickedvalues())
 
 
 @graph
-def flatten(x: [ts["T"]]) -> ts["T"]:
+def flatten(x: List[ts["T"]]) -> ts["T"]:
     """flatten a basket of inputs into ts[ 'T' ]"""
     # Minor optimization, if we have a list with just
     # a single ts, then just emit it as-is. Otherwise,
@@ -504,7 +504,7 @@ def flatten(x: [ts["T"]]) -> ts["T"]:
 
 # TODO cppimpl
 @node
-def gate(x: ts["T"], release: ts[bool], release_on_tick: bool = False) -> ts[["T"]]:
+def gate(x: ts["T"], release: ts[bool], release_on_tick: bool = False) -> ts[List["T"]]:
     """ "gate" the input.
     if release is false, input will be held until release is true.
     when release ticks true, all gated inputs will tick in one shot
@@ -551,7 +551,9 @@ def null_ts(typ: "T") -> ts["T"]:
 
 
 @node(cppimpl=_cspbaselibimpl.multiplex)
-def multiplex(x: {"K": ts["T"]}, key: ts["K"], tick_on_index: bool = False, raise_on_bad_key: bool = False) -> ts["T"]:
+def multiplex(
+    x: Dict["K", ts["T"]], key: ts["K"], tick_on_index: bool = False, raise_on_bad_key: bool = False
+) -> ts["T"]:
     """
     :param x: The basket of time series to multiplex
     :param key: A
@@ -578,8 +580,8 @@ def multiplex(x: {"K": ts["T"]}, key: ts["K"], tick_on_index: bool = False, rais
 
 
 @node(cppimpl=_cspbaselibimpl.demultiplex)
-def demultiplex(x: ts["T"], key: ts["K"], keys: ["K"], raise_on_bad_key: bool = False) -> OutputBasket(
-    {"K": ts["T"]}, shape="keys"
+def demultiplex(x: ts["T"], key: ts["K"], keys: List["K"], raise_on_bad_key: bool = False) -> OutputBasket(
+    Dict["K", ts["T"]], shape="keys"
 ):
     """whenever the timeseries input ticks, output a tick on the appropriate basket output"""
     with csp.state():
@@ -595,7 +597,7 @@ def demultiplex(x: ts["T"], key: ts["K"], keys: ["K"], raise_on_bad_key: bool = 
 # TODO - looks like output annotations arent working for dynamic baskets, needs to be fixed
 # @node(cppimpl=_cspbaselibimpl.dynamic_demultiplex)
 @node
-def dynamic_demultiplex(x: ts["T"], key: ts["K"]) -> {ts["K"]: ts["T"]}:
+def dynamic_demultiplex(x: ts["T"], key: ts["K"]) -> Dict[ts["K"], ts["T"]]:
     """whenever the timeseries input ticks, output a tick on the appropriate dynamic basket output"""
     if csp.ticked(x) and csp.valid(key):
         csp.output({key: x})
@@ -603,7 +605,7 @@ def dynamic_demultiplex(x: ts["T"], key: ts["K"]) -> {ts["K"]: ts["T"]}:
 
 # @node(cppimpl=_cspbaselibimpl.dynamic_collect)
 @node
-def dynamic_collect(data: {ts["K"]: ts["V"]}) -> ts[{"K": "V"}]:
+def dynamic_collect(data: Dict[ts["K"], ts["V"]]) -> ts[Dict["K", "V"]]:
     """whenever any input of the dynamic basket ticks, output the key-value pairs in a dictionary"""
     if csp.ticked(data):
         return dict(data.tickeditems())
@@ -622,7 +624,7 @@ def accum(x: ts["T"], start: "~T" = 0) -> ts["T"]:
 @node(cppimpl=_cspbaselibimpl.exprtk_impl)
 def _csp_exprtk_impl(
     expression_str: str,
-    inputs: {str: ts[object]},
+    inputs: Dict[str, ts[object]],
     state_vars: dict,
     constants: dict,
     functions: dict,
@@ -637,13 +639,13 @@ def _csp_exprtk_impl(
 @graph
 def exprtk(
     expression_str: str,
-    inputs: {str: ts[object]},
+    inputs: Dict[str, ts[object]],
     state_vars: dict = {},
     trigger: ts[object] = None,
     functions: dict = {},
     constants: dict = {},
     output_ndarray: bool = False,
-) -> ts[typing.Union[float, np.ndarray]]:
+) -> ts[Union[float, np.ndarray]]:
     """given a mathematical expression,
         and a set of timeseries corresponding to variables in that expression, tick out the result (a float) of that expression,
         either every time an input ticks, or on the trigger if provided.
@@ -679,7 +681,7 @@ def struct_field(x: ts["T"], field: str, fieldType: "Y") -> ts["Y"]:
 
 
 @node(cppimpl=_cspbaselibimpl.struct_fromts)
-def _struct_fromts(cls: "T", inputs: {str: ts[object]}, trigger: ts[object], use_trigger: bool) -> ts["T"]:
+def _struct_fromts(cls: "T", inputs: Dict[str, ts[object]], trigger: ts[object], use_trigger: bool) -> ts["T"]:
     """construct a ticking Struct from the given timeseries.
     Note structs will be created from all valid items"""
     with csp.start():
@@ -690,7 +692,7 @@ def _struct_fromts(cls: "T", inputs: {str: ts[object]}, trigger: ts[object], use
 
 
 @graph
-def struct_fromts(cls: "T", inputs: {str: ts[object]}, trigger: ts[object] = None) -> ts["T"]:
+def struct_fromts(cls: "T", inputs: Dict[str, ts[object]], trigger: ts[object] = None) -> ts["T"]:
     """construct a ticking Struct from the given timeseries basket.
     Note structs will be created from all valid items.
      trigger - Optional timeseries to control when struct gets created ( defaults to any time a basket input ticks )"""
@@ -699,7 +701,7 @@ def struct_fromts(cls: "T", inputs: {str: ts[object]}, trigger: ts[object] = Non
 
 
 @node(cppimpl=_cspbaselibimpl.struct_collectts)
-def struct_collectts(cls: "T", inputs: {str: ts[object]}) -> ts["T"]:
+def struct_collectts(cls: "T", inputs: Dict[str, ts[object]]) -> ts["T"]:
     """construct a ticking Struct from the given timeseries.
     Note structs will be created from all ticked items"""
     if csp.ticked(inputs):
@@ -820,7 +822,7 @@ class DelayedCollect(DelayedNodeWrapperDef):
         """
         super().__init__()
         self._inputs = []
-        self._output = DelayedEdge(ts[[ts_type]], default_to_null)
+        self._output = DelayedEdge(ts[List[ts_type]], default_to_null)
 
     def copy(self):
         res = DelayedCollect()
@@ -838,7 +840,7 @@ class DelayedCollect(DelayedNodeWrapperDef):
         self._inputs.append(x)
 
     def output(self):
-        """returns collected inputs as ts[ typing.List[ input_ts_type] ]"""
+        """returns collected inputs as ts[ List[ input_ts_type] ]"""
         return self._output
 
     def _instantiate(self):

--- a/csp/basketlib.py
+++ b/csp/basketlib.py
@@ -12,7 +12,7 @@ Y = TypeVar("Y")
 
 
 @csp.node(cppimpl=_cspbasketlibimpl._sync_list)
-def sync_list(x: [ts["T"]], threshold: timedelta, output_incomplete: bool = True) -> csp.OutputBasket(
+def sync_list(x: List[ts["T"]], threshold: timedelta, output_incomplete: bool = True) -> csp.OutputBasket(
     List[ts["T"]], shape_of="x"
 ):
     with csp.alarms():
@@ -37,7 +37,7 @@ def sync_list(x: [ts["T"]], threshold: timedelta, output_incomplete: bool = True
 
 
 @csp.graph
-def sync_dict(x: {"K": ts["T"]}, threshold: timedelta, output_incomplete: bool = True) -> csp.OutputBasket(
+def sync_dict(x: Dict["K", ts["T"]], threshold: timedelta, output_incomplete: bool = True) -> csp.OutputBasket(
     Dict["K", ts["T"]], shape_of="x"
 ):
     values = list(x.values())
@@ -54,7 +54,7 @@ def sync(x, threshold: timedelta, output_incomplete: bool = True):
 
 
 @csp.node(cppimpl=_cspbasketlibimpl._sample_list)
-def sample_list(trigger: ts["Y"], x: [ts["T"]]) -> csp.OutputBasket(List[ts["T"]], shape_of="x"):
+def sample_list(trigger: ts["Y"], x: List[ts["T"]]) -> csp.OutputBasket(List[ts["T"]], shape_of="x"):
     """will return valid items in x on trigger"""
     with csp.start():
         csp.make_passive(x)
@@ -66,7 +66,7 @@ def sample_list(trigger: ts["Y"], x: [ts["T"]]) -> csp.OutputBasket(List[ts["T"]
 
 
 @csp.graph()
-def sample_dict(trigger: ts["Y"], x: {"K": ts["T"]}) -> csp.OutputBasket(Dict["K", ts["T"]], shape_of="x"):
+def sample_dict(trigger: ts["Y"], x: Dict["K", ts["T"]]) -> csp.OutputBasket(Dict["K", ts["T"]], shape_of="x"):
     """will return valid items in x on trigger"""
     values = list(x.values())
     sampled_values = sample_list(trigger, values)

--- a/csp/curve.py
+++ b/csp/curve.py
@@ -1,8 +1,8 @@
 import copy
 import numpy as np
 import pytz
-import typing
 from datetime import timedelta
+from typing import Union
 
 from csp import null_ts
 from csp.impl.__cspimpl import _cspimpl
@@ -48,7 +48,7 @@ _npcurve = input_adapter_def(
 )
 
 
-def curve(typ: type, data: typing.Union[list, tuple], push_mode: PushMode = PushMode.NON_COLLAPSING):
+def curve(typ: type, data: Union[list, tuple], push_mode: PushMode = PushMode.NON_COLLAPSING):
     if isinstance(data, tuple):
         if len(data) != 2 or not all(isinstance(x, np.ndarray) for x in data):
             raise ValueError("for numpy curves, must pass tuple of two ndarrays as data")

--- a/csp/impl/pandas_accessor.py
+++ b/csp/impl/pandas_accessor.py
@@ -15,14 +15,14 @@ T = TypeVar("T")
 
 
 @csp.node
-def _basket_valid(xs: [ts[object]]) -> ts[bool]:
+def _basket_valid(xs: List[ts[object]]) -> ts[bool]:
     if csp.valid(xs):
         csp.make_passive(xs)
         return True
 
 
 @csp.node
-def _basket_synchronize(xs: [ts["T"]], threshold: timedelta) -> csp.OutputBasket(List[ts["T"]], shape_of="xs"):
+def _basket_synchronize(xs: List[ts["T"]], threshold: timedelta) -> csp.OutputBasket(List[ts["T"]], shape_of="xs"):
     with csp.alarms():
         a_end = csp.alarm(bool)
 
@@ -662,7 +662,7 @@ class ToCspFrameAccessor(object):
 
 
 @csp.node
-def _collect_numpy(x: [ts[object]], dim: int) -> ts[object]:
+def _collect_numpy(x: List[ts[object]], dim: int) -> ts[object]:
     with csp.state():
         s_array = np.array([np.nan for _ in range(dim)], dtype=object)
 

--- a/csp/impl/pandas_ext_type.py
+++ b/csp/impl/pandas_ext_type.py
@@ -556,7 +556,7 @@ def _unary_op(x: ts["T"], op: object) -> ts["T"]:
 
 
 @node
-def _reduce(x: [ts["T"]], typ: "T", func: object, args: object = (), kwargs: object = {}) -> ts["T"]:
+def _reduce(x: List[ts["T"]], typ: "T", func: object, args: object = (), kwargs: object = {}) -> ts["T"]:
     # The choice was made to only emit values if all basket elements are valid.
     # If one wanted to reduce only over valid elements, then in many cases you could pre-apply csp.default
     # with a nan/sentinal value, and then apply a function which ignores these values
@@ -578,14 +578,14 @@ def _reduce(x: [ts["T"]], typ: "T", func: object, args: object = (), kwargs: obj
 
 
 @node
-def _reduce_float(x: [ts["T"]], typ: "T", func: object, args: object = (), kwargs: object = {}) -> ts[float]:
+def _reduce_float(x: List[ts["T"]], typ: "T", func: object, args: object = (), kwargs: object = {}) -> ts[float]:
     if csp.valid(x):
         data = np.fromiter(x.validvalues(), dtype=typ)
         return func(data, *args, **kwargs)
 
 
 @node
-def _reduce_bool(x: [ts["T"]], typ: "T", func: object, args: object = (), kwargs: object = {}) -> ts[bool]:
+def _reduce_bool(x: List[ts["T"]], typ: "T", func: object, args: object = (), kwargs: object = {}) -> ts[bool]:
     if csp.valid(x):
         data = np.fromiter(x.validvalues(), dtype=typ)
         return bool(func(data, *args, **kwargs))

--- a/csp/impl/types/container_type_normalizer.py
+++ b/csp/impl/types/container_type_normalizer.py
@@ -1,5 +1,6 @@
 import numpy
 import typing
+from warnings import warn
 
 import csp.typing
 from csp.impl.types.typing_utils import CspTypingUtils, FastList
@@ -27,6 +28,11 @@ class ContainerTypeNormalizer:
             return typ
             # cls._deep_convert_generic_meta_to_typing_generic_meta(typ, is_within_container)
         elif isinstance(typ, dict):
+            warn(
+                "Using {K: V} syntax for type declaration is deprecated. Use Dict[K, V] instead.",
+                DeprecationWarning,
+                stacklevel=4,
+            )
             if type(typ) is not dict or len(typ) != 1:  # noqa: E721
                 raise TypeError(f"Invalid type decorator: '{typ}'")
             t1, t2 = typ.items().__iter__().__next__()
@@ -35,11 +41,21 @@ class ContainerTypeNormalizer:
                 cls._convert_containers_to_typing_generic_meta(t2, True),
             ]
         elif isinstance(typ, set):
+            warn(
+                "Using {T} syntax for type declaration is deprecated. Use Set[T] instead.",
+                DeprecationWarning,
+                stacklevel=4,
+            )
             if type(typ) is not set or len(typ) != 1:  # noqa: E721
                 raise TypeError(f"Invalid type decorator: '{typ}'")
             t = typ.__iter__().__next__()
             return typing.Set[cls._convert_containers_to_typing_generic_meta(t, True)]
         elif isinstance(typ, list):
+            warn(
+                "Using [T] syntax for type declaration is deprecated. Use List[T] instead.",
+                DeprecationWarning,
+                stacklevel=4,
+            )
             if type(typ) is not list or len(typ) != 1:  # noqa: E721
                 raise TypeError(f"Invalid type decorator: '{typ}'")
             t = typ.__iter__().__next__()

--- a/csp/impl/wiring/adapters.py
+++ b/csp/impl/wiring/adapters.py
@@ -1,4 +1,5 @@
 from datetime import timedelta
+from typing import List
 
 from csp.impl.__cspimpl import _cspimpl
 from csp.impl.mem_cache import csp_memoized_graph_object
@@ -30,7 +31,7 @@ class AdapterDefMeta(type):
             # Note that we augment the returned Edge to be list of expected type, but not the output def
             # output def remains the original type
             if kwargs.get("push_mode", None) == PushMode.BURST:
-                output.tstype = tstype.ts[[output.tstype.typ]]
+                output.tstype = tstype.ts[List[output.tstype.typ]]
 
         return output
 

--- a/csp/math.py
+++ b/csp/math.py
@@ -1,7 +1,7 @@
 import math
 import numpy as np
-import typing
 from functools import lru_cache
+from typing import List, TypeVar, get_origin
 
 import csp
 from csp.impl.types.tstype import ts
@@ -53,8 +53,8 @@ __all__ = [
     "tanh",
 ]
 
-T = typing.TypeVar("T")
-U = typing.TypeVar("U")
+T = TypeVar("T")
+U = TypeVar("U")
 
 
 @node(cppimpl=_cspmathimpl.bitwise_not)
@@ -70,7 +70,7 @@ def not_(x: ts[bool]) -> ts[bool]:
 
 
 @node
-def andnode(x: [ts[bool]]) -> ts[bool]:
+def andnode(x: List[ts[bool]]) -> ts[bool]:
     if csp.valid(x):
         return all(x.validvalues())
 
@@ -82,7 +82,7 @@ def and_(*inputs):
 
 
 @node
-def ornode(x: [ts[bool]]) -> ts[bool]:
+def ornode(x: List[ts[bool]]) -> ts[bool]:
     if csp.valid(x):
         return any(x.validvalues())
 
@@ -270,7 +270,7 @@ def define_binary_op(name, op_lambda):
             return op_lambda(x, y)
 
     def comp(x: ts["T"], y: ts["U"]):
-        if typing.get_origin(x.tstype.typ) in [Numpy1DArray, NumpyNDArray] or typing.get_origin(y.tstype.typ) in [
+        if get_origin(x.tstype.typ) in [Numpy1DArray, NumpyNDArray] or get_origin(y.tstype.typ) in [
             Numpy1DArray,
             NumpyNDArray,
         ]:
@@ -326,7 +326,7 @@ def define_unary_op(name, op_lambda):
             return op_lambda(x)
 
     def comp(x: ts["T"]):
-        if typing.get_origin(x.tstype.typ) in [Numpy1DArray, NumpyNDArray]:
+        if get_origin(x.tstype.typ) in [Numpy1DArray, NumpyNDArray]:
             return numpy_type(x)
         elif x.tstype.typ is float:
             return float_type(x)

--- a/csp/stats.py
+++ b/csp/stats.py
@@ -1,7 +1,7 @@
 import numpy as np
 import typing
 from datetime import datetime, timedelta
-from typing import List, TypeVar
+from typing import List, TypeVar, Union
 
 import csp
 from csp import ts
@@ -58,7 +58,7 @@ Base data processing nodes for statistical functions
 @csp.node(cppimpl=_cspstatsimpl._tick_window_updates)
 def _tick_window_updates(
     x: ts[float], interval: int, trigger: ts[object], sampler: ts[object], reset: ts[object], recalc: ts[object]
-) -> csp.Outputs(additions=ts[[float]], removals=ts[[float]]):
+) -> csp.Outputs(additions=ts[List[float]], removals=ts[List[float]]):
     raise NotImplementedError("_tick_window_updates only implemented in C++")
     return csp.output(additions=0, removals=0)
 
@@ -66,7 +66,7 @@ def _tick_window_updates(
 @csp.node(cppimpl=_cspstatsimpl._time_window_updates)
 def _time_window_updates(
     x: ts[float], interval: timedelta, trigger: ts[object], sampler: ts[object], reset: ts[object], recalc: ts[object]
-) -> csp.Outputs(additions=ts[[float]], removals=ts[[float]]):
+) -> csp.Outputs(additions=ts[List[float]], removals=ts[List[float]]):
     raise NotImplementedError("_time_window_updates only implemented in C++")
     return csp.output(additions=0, removals=0)
 
@@ -74,7 +74,7 @@ def _time_window_updates(
 @csp.node(cppimpl=_cspnpstatsimpl._np_tick_window_updates)
 def _np_tick_window_updates(
     x: ts[np.ndarray], interval: int, trigger: ts[object], sampler: ts[object], reset: ts[object], recalc: ts[object]
-) -> csp.Outputs(additions=ts[[np.ndarray]], removals=ts[[np.ndarray]]):
+) -> csp.Outputs(additions=ts[List[np.ndarray]], removals=ts[List[np.ndarray]]):
     raise NotImplementedError("_np_tick_window_updates only implemented in C++")
     return csp.output(additions=0, removals=0)
 
@@ -87,7 +87,7 @@ def _np_time_window_updates(
     sampler: ts[object],
     reset: ts[object],
     recalc: ts[object],
-) -> csp.Outputs(additions=ts[[np.ndarray]], removals=ts[[np.ndarray]]):
+) -> csp.Outputs(additions=ts[List[np.ndarray]], removals=ts[List[np.ndarray]]):
     raise NotImplementedError("_np_time_window_updates only implemented in C++")
     return csp.output(additions=0, removals=0)
 
@@ -100,7 +100,7 @@ def _window_updates(
     sampler: ts[object],
     reset: ts[object],
     recalc: ts[object],
-) -> csp.Outputs(additions=ts[[typing.Union[float, np.ndarray]]], removals=ts[[typing.Union[float, np.ndarray]]]):
+) -> csp.Outputs(additions=ts[List[Union[float, np.ndarray]]], removals=ts[List[Union[float, np.ndarray]]]):
     """
     :param x: the time-series data
     :param interval: a tick or timedelta interval to calculate over
@@ -353,8 +353,8 @@ Utility nodes for the statistical API
 
 @csp.node(cppimpl=_cspstatsimpl._count)
 def _count(
-    additions: ts[[float]],
-    removals: ts[[float]],
+    additions: ts[List[float]],
+    removals: ts[List[float]],
     trigger: ts[object],
     reset: ts[object],
     min_data_points: int,
@@ -366,8 +366,8 @@ def _count(
 
 @csp.node(cppimpl=_cspnpstatsimpl._np_count)
 def _np_count(
-    additions: ts[[np.ndarray]],
-    removals: ts[[np.ndarray]],
+    additions: ts[List[np.ndarray]],
+    removals: ts[List[np.ndarray]],
     trigger: ts[object],
     reset: ts[object],
     min_data_points: int,
@@ -379,8 +379,8 @@ def _np_count(
 
 @csp.node(cppimpl=_cspstatsimpl._sum)
 def _sum(
-    additions: ts[[float]],
-    removals: ts[[float]],
+    additions: ts[List[float]],
+    removals: ts[List[float]],
     trigger: ts[object],
     reset: ts[object],
     min_data_points: int,
@@ -392,8 +392,8 @@ def _sum(
 
 @csp.node(cppimpl=_cspstatsimpl._kahan_sum)
 def _kahan_sum(
-    additions: ts[[float]],
-    removals: ts[[float]],
+    additions: ts[List[float]],
+    removals: ts[List[float]],
     trigger: ts[object],
     reset: ts[object],
     min_data_points: int,
@@ -405,8 +405,8 @@ def _kahan_sum(
 
 @csp.node(cppimpl=_cspnpstatsimpl._np_sum)
 def _np_sum(
-    additions: ts[[np.ndarray]],
-    removals: ts[[np.ndarray]],
+    additions: ts[List[np.ndarray]],
+    removals: ts[List[np.ndarray]],
     trigger: ts[object],
     reset: ts[object],
     min_data_points: int,
@@ -418,8 +418,8 @@ def _np_sum(
 
 @csp.node(cppimpl=_cspnpstatsimpl._np_kahan_sum)
 def _np_kahan_sum(
-    additions: ts[[np.ndarray]],
-    removals: ts[[np.ndarray]],
+    additions: ts[List[np.ndarray]],
+    removals: ts[List[np.ndarray]],
     trigger: ts[object],
     reset: ts[object],
     min_data_points: int,
@@ -431,8 +431,8 @@ def _np_kahan_sum(
 
 @csp.node(cppimpl=_cspstatsimpl._mean)
 def _mean(
-    additions: ts[[float]],
-    removals: ts[[float]],
+    additions: ts[List[float]],
+    removals: ts[List[float]],
     trigger: ts[object],
     reset: ts[object],
     min_data_points: int,
@@ -444,10 +444,10 @@ def _mean(
 
 @csp.node(cppimpl=_cspstatsimpl._weighted_mean)
 def _weighted_mean(
-    x_add: ts[[float]],
-    x_rem: ts[[float]],
-    y_add: ts[[float]],
-    y_rem: ts[[float]],
+    x_add: ts[List[float]],
+    x_rem: ts[List[float]],
+    y_add: ts[List[float]],
+    y_rem: ts[List[float]],
     trigger: ts[object],
     reset: ts[object],
     min_data_points: int,
@@ -459,8 +459,8 @@ def _weighted_mean(
 
 @csp.node(cppimpl=_cspnpstatsimpl._np_mean)
 def _np_mean(
-    additions: ts[[np.ndarray]],
-    removals: ts[[np.ndarray]],
+    additions: ts[List[np.ndarray]],
+    removals: ts[List[np.ndarray]],
     trigger: ts[object],
     reset: ts[object],
     min_data_points: int,
@@ -472,8 +472,8 @@ def _np_mean(
 
 @csp.node(cppimpl=_cspstatsimpl._var)
 def _var(
-    additions: ts[[float]],
-    removals: ts[[float]],
+    additions: ts[List[float]],
+    removals: ts[List[float]],
     trigger: ts[object],
     reset: ts[object],
     arg: int,
@@ -486,8 +486,8 @@ def _var(
 
 @csp.node(cppimpl=_cspstatsimpl._sem)
 def _sem(
-    additions: ts[[float]],
-    removals: ts[[float]],
+    additions: ts[List[float]],
+    removals: ts[List[float]],
     trigger: ts[object],
     reset: ts[object],
     arg: int,
@@ -500,10 +500,10 @@ def _sem(
 
 @csp.node(cppimpl=_cspstatsimpl._weighted_var)
 def _weighted_var(
-    x_add: ts[[float]],
-    x_rem: ts[[float]],
-    y_add: ts[[float]],
-    y_rem: ts[[float]],
+    x_add: ts[List[float]],
+    x_rem: ts[List[float]],
+    y_add: ts[List[float]],
+    y_rem: ts[List[float]],
     arg: int,
     trigger: ts[object],
     reset: ts[object],
@@ -516,10 +516,10 @@ def _weighted_var(
 
 @csp.node(cppimpl=_cspstatsimpl._weighted_sem)
 def _weighted_sem(
-    x_add: ts[[float]],
-    x_rem: ts[[float]],
-    y_add: ts[[float]],
-    y_rem: ts[[float]],
+    x_add: ts[List[float]],
+    x_rem: ts[List[float]],
+    y_add: ts[List[float]],
+    y_rem: ts[List[float]],
     arg: int,
     trigger: ts[object],
     reset: ts[object],
@@ -532,10 +532,10 @@ def _weighted_sem(
 
 @csp.node(cppimpl=_cspnpstatsimpl._np_weighted_mean)
 def _np_weighted_mean(
-    x_add: ts[[np.ndarray]],
-    x_rem: ts[[np.ndarray]],
-    w_add: ts[[np.ndarray]],
-    w_rem: ts[[np.ndarray]],
+    x_add: ts[List[np.ndarray]],
+    x_rem: ts[List[np.ndarray]],
+    w_add: ts[List[np.ndarray]],
+    w_rem: ts[List[np.ndarray]],
     trigger: ts[object],
     reset: ts[object],
     min_data_points: int,
@@ -547,10 +547,10 @@ def _np_weighted_mean(
 
 @csp.node(cppimpl=_cspstatsimpl._covar)
 def _covar(
-    x_add: ts[[float]],
-    x_rem: ts[[float]],
-    y_add: ts[[float]],
-    y_rem: ts[[float]],
+    x_add: ts[List[float]],
+    x_rem: ts[List[float]],
+    y_add: ts[List[float]],
+    y_rem: ts[List[float]],
     trigger: ts[object],
     reset: ts[object],
     arg: int,
@@ -563,10 +563,10 @@ def _covar(
 
 @csp.node(cppimpl=_cspstatsimpl._corr)
 def _corr(
-    x_add: ts[[float]],
-    x_rem: ts[[float]],
-    y_add: ts[[float]],
-    y_rem: ts[[float]],
+    x_add: ts[List[float]],
+    x_rem: ts[List[float]],
+    y_add: ts[List[float]],
+    y_rem: ts[List[float]],
     trigger: ts[object],
     reset: ts[object],
     min_data_points: int,
@@ -578,12 +578,12 @@ def _corr(
 
 @csp.node(cppimpl=_cspstatsimpl._weighted_covar)
 def _weighted_covar(
-    x_add: ts[[float]],
-    x_rem: ts[[float]],
-    y_add: ts[[float]],
-    y_rem: ts[[float]],
-    w_add: ts[[float]],
-    w_rem: ts[[float]],
+    x_add: ts[List[float]],
+    x_rem: ts[List[float]],
+    y_add: ts[List[float]],
+    y_rem: ts[List[float]],
+    w_add: ts[List[float]],
+    w_rem: ts[List[float]],
     trigger: ts[object],
     reset: ts[object],
     arg: int,
@@ -596,12 +596,12 @@ def _weighted_covar(
 
 @csp.node(cppimpl=_cspstatsimpl._weighted_corr)
 def _weighted_corr(
-    x_add: ts[[float]],
-    x_rem: ts[[float]],
-    y_add: ts[[float]],
-    y_rem: ts[[float]],
-    w_add: ts[[float]],
-    w_rem: ts[[float]],
+    x_add: ts[List[float]],
+    x_rem: ts[List[float]],
+    y_add: ts[List[float]],
+    y_rem: ts[List[float]],
+    w_add: ts[List[float]],
+    w_rem: ts[List[float]],
     trigger: ts[object],
     reset: ts[object],
     arg: int,
@@ -614,8 +614,8 @@ def _weighted_corr(
 
 @csp.node(cppimpl=_cspnpstatsimpl._np_var)
 def _np_var(
-    additions: ts[[np.ndarray]],
-    removals: ts[[np.ndarray]],
+    additions: ts[List[np.ndarray]],
+    removals: ts[List[np.ndarray]],
     trigger: ts[object],
     reset: ts[object],
     arg: int,
@@ -628,8 +628,8 @@ def _np_var(
 
 @csp.node(cppimpl=_cspnpstatsimpl._np_sem)
 def _np_sem(
-    additions: ts[[np.ndarray]],
-    removals: ts[[np.ndarray]],
+    additions: ts[List[np.ndarray]],
+    removals: ts[List[np.ndarray]],
     trigger: ts[object],
     reset: ts[object],
     arg: int,
@@ -642,10 +642,10 @@ def _np_sem(
 
 @csp.node(cppimpl=_cspnpstatsimpl._np_covar)
 def _np_covar(
-    x_add: ts[[np.ndarray]],
-    x_rem: ts[[np.ndarray]],
-    w_add: ts[[np.ndarray]],
-    w_rem: ts[[np.ndarray]],
+    x_add: ts[List[np.ndarray]],
+    x_rem: ts[List[np.ndarray]],
+    w_add: ts[List[np.ndarray]],
+    w_rem: ts[List[np.ndarray]],
     trigger: ts[object],
     reset: ts[object],
     arg: int,
@@ -658,10 +658,10 @@ def _np_covar(
 
 @csp.node(cppimpl=_cspnpstatsimpl._np_corr)
 def _np_corr(
-    x_add: ts[[np.ndarray]],
-    x_rem: ts[[np.ndarray]],
-    w_add: ts[[np.ndarray]],
-    w_rem: ts[[np.ndarray]],
+    x_add: ts[List[np.ndarray]],
+    x_rem: ts[List[np.ndarray]],
+    w_add: ts[List[np.ndarray]],
+    w_rem: ts[List[np.ndarray]],
     trigger: ts[object],
     reset: ts[object],
     min_data_points: int,
@@ -673,10 +673,10 @@ def _np_corr(
 
 @csp.node(cppimpl=_cspnpstatsimpl._np_weighted_var)
 def _np_weighted_var(
-    x_add: ts[[np.ndarray]],
-    x_rem: ts[[np.ndarray]],
-    w_add: ts[[np.ndarray]],
-    w_rem: ts[[np.ndarray]],
+    x_add: ts[List[np.ndarray]],
+    x_rem: ts[List[np.ndarray]],
+    w_add: ts[List[np.ndarray]],
+    w_rem: ts[List[np.ndarray]],
     arg: int,
     trigger: ts[object],
     reset: ts[object],
@@ -689,10 +689,10 @@ def _np_weighted_var(
 
 @csp.node(cppimpl=_cspnpstatsimpl._np_weighted_sem)
 def _np_weighted_sem(
-    x_add: ts[[np.ndarray]],
-    x_rem: ts[[np.ndarray]],
-    w_add: ts[[np.ndarray]],
-    w_rem: ts[[np.ndarray]],
+    x_add: ts[List[np.ndarray]],
+    x_rem: ts[List[np.ndarray]],
+    w_add: ts[List[np.ndarray]],
+    w_rem: ts[List[np.ndarray]],
     arg: int,
     trigger: ts[object],
     reset: ts[object],
@@ -705,12 +705,12 @@ def _np_weighted_sem(
 
 @csp.node(cppimpl=_cspnpstatsimpl._np_weighted_covar)
 def _np_weighted_covar(
-    x_add: ts[[np.ndarray]],
-    x_rem: ts[[np.ndarray]],
-    y_add: ts[[np.ndarray]],
-    y_rem: ts[[np.ndarray]],
-    w_add: ts[[np.ndarray]],
-    w_rem: ts[[np.ndarray]],
+    x_add: ts[List[np.ndarray]],
+    x_rem: ts[List[np.ndarray]],
+    y_add: ts[List[np.ndarray]],
+    y_rem: ts[List[np.ndarray]],
+    w_add: ts[List[np.ndarray]],
+    w_rem: ts[List[np.ndarray]],
     trigger: ts[object],
     reset: ts[object],
     arg: int,
@@ -723,12 +723,12 @@ def _np_weighted_covar(
 
 @csp.node(cppimpl=_cspnpstatsimpl._np_weighted_corr)
 def _np_weighted_corr(
-    x_add: ts[[np.ndarray]],
-    x_rem: ts[[np.ndarray]],
-    y_add: ts[[np.ndarray]],
-    y_rem: ts[[np.ndarray]],
-    w_add: ts[[np.ndarray]],
-    w_rem: ts[[np.ndarray]],
+    x_add: ts[List[np.ndarray]],
+    x_rem: ts[List[np.ndarray]],
+    y_add: ts[List[np.ndarray]],
+    y_rem: ts[List[np.ndarray]],
+    w_add: ts[List[np.ndarray]],
+    w_rem: ts[List[np.ndarray]],
     trigger: ts[object],
     reset: ts[object],
     arg: int,
@@ -741,8 +741,8 @@ def _np_weighted_corr(
 
 @csp.node(cppimpl=_cspnpstatsimpl._np_cov_matrix)
 def _np_cov_matrix(
-    additions: ts[[np.ndarray]],
-    removals: ts[[np.ndarray]],
+    additions: ts[List[np.ndarray]],
+    removals: ts[List[np.ndarray]],
     trigger: ts[object],
     reset: ts[object],
     ddof: int,
@@ -755,8 +755,8 @@ def _np_cov_matrix(
 
 @csp.node(cppimpl=_cspnpstatsimpl._np_corr_matrix)
 def _np_corr_matrix(
-    additions: ts[[np.ndarray]],
-    removals: ts[[np.ndarray]],
+    additions: ts[List[np.ndarray]],
+    removals: ts[List[np.ndarray]],
     trigger: ts[object],
     reset: ts[object],
     ddof: int,
@@ -769,10 +769,10 @@ def _np_corr_matrix(
 
 @csp.node(cppimpl=_cspnpstatsimpl._np_weighted_cov_matrix)
 def _np_weighted_cov_matrix(
-    x_add: ts[[np.ndarray]],
-    x_rem: ts[[np.ndarray]],
-    w_add: ts[[float]],
-    w_rem: ts[[float]],
+    x_add: ts[List[np.ndarray]],
+    x_rem: ts[List[np.ndarray]],
+    w_add: ts[List[float]],
+    w_rem: ts[List[float]],
     trigger: ts[object],
     reset: ts[object],
     ddof: int,
@@ -785,10 +785,10 @@ def _np_weighted_cov_matrix(
 
 @csp.node(cppimpl=_cspnpstatsimpl._np_weighted_corr_matrix)
 def _np_weighted_corr_matrix(
-    x_add: ts[[np.ndarray]],
-    x_rem: ts[[np.ndarray]],
-    w_add: ts[[float]],
-    w_rem: ts[[float]],
+    x_add: ts[List[np.ndarray]],
+    x_rem: ts[List[np.ndarray]],
+    w_add: ts[List[float]],
+    w_rem: ts[List[float]],
     trigger: ts[object],
     reset: ts[object],
     ddof: int,
@@ -801,8 +801,8 @@ def _np_weighted_corr_matrix(
 
 @csp.node(cppimpl=_cspstatsimpl._skew)
 def _skew(
-    additions: ts[[float]],
-    removals: ts[[float]],
+    additions: ts[List[float]],
+    removals: ts[List[float]],
     trigger: ts[object],
     reset: ts[object],
     arg: bool,
@@ -816,8 +816,8 @@ def _skew(
 
 @csp.node(cppimpl=_cspstatsimpl._kurt)
 def _kurt(
-    additions: ts[[float]],
-    removals: ts[[float]],
+    additions: ts[List[float]],
+    removals: ts[List[float]],
     trigger: ts[object],
     reset: ts[object],
     arg1: bool,
@@ -832,10 +832,10 @@ def _kurt(
 
 @csp.node(cppimpl=_cspstatsimpl._weighted_skew)
 def _weighted_skew(
-    x_add: ts[[float]],
-    x_rem: ts[[float]],
-    y_add: ts[[float]],
-    y_rem: ts[[float]],
+    x_add: ts[List[float]],
+    x_rem: ts[List[float]],
+    y_add: ts[List[float]],
+    y_rem: ts[List[float]],
     trigger: ts[object],
     reset: ts[object],
     arg: bool,
@@ -848,10 +848,10 @@ def _weighted_skew(
 
 @csp.node(cppimpl=_cspstatsimpl._weighted_kurt)
 def _weighted_kurt(
-    x_add: ts[[float]],
-    x_rem: ts[[float]],
-    y_add: ts[[float]],
-    y_rem: ts[[float]],
+    x_add: ts[List[float]],
+    x_rem: ts[List[float]],
+    y_add: ts[List[float]],
+    y_rem: ts[List[float]],
     trigger: ts[object],
     reset: ts[object],
     arg1: bool,
@@ -865,8 +865,8 @@ def _weighted_kurt(
 
 @csp.node(cppimpl=_cspnpstatsimpl._np_skew)
 def _np_skew(
-    additions: ts[[np.ndarray]],
-    removals: ts[[np.ndarray]],
+    additions: ts[List[np.ndarray]],
+    removals: ts[List[np.ndarray]],
     trigger: ts[object],
     reset: ts[object],
     arg: bool,
@@ -880,8 +880,8 @@ def _np_skew(
 
 @csp.node(cppimpl=_cspnpstatsimpl._np_kurt)
 def _np_kurt(
-    additions: ts[[np.ndarray]],
-    removals: ts[[np.ndarray]],
+    additions: ts[List[np.ndarray]],
+    removals: ts[List[np.ndarray]],
     trigger: ts[object],
     reset: ts[object],
     arg1: bool,
@@ -896,10 +896,10 @@ def _np_kurt(
 
 @csp.node(cppimpl=_cspnpstatsimpl._np_weighted_skew)
 def _np_weighted_skew(
-    x_add: ts[[np.ndarray]],
-    x_rem: ts[[np.ndarray]],
-    w_add: ts[[np.ndarray]],
-    w_rem: ts[[np.ndarray]],
+    x_add: ts[List[np.ndarray]],
+    x_rem: ts[List[np.ndarray]],
+    w_add: ts[List[np.ndarray]],
+    w_rem: ts[List[np.ndarray]],
     trigger: ts[object],
     reset: ts[object],
     arg: bool,
@@ -912,10 +912,10 @@ def _np_weighted_skew(
 
 @csp.node(cppimpl=_cspnpstatsimpl._np_weighted_kurt)
 def _np_weighted_kurt(
-    x_add: ts[[np.ndarray]],
-    x_rem: ts[[np.ndarray]],
-    w_add: ts[[np.ndarray]],
-    w_rem: ts[[np.ndarray]],
+    x_add: ts[List[np.ndarray]],
+    x_rem: ts[List[np.ndarray]],
+    w_add: ts[List[np.ndarray]],
+    w_rem: ts[List[np.ndarray]],
     trigger: ts[object],
     reset: ts[object],
     arg1: bool,
@@ -929,8 +929,8 @@ def _np_weighted_kurt(
 
 @csp.node(cppimpl=_cspstatsimpl._first)
 def _first(
-    additions: ts[[float]],
-    removals: ts[[float]],
+    additions: ts[List[float]],
+    removals: ts[List[float]],
     trigger: ts[object],
     reset: ts[object],
     min_data_points: int,
@@ -942,8 +942,8 @@ def _first(
 
 @csp.node(cppimpl=_cspnpstatsimpl._np_first)
 def _np_first(
-    additions: ts[[np.ndarray]],
-    removals: ts[[np.ndarray]],
+    additions: ts[List[np.ndarray]],
+    removals: ts[List[np.ndarray]],
     trigger: ts[object],
     reset: ts[object],
     min_data_points: int,
@@ -955,8 +955,8 @@ def _np_first(
 
 @csp.node(cppimpl=_cspstatsimpl._last)
 def _last(
-    additions: ts[[float]],
-    removals: ts[[float]],
+    additions: ts[List[float]],
+    removals: ts[List[float]],
     trigger: ts[object],
     reset: ts[object],
     min_data_points: int,
@@ -968,8 +968,8 @@ def _last(
 
 @csp.node(cppimpl=_cspnpstatsimpl._np_last)
 def _np_last(
-    additions: ts[[np.ndarray]],
-    removals: ts[[np.ndarray]],
+    additions: ts[List[np.ndarray]],
+    removals: ts[List[np.ndarray]],
     trigger: ts[object],
     reset: ts[object],
     min_data_points: int,
@@ -981,8 +981,8 @@ def _np_last(
 
 @csp.node(cppimpl=_cspstatsimpl._unique)
 def _unique(
-    additions: ts[[float]],
-    removals: ts[[float]],
+    additions: ts[List[float]],
+    removals: ts[List[float]],
     trigger: ts[object],
     reset: ts[object],
     min_data_points: int,
@@ -995,8 +995,8 @@ def _unique(
 
 @csp.node(cppimpl=_cspnpstatsimpl._np_unique)
 def _np_unique(
-    additions: ts[[np.ndarray]],
-    removals: ts[[np.ndarray]],
+    additions: ts[List[np.ndarray]],
+    removals: ts[List[np.ndarray]],
     trigger: ts[object],
     reset: ts[object],
     min_data_points: int,
@@ -1009,8 +1009,8 @@ def _np_unique(
 
 @csp.node(cppimpl=_cspstatsimpl._prod)
 def _prod(
-    additions: ts[[float]],
-    removals: ts[[float]],
+    additions: ts[List[float]],
+    removals: ts[List[float]],
     trigger: ts[object],
     reset: ts[object],
     min_data_points: int,
@@ -1022,8 +1022,8 @@ def _prod(
 
 @csp.node(cppimpl=_cspnpstatsimpl._np_prod)
 def _np_prod(
-    additions: ts[[np.ndarray]],
-    removals: ts[[np.ndarray]],
+    additions: ts[List[np.ndarray]],
+    removals: ts[List[np.ndarray]],
     trigger: ts[object],
     reset: ts[object],
     min_data_points: int,
@@ -1035,8 +1035,8 @@ def _np_prod(
 
 @csp.node(cppimpl=_cspstatsimpl._quantile)
 def _quantile(
-    additions: ts[[float]],
-    removals: ts[[float]],
+    additions: ts[List[float]],
+    removals: ts[List[float]],
     quants: typing.List[float],
     nq: int,
     interpolation_type: int,
@@ -1051,8 +1051,8 @@ def _quantile(
 
 @csp.node(cppimpl=_cspnpstatsimpl._np_quantile)
 def _np_quantile(
-    additions: ts[[np.ndarray]],
-    removals: ts[[np.ndarray]],
+    additions: ts[List[np.ndarray]],
+    removals: ts[List[np.ndarray]],
     quants: typing.List[float],
     nq: int,
     interpolation_type: int,
@@ -1067,8 +1067,8 @@ def _np_quantile(
 
 @csp.node(cppimpl=_cspstatsimpl._min_max)
 def _min_max(
-    additions: ts[[float]],
-    removals: ts[[float]],
+    additions: ts[List[float]],
+    removals: ts[List[float]],
     trigger: ts[object],
     reset: ts[object],
     min_data_points: int,
@@ -1081,8 +1081,8 @@ def _min_max(
 
 @csp.node(cppimpl=_cspnpstatsimpl._np_min_max)
 def _np_min_max(
-    additions: ts[[np.ndarray]],
-    removals: ts[[np.ndarray]],
+    additions: ts[List[np.ndarray]],
+    removals: ts[List[np.ndarray]],
     trigger: ts[object],
     reset: ts[object],
     min_data_points: int,
@@ -1095,8 +1095,8 @@ def _np_min_max(
 
 @csp.node(cppimpl=_cspstatsimpl._rank)
 def _rank(
-    additions: ts[[float]],
-    removals: ts[[float]],
+    additions: ts[List[float]],
+    removals: ts[List[float]],
     trigger: ts[object],
     reset: ts[object],
     min_data_points: int,
@@ -1110,8 +1110,8 @@ def _rank(
 
 @csp.node(cppimpl=_cspnpstatsimpl._np_rank)
 def _np_rank(
-    additions: ts[[np.ndarray]],
-    removals: ts[[np.ndarray]],
+    additions: ts[List[np.ndarray]],
+    removals: ts[List[np.ndarray]],
     trigger: ts[object],
     reset: ts[object],
     min_data_points: int,
@@ -1126,7 +1126,7 @@ def _np_rank(
 @csp.node(cppimpl=_cspstatsimpl._arg_min_max)
 def _arg_min_max(
     x: ts[float],
-    removals: ts[[float]],
+    removals: ts[List[float]],
     max: bool,
     recent: bool,
     trigger: ts[object],
@@ -1142,7 +1142,7 @@ def _arg_min_max(
 @csp.node(cppimpl=_cspnpstatsimpl._np_arg_min_max)
 def _np_arg_min_max(
     x: ts[np.ndarray],
-    removals: ts[[np.ndarray]],
+    removals: ts[List[np.ndarray]],
     max: bool,
     recent: bool,
     trigger: ts[object],
@@ -1157,8 +1157,8 @@ def _np_arg_min_max(
 
 @csp.node(cppimpl=_cspstatsimpl._ema_compute)
 def _ema_compute(
-    additions: ts[[float]],
-    removals: ts[[float]],
+    additions: ts[List[float]],
+    removals: ts[List[float]],
     alpha: float,
     ignore_na: bool,
     horizon: int,
@@ -1173,8 +1173,8 @@ def _ema_compute(
 
 @csp.node(cppimpl=_cspnpstatsimpl._np_ema_compute)
 def _np_ema_compute(
-    additions: ts[[np.ndarray]],
-    removals: ts[[np.ndarray]],
+    additions: ts[List[np.ndarray]],
+    removals: ts[List[np.ndarray]],
     alpha: float,
     ignore_na: bool,
     horizon: int,
@@ -1189,8 +1189,8 @@ def _np_ema_compute(
 
 @csp.node(cppimpl=_cspstatsimpl._ema_adjusted)
 def _ema_adjusted(
-    additions: ts[[float]],
-    removals: ts[[float]],
+    additions: ts[List[float]],
+    removals: ts[List[float]],
     alpha: float,
     ignore_na: bool,
     horizon: int,
@@ -1205,8 +1205,8 @@ def _ema_adjusted(
 
 @csp.node(cppimpl=_cspnpstatsimpl._np_ema_adjusted)
 def _np_ema_adjusted(
-    additions: ts[[np.ndarray]],
-    removals: ts[[np.ndarray]],
+    additions: ts[List[np.ndarray]],
+    removals: ts[List[np.ndarray]],
     alpha: float,
     ignore_na: bool,
     horizon: int,
@@ -1263,8 +1263,8 @@ def _np_ema_debias_halflife(
 
 @csp.node(cppimpl=_cspstatsimpl._ema_debias_alpha)
 def _ema_debias_alpha(
-    additions: ts[[float]],
-    removals: ts[[float]],
+    additions: ts[List[float]],
+    removals: ts[List[float]],
     alpha: float,
     ignore_na: bool,
     horizon: int,
@@ -1279,8 +1279,8 @@ def _ema_debias_alpha(
 
 @csp.node(cppimpl=_cspnpstatsimpl._np_ema_debias_alpha)
 def _np_ema_debias_alpha(
-    additions: ts[[np.ndarray]],
-    removals: ts[[np.ndarray]],
+    additions: ts[List[np.ndarray]],
+    removals: ts[List[np.ndarray]],
     alpha: float,
     ignore_na: bool,
     horizon: int,
@@ -1328,15 +1328,15 @@ def _ema_debias(
 
 @csp.node(cppimpl=_cspstatsimpl._cross_sectional_as_list)
 def _cross_sectional_as_list(
-    additions: ts[[float]], removals: ts[[float]], trigger: ts[object], reset: ts[object]
-) -> ts[[float]]:
+    additions: ts[List[float]], removals: ts[List[float]], trigger: ts[object], reset: ts[object]
+) -> ts[List[float]]:
     raise NotImplementedError("_cross_sectional_as_list only implemented in C++")
     return 0
 
 
 @csp.node(cppimpl=_cspnpstatsimpl._cross_sectional_as_np)
 def _cross_sectional_as_np(
-    additions: ts[[float]], removals: ts[[float]], trigger: ts[object], reset: ts[object]
+    additions: ts[List[float]], removals: ts[List[float]], trigger: ts[object], reset: ts[object]
 ) -> ts[np.ndarray]:
     raise NotImplementedError("_cross_sectional_as_np only implemented in C++")
     return 0
@@ -1344,15 +1344,15 @@ def _cross_sectional_as_np(
 
 @csp.node(cppimpl=_cspnpstatsimpl._np_cross_sectional_as_list)
 def _np_cross_sectional_as_list(
-    additions: ts[[np.ndarray]], removals: ts[[np.ndarray]], trigger: ts[object], reset: ts[object]
-) -> ts[[np.ndarray]]:
+    additions: ts[List[np.ndarray]], removals: ts[List[np.ndarray]], trigger: ts[object], reset: ts[object]
+) -> ts[List[np.ndarray]]:
     raise NotImplementedError("_np_cross_sectional_as_list only implemented in C++")
     return 0
 
 
 @csp.node(cppimpl=_cspnpstatsimpl._np_cross_sectional_as_np)
 def _np_cross_sectional_as_np(
-    additions: ts[[np.ndarray]], removals: ts[[np.ndarray]], trigger: ts[object], reset: ts[object]
+    additions: ts[List[np.ndarray]], removals: ts[List[np.ndarray]], trigger: ts[object], reset: ts[object]
 ) -> ts[np.ndarray]:
     raise NotImplementedError("_np_cross_sectional_as_np only implemented in C++")
     return 0

--- a/csp/tests/adapters/test_numpy.py
+++ b/csp/tests/adapters/test_numpy.py
@@ -1,6 +1,7 @@
 import numpy as np
 import unittest
 from datetime import datetime, timedelta
+from typing import List
 
 import csp
 
@@ -239,13 +240,13 @@ class TestNumpyAdapter(unittest.TestCase):
     def test_array(self):
         raw_vals = [[1, 2], [3], [4, 5, 6]]
         res = csp.run(
-            g, typ=[int], values=np.array(raw_vals, dtype="object"), dts=test_dts_ndarray, starttime=test_starttime
+            g, typ=List[int], values=np.array(raw_vals, dtype="object"), dts=test_dts_ndarray, starttime=test_starttime
         )
         self.assertEqual(res["out"], list(zip(test_dts, raw_vals)))
 
         raw_vals = [["hello", "world"], ["hows"], ["it", "going"]]
         res = csp.run(
-            g, typ=[str], values=np.array(raw_vals, dtype="object"), dts=test_dts_ndarray, starttime=test_starttime
+            g, typ=List[str], values=np.array(raw_vals, dtype="object"), dts=test_dts_ndarray, starttime=test_starttime
         )
         self.assertEqual(res["out"], list(zip(test_dts, raw_vals)))
 

--- a/csp/tests/impl/test_pulladapter.py
+++ b/csp/tests/impl/test_pulladapter.py
@@ -1,6 +1,7 @@
 import time
 import unittest
 from datetime import datetime, timedelta
+from typing import List
 
 import csp
 from csp import PushMode, ts
@@ -15,7 +16,7 @@ class TestPullAdapter(unittest.TestCase):
     def test_basic(self):
         # We just use the existing curve adapter to test pull since its currently implemented as a python PullInputAdapter
         @csp.node
-        def check(burst: ts[["T"]], lv: ts["T"], nc: ts["T"]):
+        def check(burst: ts[List["T"]], lv: ts["T"], nc: ts["T"]):
             if csp.ticked(burst):
                 self.assertEqual(len(burst), 2)
                 self.assertEqual(burst[0], nc)

--- a/csp/tests/impl/test_pushadapter.py
+++ b/csp/tests/impl/test_pushadapter.py
@@ -2,6 +2,7 @@ import threading
 import time
 import unittest
 from datetime import datetime, timedelta
+from typing import List
 
 import csp
 from csp import PushMode, ts
@@ -111,7 +112,7 @@ curve_push_adapter = py_push_adapter_def("test", CurvePushAdapter, ts["T"], Curv
 class TestPushAdapter(unittest.TestCase):
     def test_basic(self):
         @csp.node
-        def check(burst: ts[["T"]], lv: [ts["T"]], nc: ts["T"]):
+        def check(burst: ts[List["T"]], lv: List[ts["T"]], nc: ts["T"]):
             # Assert all last values have the same value since theyre injected in the same batch
             if csp.ticked(lv) and csp.valid(lv):
                 self.assertTrue(all(v == lv[0] for v in lv.validvalues()))

--- a/csp/tests/impl/test_struct.py
+++ b/csp/tests/impl/test_struct.py
@@ -5,6 +5,7 @@ import pytz
 import typing
 import unittest
 from datetime import date, datetime, time, timedelta
+from typing import Dict, List, Set, Tuple
 
 import csp
 from csp.impl.struct import defineStruct
@@ -24,9 +25,9 @@ class StructNoDefaults(csp.Struct):
     bt: bytes
     o: object
     a1: FastList[int]
-    a2: [str]
+    a2: List[str]
     a3: FastList[object]
-    a4: [bytes]
+    a4: List[bytes]
 
 
 class StructWithDefaults(csp.Struct):
@@ -37,8 +38,8 @@ class StructWithDefaults(csp.Struct):
     e: MyEnum = MyEnum.FOO
     o: object
     a1: FastList[int] = [1, 2, 3]
-    a2: [str] = ["1", "2", "3"]
-    a3: [object] = ["hey", 123, (1, 2, 3)]
+    a2: List[str] = ["1", "2", "3"]
+    a3: List[object] = ["hey", 123, (1, 2, 3)]
     np_arr: np.ndarray = np.array([1, 9])
 
 
@@ -73,9 +74,9 @@ class BaseMixed(csp.Struct):
     s: str
     l: list
     o: object
-    a1: [int]
+    a1: List[int]
     a2: FastList[str]
-    a3: [object]
+    a3: List[object]
 
 
 class DerivedFullyNative(BaseNative):
@@ -123,10 +124,10 @@ class StructWithMutableStruct(csp.Struct):
 
 
 class StructWithLists(csp.Struct):
-    # native_list: [int]
-    struct_list: [BaseNative]
+    # native_list: List[int]
+    struct_list: List[BaseNative]
     fast_list: FastList[BaseNative]
-    dialect_generic_list: [list]
+    dialect_generic_list: List[list]
 
 
 class AllTypes(csp.Struct):
@@ -140,7 +141,7 @@ class AllTypes(csp.Struct):
     s: str = "hello hello"
     e: MyEnum = MyEnum.FOO
     struct: BaseNative = BaseNative(i=123, b=True, f=456.789)
-    arr: [int] = [1, 2, 3]
+    arr: List[int] = [1, 2, 3]
     fl: FastList[int] = [1, 2, 3, 4]
     o: object = {"k": "v"}
 
@@ -171,7 +172,7 @@ class SimpleClass:
 
 
 class SimpleStructForPickleList(csp.Struct):
-    a: typing.List[int]
+    a: List[int]
 
 
 class SimpleStructForPickleFastList(csp.Struct):
@@ -270,7 +271,7 @@ struct_list_test_values = {
         None,
     ],  # generic type user-defined
 }
-struct_list_annotation_types = (typing.List, FastList)
+struct_list_annotation_types = (List, FastList)
 
 
 class TestCspStruct(unittest.TestCase):
@@ -384,7 +385,7 @@ class TestCspStruct(unittest.TestCase):
         # Was a bug with typed list of struct comparisons
         class BAR(csp.Struct):
             a: int
-            b: [FOO]
+            b: List[FOO]
 
         a = BAR(a=123, b=[FOO(a=1, b="2", c=[1, 2, 3])])
         b = BAR(a=123, b=[FOO(a=1, b="2", c=[1, 2, 3])])
@@ -518,7 +519,7 @@ class TestCspStruct(unittest.TestCase):
             v: int
 
         class Outer(csp.Struct):
-            a3: [object]
+            a3: List[object]
 
         i = Inner(v=5)
         s = Outer(a3=[i, i, i])
@@ -821,8 +822,8 @@ class TestCspStruct(unittest.TestCase):
 
     def test_from_dict_loop_with_generic_typing(self):
         class MyStruct(csp.Struct):
-            foo: typing.Set[int]
-            bar: typing.Tuple[str]
+            foo: Set[int]
+            bar: Tuple[str]
             np_arr: csp.typing.NumpyNDArray[float]
 
         looped = MyStruct.from_dict(MyStruct(foo=set((9, 10)), bar=("a", "b"), np_arr=np.array([1, 3])).to_dict())
@@ -839,13 +840,13 @@ class TestCspStruct(unittest.TestCase):
             default_i: int = 42
 
         class S2(csp.Struct):
-            value: typing.Tuple[int]
-            set_value: typing.Set[str]
+            value: Tuple[int]
+            set_value: Set[str]
 
         class S(csp.Struct):
-            d: typing.Dict[str, S1]
-            ls: typing.List[int]
-            lc: typing.List[S2]
+            d: Dict[str, S1]
+            ls: List[int]
+            lc: List[S2]
 
         input = """
         d:
@@ -933,7 +934,7 @@ class TestCspStruct(unittest.TestCase):
 
     def test_list_field_set_iterator(self):
         class S(csp.Struct):
-            l: [object]
+            l: List[object]
 
         s = S()
         expected = list(range(100))
@@ -1070,7 +1071,7 @@ class TestCspStruct(unittest.TestCase):
             "b": int,
             "c": {
                 "x": MyEnum,
-                "y": [int],
+                "y": List[int],
             },
             "d": {"s": object, "t": FastList[object]},
         }
@@ -1176,7 +1177,7 @@ class TestCspStruct(unittest.TestCase):
         class StructA(csp.Struct):
             a: int
             b: str
-            c: typing.List[int]
+            c: List[int]
 
         s1 = StructA(a=1, b="b", c=[1, 2])
         exp_repr_s1 = "StructA( a=1, b=b, c=[1, 2] )"
@@ -1238,7 +1239,7 @@ class TestCspStruct(unittest.TestCase):
         # test structs with struct, struct array fields
         class StructE(csp.Struct):
             a: StructA
-            b: typing.List[StructC]
+            b: List[StructC]
 
         s5 = StructE(
             a=StructA(a=1, b="b", c=[1, 2]),
@@ -1250,12 +1251,12 @@ class TestCspStruct(unittest.TestCase):
 
         # test array fields
         class StructF(csp.Struct):
-            a: typing.List[int]
-            b: typing.List[bool]
-            c: typing.List[typing.List[float]]
-            d: typing.List[ClassA]
-            e: typing.List[EnumA]
-            f: typing.List[StructC]  # leave unset for test
+            a: List[int]
+            b: List[bool]
+            c: List[List[float]]
+            d: List[ClassA]
+            e: List[EnumA]
+            f: List[StructC]  # leave unset for test
 
         # str (called by print) will show unset fields, repr (called in logging) will not
         s6 = StructF(a=[1], b=[True], c=[[1.0]], d=[ClassA()], e=[EnumA.RED, EnumA.BLUE])
@@ -1269,7 +1270,7 @@ class TestCspStruct(unittest.TestCase):
         # test unset in arrays/nested structs
         class StructG(csp.Struct):
             a: StructA
-            b: typing.List[StructA]
+            b: List[StructA]
             c: ClassA
 
         s7 = StructG(a=StructA(), b=[StructA(), StructA()])
@@ -1376,7 +1377,7 @@ class TestCspStruct(unittest.TestCase):
         """Test [bool] specific functionality since its special cased as vector<uint8> in C++"""
 
         class A(csp.Struct):
-            l: [bool]
+            l: List[bool]
 
         raw = [True, False, True]
         a = A(l=raw)
@@ -1594,11 +1595,11 @@ class TestCspStruct(unittest.TestCase):
     def test_to_json_list(self):
         class MyStruct(csp.Struct):
             i: int = 123
-            l_i: typing.List[int]
-            l_b: typing.List[bool]
-            l_dt: typing.List[datetime]
-            l_l_i: typing.List[typing.List[int]]
-            l_tuple: typing.Tuple[int, float, str]
+            l_i: List[int]
+            l_b: List[bool]
+            l_dt: List[datetime]
+            l_l_i: List[List[int]]
+            l_tuple: Tuple[int, float, str]
             l_any: list
 
         test_struct = MyStruct()
@@ -1666,10 +1667,10 @@ class TestCspStruct(unittest.TestCase):
     def test_to_json_dict(self):
         class MyStruct(csp.Struct):
             i: int = 123
-            d_i: typing.Dict[int, int]
-            d_f: typing.Dict[float, int]
-            d_dt: typing.Dict[str, datetime]
-            d_d_s: typing.Dict[str, typing.Dict[str, str]]
+            d_i: Dict[int, int]
+            d_f: Dict[float, int]
+            d_dt: Dict[str, datetime]
+            d_d_s: Dict[str, Dict[str, str]]
             d_any: dict
 
         test_struct = MyStruct()
@@ -1844,14 +1845,14 @@ class TestCspStruct(unittest.TestCase):
 
         class MySubStruct(csp.Struct):
             d_s_msss: dict
-            l_ncsp: typing.List[NonCspStruct]
+            l_ncsp: List[NonCspStruct]
             py_l_ncsp: list
 
         class MyStruct(csp.Struct):
             i: int = 789
             s: str = "MyStruct"
             ts: datetime
-            l_mss: typing.List[MySubStruct]
+            l_mss: List[MySubStruct]
             l_msss: list
             d_i_ncsp: dict
 
@@ -2253,7 +2254,7 @@ class TestCspStruct(unittest.TestCase):
                     self.assertEqual(s.a, [v[0], v[4], v[2], v[3], v[1], v[5]])
 
             class B(csp.Struct):
-                a: [MyEnum]
+                a: List[MyEnum]
 
             s = B(a=[MyEnum.A, MyEnum.FOO])
 
@@ -2693,7 +2694,7 @@ class TestCspStruct(unittest.TestCase):
                 self.assertEqual(s4.a == s3.a, True)
 
             class B(csp.Struct):
-                a: [MyEnum]
+                a: List[MyEnum]
 
             s = B(a=[MyEnum.A, MyEnum.FOO])
             t = B(a=[MyEnum.FOO, MyEnum.FOO])
@@ -2794,15 +2795,15 @@ class TestCspStruct(unittest.TestCase):
         """Check that FastList and PyStructList types are used correctly"""
 
         class A(csp.Struct):
-            a: [int]
+            a: List[int]
 
         with self.assertRaises(TypeError):
 
             class B(csp.Struct):
-                a: [int, False]
+                a: List[int, False]
 
         class C(csp.Struct):
-            a: typing.List[int]
+            a: List[int]
 
         class D(csp.Struct):
             a: FastList[int]
@@ -2810,7 +2811,7 @@ class TestCspStruct(unittest.TestCase):
         with self.assertRaises(TypeError):
 
             class E(csp.Struct):
-                a: [int, True]
+                a: List[int, True]
 
         p = A(a=[1, 2])
         r = C(a=[1, 2])
@@ -2824,7 +2825,7 @@ class TestCspStruct(unittest.TestCase):
         """Check that FastList can be passed to where Python list is expected"""
 
         class A(csp.Struct):
-            a: [int]
+            a: List[int]
 
         class B(csp.Struct):
             a: FastList[int]

--- a/csp/tests/test_baselib.py
+++ b/csp/tests/test_baselib.py
@@ -6,6 +6,7 @@ import numpy as np
 import unittest
 from datetime import date, datetime, timedelta, timezone
 from enum import Enum, auto
+from typing import List
 
 import csp
 from csp import ts
@@ -210,7 +211,7 @@ class TestBaselib(unittest.TestCase):
         st = datetime(2020, 1, 1)
         td = timedelta(seconds=1)
         x = csp.curve(
-            [int],
+            List[int],
             [
                 (st, [1]),
                 (st + td * 1, [2, 3, 4]),
@@ -220,7 +221,7 @@ class TestBaselib(unittest.TestCase):
             ],
         )
         x2 = csp.curve(
-            [[int]],
+            List[List[int]],
             [
                 (st, [[1]]),
                 (st + td * 1, [[2, 3, 4]]),
@@ -662,7 +663,7 @@ class TestBaselib(unittest.TestCase):
         @csp.graph
         def my_graph():
             ticks = [MyStruct(key=chr(ord("A") + i % 5), value=i) for i in range(1000)]
-            ticks = csp.unroll(csp.const.using(T=[MyStruct])(ticks))
+            ticks = csp.unroll(csp.const.using(T=List[MyStruct])(ticks))
             demux = csp.DelayedDemultiplex(ticks, ticks.key, raise_on_bad_key=False)
 
             csp.add_graph_output("A", demux.demultiplex("A"))
@@ -785,11 +786,11 @@ class TestBaselib(unittest.TestCase):
     def test_drop_dups(self):
         @csp.graph
         def g(d1: list, d2: list, d3: list, d4: list, d5: list):
-            d1 = csp.unroll(csp.const.using(T=[int])(d1))
-            d2 = csp.unroll(csp.const.using(T=[tuple])(d2))
-            d3 = csp.unroll(csp.const.using(T=[float])(d3))
-            d4 = csp.unroll(csp.const.using(T=[float])(d4))
-            d5 = csp.unroll(csp.const.using(T=[float])(d5))
+            d1 = csp.unroll(csp.const.using(T=List[int])(d1))
+            d2 = csp.unroll(csp.const.using(T=List[tuple])(d2))
+            d3 = csp.unroll(csp.const.using(T=List[float])(d3))
+            d4 = csp.unroll(csp.const.using(T=List[float])(d4))
+            d5 = csp.unroll(csp.const.using(T=List[float])(d5))
 
             csp.add_graph_output("d1", csp.drop_dups(d1))
             csp.add_graph_output("d2", csp.drop_dups(d2))
@@ -899,8 +900,8 @@ class TestBaselib(unittest.TestCase):
             e: MyEnum
             st: MyStruct
             o: MyObject
-            l: [int]
-            lb: [bool]
+            l: List[int]
+            lb: List[bool]
 
         @csp.node
         def random_gen(trigger: ts[object], typ: "T") -> ts["T"]:
@@ -947,7 +948,7 @@ class TestBaselib(unittest.TestCase):
                 return tick
 
         @csp.node
-        def accum_list(x: ts["T"]) -> ts[["T"]]:
+        def accum_list(x: ts["T"]) -> ts[List["T"]]:
             with csp.state():
                 s_nextcount = 1
                 s_accum = []

--- a/csp/tests/test_baskets.py
+++ b/csp/tests/test_baskets.py
@@ -1,10 +1,10 @@
 import numpy
 import random
 import time
-import typing
 import unittest
 from collections import defaultdict
 from datetime import datetime, timedelta
+from typing import Dict, List
 
 import csp
 import csp.impl
@@ -14,15 +14,15 @@ from csp import ts
 class TestBaskets(unittest.TestCase):
     def test_functionality(self):
         @csp.node
-        def list_basket(x: [ts[int]]) -> csp.Outputs(
-            tickedvalues=ts[[int]],
-            tickeditems=ts[[object]],
-            tickedkeys=ts[[int]],
-            validvalues=ts[[int]],
-            validitems=ts[[object]],
-            validkeys=ts[[int]],
+        def list_basket(x: List[ts[int]]) -> csp.Outputs(
+            tickedvalues=ts[List[int]],
+            tickeditems=ts[List[object]],
+            tickedkeys=ts[List[int]],
+            validvalues=ts[List[int]],
+            validitems=ts[List[object]],
+            validkeys=ts[List[int]],
             valid=ts[bool],
-            iter=ts[[int]],
+            iter=ts[List[int]],
             elem_access=ts[int],
         ):
             if csp.ticked(x):
@@ -41,13 +41,13 @@ class TestBaskets(unittest.TestCase):
                     csp.output(elem_access=x[1])
 
         @csp.node
-        def dict_basket(x: {str: ts[int]}) -> csp.Outputs(
-            tickedvalues=ts[[int]],
-            tickeditems=ts[[object]],
-            tickedkeys=ts[[str]],
-            validvalues=ts[[int]],
-            validitems=ts[[object]],
-            validkeys=ts[[str]],
+        def dict_basket(x: Dict[str, ts[int]]) -> csp.Outputs(
+            tickedvalues=ts[List[int]],
+            tickeditems=ts[List[object]],
+            tickedkeys=ts[List[str]],
+            validvalues=ts[List[int]],
+            validitems=ts[List[object]],
+            validkeys=ts[List[str]],
             valid=ts[bool],
             elem_access=ts[int],
         ):
@@ -207,7 +207,7 @@ class TestBaskets(unittest.TestCase):
                 csp.output(changes=changes, ticks=ticks)
 
         @csp.node
-        def consume(x: {ts[str]: ts[float]}, changes: ts[list], ticks: ts[list]):
+        def consume(x: Dict[ts[str], ts[float]], changes: ts[list], ticks: ts[list]):
             with csp.state():
                 s_valid = {}
 
@@ -256,10 +256,10 @@ class TestBaskets(unittest.TestCase):
         random.seed(seed)
         csp.run(g, starttime=datetime(2021, 5, 25), endtime=timedelta(hours=4))
 
-    def test_dynamic_basket_tick_remove_exception(self) -> csp.OutputBasket({ts[str]: ts[int]}):
+    def test_dynamic_basket_tick_remove_exception(self) -> csp.OutputBasket(Dict[ts[str], ts[int]]):
         # tick/remove exception check
         @csp.node
-        def gen() -> csp.OutputBasket({ts[str]: ts[int]}):
+        def gen() -> csp.OutputBasket(Dict[ts[str], ts[int]]):
             with csp.alarms():
                 a_same_cycle_check = csp.alarm(bool)
 
@@ -271,7 +271,7 @@ class TestBaskets(unittest.TestCase):
                 csp.remove_dynamic_key("FOOBAR")
 
         @csp.node
-        def consume(x: {ts[str]: ts[float]}):
+        def consume(x: Dict[ts[str], ts[float]]):
             pass
 
         with self.assertRaisesRegex(
@@ -281,7 +281,7 @@ class TestBaskets(unittest.TestCase):
 
     def test_dynamic_basket_buffering_policy(self):
         @csp.node
-        def gen(x: ts[object]) -> csp.OutputBasket({ts[str]: ts[int]}):
+        def gen(x: ts[object]) -> csp.OutputBasket(Dict[ts[str], ts[int]]):
             with csp.state():
                 s_last = defaultdict(lambda: 1)
 
@@ -292,7 +292,7 @@ class TestBaskets(unittest.TestCase):
                 csp.output({key: v})
 
         @csp.node
-        def consume(x: {ts[str]: ts[int]}):
+        def consume(x: Dict[ts[str], ts[int]]):
             with csp.start():
                 csp.set_buffering_policy(x, tick_count=10, tick_history=timedelta(seconds=30))
 
@@ -311,7 +311,7 @@ class TestBaskets(unittest.TestCase):
     def test_basket_valid(self):
         # a basket input that is passive from the start should still register as valid once all its ts have ticked
         @csp.node
-        def triggered(x: {str: ts[float]}, y: ts[bool]) -> ts[float]:
+        def triggered(x: Dict[str, ts[float]], y: ts[bool]) -> ts[float]:
             with csp.start():
                 csp.make_passive(x)
 
@@ -333,13 +333,13 @@ class TestBaskets(unittest.TestCase):
 
     def test_list_basket_np_index(self):
         @csp.node
-        def echo_np(x: [ts[float]], num_keys: int) -> csp.OutputBasket(typing.List[ts[float]], shape="num_keys"):
+        def echo_np(x: List[ts[float]], num_keys: int) -> csp.OutputBasket(List[ts[float]], shape="num_keys"):
             if csp.ticked(x):
                 all_idx = numpy.arange(num_keys)
                 return dict(zip(all_idx, x))
 
         @csp.node
-        def echo_int(x: [ts[float]], num_keys: int) -> csp.OutputBasket(typing.List[ts[float]], shape="num_keys"):
+        def echo_int(x: List[ts[float]], num_keys: int) -> csp.OutputBasket(List[ts[float]], shape="num_keys"):
             if csp.ticked(x):
                 all_idx = numpy.arange(num_keys)
                 return dict(zip(all_idx.tolist(), x))  # Converts idx from np.int64 -> int

--- a/csp/tests/test_history.py
+++ b/csp/tests/test_history.py
@@ -1,9 +1,9 @@
 import numpy as np
 import os
 import psutil
-import typing
 import unittest
 from datetime import datetime, timedelta
+from typing import List
 
 import csp
 from csp import ts
@@ -636,7 +636,7 @@ class TestHistory(unittest.TestCase):
                         i += 1
 
         def g():
-            n(csp.unroll(csp.const.using(T=[int])(list(range(100000)))))
+            n(csp.unroll(csp.const.using(T=List[int])(list(range(100000)))))
 
         process = psutil.Process(os.getpid())
         mem_before = process.memory_info().rss

--- a/csp/tests/test_parsing.py
+++ b/csp/tests/test_parsing.py
@@ -47,21 +47,21 @@ class TestParsing(unittest.TestCase):
         with self.assertRaisesRegex(CspParseError, "Invalid use of 'with_shape'"):
 
             @csp.node
-            def foo(x: [str]):
-                __outputs__([ts[int]].with_shape(x=1))
+            def foo(x: List[str]):
+                __outputs__(List[ts[int]].with_shape(x=1))
                 pass
 
         with self.assertRaisesRegex(CspParseError, "__outputs__ must all be named or be single output, cant be both"):
 
             @csp.node
-            def foo(x: [str]):
+            def foo(x: List[str]):
                 __outputs__(ts[int], x=ts[bool])
                 pass
 
         with self.assertRaisesRegex(CspParseError, "__outputs__ single unnamed arg only"):
 
             @csp.node
-            def foo(x: [str]):
+            def foo(x: List[str]):
                 __outputs__(ts[int], ts[bool])
                 pass
 
@@ -70,7 +70,7 @@ class TestParsing(unittest.TestCase):
         ):
 
             @csp.node
-            def foo(x: [str]) -> Outputs(ts[int], ts[bool]):
+            def foo(x: List[str]) -> Outputs(ts[int], ts[bool]):
                 pass
 
         with self.assertRaisesRegex(
@@ -78,7 +78,7 @@ class TestParsing(unittest.TestCase):
         ):
 
             @csp.node
-            def foo(x: [str]) -> Outputs(ts[int], x=ts[bool]):
+            def foo(x: List[str]) -> Outputs(ts[int], x=ts[bool]):
                 pass
 
         with self.assertRaisesRegex(
@@ -86,7 +86,7 @@ class TestParsing(unittest.TestCase):
         ):
 
             @csp.node
-            def foo(x: [str]) -> Outputs(ts[int]):
+            def foo(x: List[str]) -> Outputs(ts[int]):
                 __outputs__(ts[int])
                 pass
 
@@ -96,7 +96,7 @@ class TestParsing(unittest.TestCase):
         ):
 
             @csp.node
-            def foo(x: [str]):
+            def foo(x: List[str]):
                 x = 1
                 __outputs__(ts[int])
 
@@ -1751,11 +1751,11 @@ class TestParsing(unittest.TestCase):
         @csp.node
         def n_cont() -> ts[bool]:
             with csp.alarms():
-                a: ts[[bool]] = csp.alarm([bool])
-                b: ts[[[int]]] = csp.alarm([[int]])
-                c: ts[{str: int}] = csp.alarm({str: int})
-                d: ts[{str: [int]}] = csp.alarm({str: [int]})  # dict of lists
-                e: ts[[{str: bool}]] = csp.alarm([{str: bool}])  # list of dicts
+                a: ts[List[bool]] = csp.alarm(List[bool])
+                b: ts[List[List[int]]] = csp.alarm(List[List[int]])
+                c: ts[Dict[str, int]] = csp.alarm(Dict[str, int])
+                d: ts[Dict[str : List[int]]] = csp.alarm(Dict[str, List[int]])  # dict of lists
+                e: ts[List[Dict[str, bool]]] = csp.alarm(List[Dict[str, bool]])  # list of dicts
 
             with csp.start():
                 csp.schedule_alarm(a, timedelta(seconds=1), [True])

--- a/csp/tests/test_profiler.py
+++ b/csp/tests/test_profiler.py
@@ -9,6 +9,7 @@ import time as Time
 import unittest
 from datetime import date, datetime, time, timedelta
 from functools import reduce
+from typing import List
 
 import csp
 import csp.stats as stats
@@ -143,7 +144,7 @@ class TestProfiler(unittest.TestCase):
 
         # From test_dynamic.py
         @csp.graph
-        def dyn(key: str, val: [str], key_ts: ts[DynData], scalar: str):
+        def dyn(key: str, val: List[str], key_ts: ts[DynData], scalar: str):
             csp.add_graph_output(f"{key}_key", csp.const(key))
             csp.add_graph_output(f"{key}_val", csp.const(val))
             csp.add_graph_output(f"{key}_ts", key_ts)
@@ -154,7 +155,7 @@ class TestProfiler(unittest.TestCase):
         def graph3():
             keys = random_keys(list(string.ascii_uppercase), timedelta(seconds=1), True)
             csp.add_graph_output("keys", keys)
-            basket = gen_basket(keys, csp.null_ts([str]))
+            basket = gen_basket(keys, csp.null_ts(List[str]))
             csp.dynamic(basket, dyn, csp.snapkey(), csp.snap(keys), csp.attach(), "hello world!")
 
         with profiler.Profiler() as p:
@@ -227,7 +228,7 @@ class TestProfiler(unittest.TestCase):
         max_times = df_node.groupby("Node Type").max().reset_index()
         self.assertEqual(
             round(prof_info.node_stats["cast_int_to_float"]["max_time"], 4),
-            round(float(max_times.loc[max_times["Node Type"] == "cast_int_to_float"]["Execution Time"]), 4),
+            round(float(max_times.loc[max_times["Node Type"] == "cast_int_to_float"]["Execution Time"].iloc[0]), 4),
         )
 
         # Cleanup files


### PR DESCRIPTION
Left existing cases in test_parsing.py and test_type_Checking.py to ensure they still work for now (even though they create deprecation messages when running the tests).

See discussion #166 