### PR TITLE
Build librdkafka with gssapi support for pip package, fixes #325

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -191,7 +191,7 @@ endif
 .PHONY: dependencies-mac dependencies-debian dependencies-fedora dependencies-vcpkg dependencies-win
 
 dependencies-mac:  ## install dependencies for mac
-	HOMEBREW_NO_AUTO_UPDATE=1 brew install autoconf autoconf-archive bison cmake flex libtool make ninja pkg-config
+	HOMEBREW_NO_AUTO_UPDATE=1 brew install autoconf autoconf-archive automake bison cmake flex libtool make ninja pkg-config
 	brew unlink bison flex && brew link --force bison flex
 
 dependencies-debian:  ## install dependencies for linux

--- a/Makefile
+++ b/Makefile
@@ -191,14 +191,14 @@ endif
 .PHONY: dependencies-mac dependencies-debian dependencies-fedora dependencies-vcpkg dependencies-win
 
 dependencies-mac:  ## install dependencies for mac
-	HOMEBREW_NO_AUTO_UPDATE=1 brew install bison cmake flex make ninja
+	HOMEBREW_NO_AUTO_UPDATE=1 brew install autoconf autoconf-archive bison cmake flex libtool make ninja pkg-config
 	brew unlink bison flex && brew link --force bison flex
 
 dependencies-debian:  ## install dependencies for linux
-	apt-get install -y automake bison cmake curl flex ninja-build tar unzip zip
+	apt-get install -y autoconf autoconf-archive automake bison cmake curl flex libtool ninja-build pkg-config tar unzip zip
 
 dependencies-fedora:  ## install dependencies for linux
-	yum install -y automake bison ccache cmake curl flex perl-IPC-Cmd tar unzip zip
+	yum install -y autoconf autoconf-archive automake bison ccache cmake curl flex libtool perl-IPC-Cmd pkg-config tar unzip zip
 
 dependencies-vcpkg:  ## install dependencies via vcpkg
 	cd vcpkg && ./bootstrap-vcpkg.sh && ./vcpkg install

--- a/cpp/cmake/modules/FindDepsKafkaAdapter.cmake
+++ b/cpp/cmake/modules/FindDepsKafkaAdapter.cmake
@@ -2,6 +2,11 @@ cmake_minimum_required(VERSION 3.7.2)
 
 if (CSP_USE_VCPKG)
   find_package(RdKafka CONFIG REQUIRED)
+  if(NOT WIN32) 
+    # Bad, but a temporary workaround for
+    # https://github.com/microsoft/vcpkg/issues/40320
+    link_directories(${VCPKG_INSTALLED_DIR}/${VCPKG_TARGET_TRIPLET}/lib)
+  endif()
 else()
   find_package(RdKafka REQUIRED)
 endif()

--- a/cpp/csp/adapters/kafka/CMakeLists.txt
+++ b/cpp/csp/adapters/kafka/CMakeLists.txt
@@ -22,7 +22,7 @@ set_target_properties(csp_kafka_adapter PROPERTIES PUBLIC_HEADER "${KAFKA_HEADER
 
 find_package(DepsKafkaAdapter REQUIRED)
 
-target_link_libraries(csp_kafka_adapter PRIVATE csp_adapter_utils RdKafka::rdkafka RdKafka::rdkafka++)
+target_link_libraries(csp_kafka_adapter PUBLIC csp_adapter_utils RdKafka::rdkafka RdKafka::rdkafka++)
 
 install(TARGETS csp_kafka_adapter
         PUBLIC_HEADER DESTINATION include/csp/adapters/kafka

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -164,6 +164,7 @@ rpm --import https://repo.almalinux.org/almalinux/RPM-GPG-KEY-AlmaLinux &&
 dnf config-manager --set-enabled powertools &&
 dnf install epel-release -y &&
 make dependencies-fedora
+export ACLOCAL_PATH="/usr/share/aclocal:$(printenv ACLOCAL_PATH)"
 """
 environment = {CSP_MANYLINUX="ON"}
 repair-wheel-command = "auditwheel -v show {wheel} && LD_LIBRARY_PATH=/project/csp/lib auditwheel -v repair -w {dest_dir} {wheel}"
@@ -171,7 +172,10 @@ skip = "*i686 musllinux*"
 manylinux-x86_64-image = "manylinux_2_28"
 
 [tool.cibuildwheel.macos]
-before-all ="make dependencies-mac"
+before-all ="""
+make dependencies-mac
+export ACLOCAL_PATH="$(brew --prefix autoconf-archive)/share/aclocal:$(printenv ACLOCAL_PATH)"
+"""
 archs = "x86_64"  # NOTE: we use gcc and we cannot cross compile for now
 
 [tool.cibuildwheel.windows]

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -7,13 +7,29 @@
     "boost-beast",
     "boost-multi-index",
     "brotli",
+    {
+      "name": "cyrus-sasl",
+      "platform": "!windows"
+    },
     "exprtk",
     "gtest",
     {
+      "name": "krb5",
+      "platform": "!windows"
+    },
+    {
       "name": "librdkafka",
       "features": [
+        {
+          "name": "sasl",
+          "platform": "!windows"
+        },
         "ssl"
       ]
+    },
+    {
+      "name": "lmdb",
+      "platform": "!windows"
     },
     "lz4",
     "openssl",
@@ -30,5 +46,5 @@
       "port-version" : 1
     }
   ],
-  "builtin-baseline": "1b5f7346612cd63910567df714d867f5b3fa8e3b"
+  "builtin-baseline": "6af584dd59aa5bdba75dae6781ec74614e03e5b9"
 }


### PR DESCRIPTION
As title, builds `librdkafka` with GSSAPI support via `cyrus-sasl`, enabling this feature for our pip packages (currently this only works on our conda packages). 

No windows support for now as vcpkg krb5 does not support our static build, will make a separate ticket to track

xref: https://github.com/microsoft/vcpkg/issues/40320