### PR TITLE
Change hidden visibility flag in non-windows builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -172,7 +172,7 @@ else()
     if(CSP_BUILD_NO_CXX_ABI)
         set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -D_GLIBCXX_USE_CXX11_ABI=0")
     endif()
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fvisibility=hidden")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fvisibility=default")
     if (COVERAGE)
         # TODO windows
         add_compile_options(--coverage)


### PR DESCRIPTION
While [this PR](https://github.com/Point72/csp/pull/365) is being worked on, we should change the visibility flag to default.

Ref: #365 