### PR TITLE
Document in detail how duplicate timestamps are handled

### DIFF
--- a/docs/wiki/api-references/Base-Nodes-API.md
+++ b/docs/wiki/api-references/Base-Nodes-API.md
@@ -174,6 +174,7 @@ csp.unroll(x: ts[['T']]) → ts['T']
 Given a timeseries of a *list* of values, unroll will "unroll" the values in the list into a timeseries of the elements.
 `unroll` will ensure to preserve the order across all list ticks.
 Ticks will be unrolled in subsequent engine cycles.
+For a detailed explanation of this behavior, see the documentation on [duplicate timestamps](Execution-Modes#handling-duplicate-timestamps).
 
 ## `csp.collect`
 

--- a/docs/wiki/concepts/Common-Mistakes.md
+++ b/docs/wiki/concepts/Common-Mistakes.md
@@ -74,7 +74,7 @@ from typing import List
 def next_movie_showing(show_times: ts[List[datetime]]) -> ts[datetime]:
     next_showing = None
     for time in show_times:
-        if time >= csp.now(): # list may include some shows today that have already past, so let's filter those out
+        if time >= datetime.now(): # list may include some shows today that have already past, so let's filter those out
             if next_showing is None or time < next_showing:
                 next_showing = time
 


### PR DESCRIPTION
Closes #291 

Fixes mistake from #339 