### PR TITLE
Change Time::MIN to Time::MIN_VALUE to match DateTime

### DIFF
--- a/cpp/csp/core/Time.h
+++ b/cpp/csp/core/Time.h
@@ -360,7 +360,7 @@ public:
     static Time fromString( const std::string & );
 
     static Time NONE() { return Time( -1 ); }
-    static Time MIN()  { return Time( 0, 0, 0 ); }
+    static Time MIN_VALUE()  { return Time( 0, 0, 0 ); }
 
 private:
     Time( int64_t raw );


### PR DESCRIPTION
Semantically align the "minimum" value for `Time` with `DateTime` & `TimeDelta` (e.g. `::MIN_VALUE`). Also, this avoids conflicts with other headers that rely on a `MIN` macro.