### PR TITLE
Replace build with python-build, fix package order

### DIFF
--- a/conda/dev-environment-unix.yml
+++ b/conda/dev-environment-unix.yml
@@ -5,7 +5,6 @@ channels:
 dependencies:
  - bison
  - brotli
- - build
  - bump2version>=1
  - cmake
  - codespell>=2.2.6,<2.3
@@ -15,7 +14,6 @@ dependencies:
  - exprtk
  - flex
  - graphviz
- - python-graphviz
  - gtest
  - httpx>=0.20,<1
  - isort>=5,<6
@@ -33,13 +31,15 @@ dependencies:
  - polars
  - psutil
  - pyarrow=16
- - pytz
  - pytest
  - pytest-asyncio
  - pytest-cov
  - pytest-sugar
  - python<3.13
+ - python-build
+ - python-graphviz
  - python-rapidjson
+ - pytz
  - rapidjson
  - requests
  - ruamel.yaml

--- a/conda/dev-environment-win.yml
+++ b/conda/dev-environment-win.yml
@@ -4,7 +4,6 @@ channels:
   - nodefaults
 dependencies:
  - brotli
- - build
  - bump2version>=1
  - cmake
  - codespell>=2.2.6,<2.3
@@ -36,6 +35,7 @@ dependencies:
  - pytest-cov
  - pytest-sugar
  - python<3.13
+ - python-build
  - python-graphviz
  - python-rapidjson
  - pytz


### PR DESCRIPTION
build feedstock is deprecated: https://github.com/conda-forge/build-feedstock
