### PR TITLE
Add "Common Mistakes" page to wiki Sidebar

### DIFF
--- a/docs/wiki/_Sidebar.md
+++ b/docs/wiki/_Sidebar.md
@@ -22,6 +22,7 @@ Notes for editors:
 - [Historical Buffers](Historical-Buffers)
 - [Execution Modes](Execution-Modes)
 - [Adapters](Adapters)
+- [Common Mistakes](Common-Mistakes)
 
 **How-to guides**
 


### PR DESCRIPTION
Omission from #339 