### PR TITLE
Add support for Annotated to struct type.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -225,45 +225,7 @@ message("\n${Green}CMake Search Path: ${CMAKE_MODULE_PATH}${ColorReset}")
 ###################################################################################################################################################
 # Helpers #
 ###########
-# FIXME: consolidate this function with Findcsp_autogen.cmake
-function(csp_autogen MODULE_NAME DEST_FILENAME HEADER_NAME_OUTVAR SOURCE_NAME_OUTVAR)
-    string( REPLACE "." "\/" MODULE_FILENAME ${MODULE_NAME} )
-    string( JOIN "." MODULE_FILENAME ${MODULE_FILENAME} "py" )
-
-    add_custom_target( mkdir_autogen_${MODULE_NAME}
-        ALL COMMAND ${CMAKE_COMMAND} -E make_directory
-        "${CMAKE_CURRENT_BINARY_DIR}/csp_autogen" )
-
-    # VARARGS done by position
-    if(ARGV4)
-        set(CSP_AUTOGEN_EXTRA_ARGS "${ARGV4}")
-    else()
-        set(CSP_AUTOGEN_EXTRA_ARGS "")
-    endif()
-
-    cmake_path(SET CSP_AUTOGEN_MODULE_PATH NORMALIZE "${CMAKE_SOURCE_DIR}/csp/build/csp_autogen.py")
-    cmake_path(SET CSP_AUTOGEN_DESTINATION_FOLDER NORMALIZE "${CMAKE_CURRENT_BINARY_DIR}/csp_autogen")
-    cmake_path(SET CSP_AUTOTGEN_CPP_OUT NORMALIZE "${CMAKE_CURRENT_BINARY_DIR}/csp_autogen/${DEST_FILENAME}.cpp")
-    cmake_path(SET CSP_AUTOTGEN_H_OUT NORMALIZE "${CMAKE_CURRENT_BINARY_DIR}/csp_autogen/${DEST_FILENAME}.h")
-
-    if(${CMAKE_SYSTEM_NAME} MATCHES "Windows")
-        set(CSP_AUTOGEN_PYTHONPATH ${PROJECT_BINARY_DIR}/lib/${CMAKE_BUILD_TYPE};${CMAKE_SOURCE_DIR};%PYTHONPATH% )
-    else()
-        set(CSP_AUTOGEN_PYTHONPATH ${PROJECT_BINARY_DIR}/lib:${CMAKE_SOURCE_DIR}:$$PYTHONPATH )
-    endif()
-
-    add_custom_command(OUTPUT "${CSP_AUTOTGEN_CPP_OUT}" "${CSP_AUTOTGEN_H_OUT}"
-        COMMAND ${CMAKE_COMMAND} -E env "PYTHONPATH=${CSP_AUTOGEN_PYTHONPATH}" ${Python_EXECUTABLE} ${CSP_AUTOGEN_MODULE_PATH} -m ${MODULE_NAME} -d ${CSP_AUTOGEN_DESTINATION_FOLDER} -o ${DEST_FILENAME} ${CSP_AUTOGEN_EXTRA_ARGS}
-        COMMENT "generating csp c++ types from module ${MODULE_NAME}"
-        DEPENDS mkdir_autogen_${MODULE_NAME} 
-                    ${CMAKE_SOURCE_DIR}/csp/build/csp_autogen.py
-                    ${CMAKE_SOURCE_DIR}/${MODULE_FILENAME}
-                    csptypesimpl
-    )
-
-    set(${SOURCE_NAME_OUTVAR} "${CMAKE_CURRENT_BINARY_DIR}/csp_autogen/${DEST_FILENAME}.cpp" PARENT_SCOPE )
-    set(${HEADER_NAME_OUTVAR} "${CMAKE_CURRENT_BINARY_DIR}/csp_autogen/${DEST_FILENAME}.h" PARENT_SCOPE )
-endfunction()
+find_package(csp_autogen REQUIRED)
 
 
 ###################################################################################################################################################

--- a/conda/dev-environment-unix.yml
+++ b/conda/dev-environment-unix.yml
@@ -20,6 +20,7 @@ dependencies:
  - libarrow=16
  - libboost>=1.80.0
  - libboost-headers>=1.80.0
+ - libprotobuf<5
  - librdkafka
  - lz4-c
  - mamba

--- a/conda/dev-environment-win.yml
+++ b/conda/dev-environment-win.yml
@@ -18,6 +18,7 @@ dependencies:
  - libarrow=16
  - libboost>=1.80.0
  - libboost-headers>=1.80.0
+ - libprotobuf<5
  - librdkafka
  - lz4-c
  - make

--- a/cpp/cmake/modules/FindCSP.cmake
+++ b/cpp/cmake/modules/FindCSP.cmake
@@ -29,69 +29,110 @@
 
 cmake_minimum_required(VERSION 3.7.2)
 
-find_package(Python ${CSP_PYTHON_VERSION} EXACT REQUIRED COMPONENTS Interpreter)
 
-set(ENV{PYTHONPATH} "${CMAKE_SOURCE_DIR}/ext:$ENV{PYTHONPATH}")
-
-# Find out the base path
-execute_process(
-  COMMAND "${Python_EXECUTABLE}" -c
-          "from __future__ import print_function;import os.path;import csp;print(os.path.dirname(csp.__file__), end='')"
-          OUTPUT_VARIABLE __csp_base_path)
-
-# Find out the include path
-execute_process(
-  COMMAND "${Python_EXECUTABLE}" -c
-          "from __future__ import print_function;import csp;print(csp.get_include_path(), end='')"
-          OUTPUT_VARIABLE __csp_include_path)
-
-# Find out the lib path
-execute_process(
+if(EXISTS "${CMAKE_SOURCE_DIR}/csp/__init__.py")
+  set(CSP_IN_SOURCE_BUILD ON)
+  set(__csp_base_path "${CMAKE_SOURCE_DIR}/csp")
+  set(__csp_include_path "${CMAKE_SOURCE_DIR}/cpp")
+  set(__csp_lib_path "${CMAKE_SOURCE_DIR}/")
+  set(__csp_base_path "${CMAKE_SOURCE_DIR}/csp")
+  set(__csp_base_path "${CMAKE_SOURCE_DIR}/csp")
+  set(__csp_version "0.0.0")
+else()
+  set(CSP_IN_SOURCE_BUILD OFF)
+  # Find out the base path by interrogating the installed csp
+  find_package(Python ${CSP_PYTHON_VERSION} EXACT REQUIRED COMPONENTS Interpreter)
+  execute_process(
     COMMAND "${Python_EXECUTABLE}" -c
-            "from __future__ import print_function;import csp;print(csp.get_lib_path(), end='')"
-            OUTPUT_VARIABLE __csp_lib_path)
+            "from __future__ import print_function;import os.path;import csp;print(os.path.dirname(csp.__file__), end='')"
+    OUTPUT_VARIABLE __csp_base_path)
 
-# And the version
-execute_process(
-  COMMAND "${Python_EXECUTABLE}" -c
-          "from __future__ import print_function;import csp;print(csp.__version__, end='')"
-  OUTPUT_VARIABLE __csp_version)
+  # Find out the include path
+  execute_process(
+    COMMAND "${Python_EXECUTABLE}" -c
+            "from __future__ import print_function;import csp;print(csp.get_include_path(), end='')"
+    OUTPUT_VARIABLE __csp_include_path)
+
+  # Find out the lib path
+  execute_process(
+    COMMAND "${Python_EXECUTABLE}" -c
+              "from __future__ import print_function;import csp;print(csp.get_lib_path(), end='')"
+    OUTPUT_VARIABLE __csp_lib_path)
+
+  # And the version
+  execute_process(
+    COMMAND "${Python_EXECUTABLE}" -c
+            "from __future__ import print_function;import csp;print(csp.__version__, end='')"
+    OUTPUT_VARIABLE __csp_version)
+endif()
 
 # Now look for files
 find_file(CSP_AUTOGEN csp_autogen.py HINTS "${__csp_base_path}/build" NO_DEFAULT_PATH)
 find_path(CSP_INCLUDE_DIR csp/core/System.h HINTS "${__csp_include_path}" "${PYTHON_INCLUDE_PATH}" NO_DEFAULT_PATH)
-find_path(CSP_LIBS_DIR _cspimpl.so HINTS "${__csp_lib_path}" NO_DEFAULT_PATH)
 
-find_library(CSP_LIBRARY NAMES _cspimpl.so PATHS "${__csp_lib_path}" NO_DEFAULT_PATH)
-find_library(CSP_CORE_LIBRARY NAMES libcsp_core_static.a PATHS "${__csp_lib_path}" NO_DEFAULT_PATH)
-find_library(CSP_ENGINE_LIBRARY NAMES libcsp_engine_static.a PATHS "${__csp_lib_path}" NO_DEFAULT_PATH)
+if(CSP_IN_SOURCE_BUILD)
+  set(CSP_LIBS_DIR "${CMAKE_BINARY_DIR}/lib")
+  set(CSP_LIBRARY "${CSP_LIBS_DIR}/_cspimpl.so")
+  set(CSP_CORE_LIBRARY "${CSP_LIBS_DIR}/libcsp_core_static.a")
+  set(CSP_ENGINE_LIBRARY "${CSP_LIBS_DIR}/libcsp_engine_static.a")
+  set(CSP_TYPES_LIBRARY "${CSP_LIBS_DIR}/_csptypesimpl.so")
+  set(CSP_TYPES_LIBRARY_FOR_AUTOGEN "csptypesimpl")  # NOTE: this is handled a bit specially in-source
+  set(CSP_TYPES_STATIC_LIBRARY "${CSP_LIBS_DIR}/libcsp_types_static.a")
+  set(CSP_BASELIB_LIBARY "${CSP_LIBS_DIR}/_cspbaselibimpl.so")
+  set(CSP_BASELIB_STATIC_LIBRARY "${CSP_LIBS_DIR}/libbaselibimpl_static.a")
+  set(CSP_BASKETLIB_LIBRARY "${CSP_LIBS_DIR}/_cspbasketlibimpl.so")
+  set(CSP_BASKETLIB_STATIC_LIBRARY "${CSP_LIBS_DIR}/libbasketlibimpl_static.a")
+  set(CSP_TESTLIB_LIBRARY "${CSP_LIBS_DIR}/_csptestlibimpl.so")
+  set(CSP_MATH_LIBRARY "${CSP_LIBS_DIR}/_cspmathimpl.so")
+  set(CSP_MATH_STATIC_LIBRARY "${CSP_LIBS_DIR}/libmathimpl_static.a")
+  set(CSP_STATS_LIBRARY "${CSP_LIBS_DIR}/_cspstatsimpl.so")
+  set(CSP_STATS_STATIC_LIBRARY "${CSP_LIBS_DIR}/libstatsimpl_static.a")
+  set(CSP_NPSTATS_LIBRARY "${CSP_LIBS_DIR}/_cspnpstatsimpl.so")
+  set(CSP_ADAPTER_UTILS_LIBRARY "${CSP_LIBS_DIR}/libcsp_adapter_utils_static.a")
+  set(CSP_KAFKAADAPTER_LIBRARY "${CSP_LIBS_DIR}/_kafkaadapterimpl.so")
+  set(CSP_KAFKAADAPTER_STATIC_LIBRARY "${CSP_LIBS_DIR}/libcsp_kafka_adapter_static.a")
+  set(CSP_PARQUETADAPTER_LIBRARY "${CSP_LIBS_DIR}/_parquetadapterimpl.so")
+  set(CSP_PARQUETADAPTER_STATIC_LIBRARY "${CSP_LIBS_DIR}/libcsp_parquet_adapter_static.a")
+  set(CSP_WEBSOCKETADAPTER_LIBRARY "${CSP_LIBS_DIR}/_websocketadapterimpl.so")
+  set(CSP_WEBSOCKETADAPTER_STATIC_LIBRARY "${CSP_LIBS_DIR}/libcsp_websocket_client_adapter_static.a")
+else()
+  find_path(CSP_LIBS_DIR _cspimpl.so HINTS "${__csp_lib_path}" NO_DEFAULT_PATH)
 
-find_library(CSP_TYPES_LIBRARY NAMES _csptypesimpl.so PATHS "${__csp_lib_path}" NO_DEFAULT_PATH)
-find_library(CSP_TYPES_STATIC_LIBRARY NAMES libcsp_types_static.a PATHS "${__csp_lib_path}" NO_DEFAULT_PATH)
+  find_library(CSP_LIBRARY NAMES _cspimpl.so PATHS "${__csp_lib_path}" NO_DEFAULT_PATH)
+  find_library(CSP_CORE_LIBRARY NAMES libcsp_core_static.a PATHS "${__csp_lib_path}" NO_DEFAULT_PATH)
+  find_library(CSP_ENGINE_LIBRARY NAMES libcsp_engine_static.a PATHS "${__csp_lib_path}" NO_DEFAULT_PATH)
 
-find_library(CSP_BASELIB_LIBARY NAMES _cspbaselibimpl.so PATHS "${__csp_lib_path}" NO_DEFAULT_PATH)
-find_library(CSP_BASELIB_STATIC_LIBRARY NAMES libbaselibimpl_static.a PATHS "${__csp_lib_path}" NO_DEFAULT_PATH)
+  find_library(CSP_TYPES_LIBRARY NAMES _csptypesimpl.so PATHS "${__csp_lib_path}" NO_DEFAULT_PATH)
+  set(CSP_TYPES_LIBRARY_FOR_AUTOGEN "${CSP_TYPES_LIBRARY}")
+  find_library(CSP_TYPES_STATIC_LIBRARY NAMES libcsp_types_static.a PATHS "${__csp_lib_path}" NO_DEFAULT_PATH)
 
-find_library(CSP_BASKETLIB_LIBRARY NAMES _cspbasketlibimpl.so PATHS "${__csp_lib_path}" NO_DEFAULT_PATH)
-find_library(CSP_BASKETLIB_STATIC_LIBRARY NAMES libbasketlibimpl_static.a PATHS "${__csp_lib_path}" NO_DEFAULT_PATH)
+  find_library(CSP_BASELIB_LIBARY NAMES _cspbaselibimpl.so PATHS "${__csp_lib_path}" NO_DEFAULT_PATH)
+  find_library(CSP_BASELIB_STATIC_LIBRARY NAMES libbaselibimpl_static.a PATHS "${__csp_lib_path}" NO_DEFAULT_PATH)
 
-find_library(CSP_TESTLIB_LIBRARY NAMES _csptestlibimpl.so PATHS "${__csp_lib_path}" NO_DEFAULT_PATH)
+  find_library(CSP_BASKETLIB_LIBRARY NAMES _cspbasketlibimpl.so PATHS "${__csp_lib_path}" NO_DEFAULT_PATH)
+  find_library(CSP_BASKETLIB_STATIC_LIBRARY NAMES libbasketlibimpl_static.a PATHS "${__csp_lib_path}" NO_DEFAULT_PATH)
 
-find_library(CSP_MATH_LIBRARY NAMES _cspmathimpl.so PATHS "${__csp_lib_path}" NO_DEFAULT_PATH)
-find_library(CSP_MATH_STATIC_LIBRARY NAMES libmathimpl_static.a PATHS "${__csp_lib_path}" NO_DEFAULT_PATH)
+  find_library(CSP_TESTLIB_LIBRARY NAMES _csptestlibimpl.so PATHS "${__csp_lib_path}" NO_DEFAULT_PATH)
 
-find_library(CSP_STATS_LIBRARY NAMES _cspstatsimpl.so PATHS "${__csp_lib_path}" NO_DEFAULT_PATH)
-find_library(CSP_STATS_STATIC_LIBRARY NAMES libstatsimpl_static.a PATHS "${__csp_lib_path}" NO_DEFAULT_PATH)
+  find_library(CSP_MATH_LIBRARY NAMES _cspmathimpl.so PATHS "${__csp_lib_path}" NO_DEFAULT_PATH)
+  find_library(CSP_MATH_STATIC_LIBRARY NAMES libmathimpl_static.a PATHS "${__csp_lib_path}" NO_DEFAULT_PATH)
 
-find_library(CSP_NPSTATS_LIBRARY NAMES _cspnpstatsimpl.so PATHS "${__csp_lib_path}" NO_DEFAULT_PATH)
+  find_library(CSP_STATS_LIBRARY NAMES _cspstatsimpl.so PATHS "${__csp_lib_path}" NO_DEFAULT_PATH)
+  find_library(CSP_STATS_STATIC_LIBRARY NAMES libstatsimpl_static.a PATHS "${__csp_lib_path}" NO_DEFAULT_PATH)
 
-find_library(CSP_ADAPTER_UTILS_LIBRARY NAMES libcsp_adapter_utils_static.a PATHS "${__csp_lib_path}" NO_DEFAULT_PATH)
+  find_library(CSP_NPSTATS_LIBRARY NAMES _cspnpstatsimpl.so PATHS "${__csp_lib_path}" NO_DEFAULT_PATH)
 
-find_library(CSP_KAFKAADAPTER_LIBRARY NAMES _kafkaadapterimpl.so PATHS "${__csp_lib_path}" NO_DEFAULT_PATH)
-find_library(CSP_KAFKAADAPTER_STATIC_LIBRARY NAMES libcsp_kafka_adapter_static.a PATHS "${__csp_lib_path}" NO_DEFAULT_PATH)
+  find_library(CSP_ADAPTER_UTILS_LIBRARY NAMES libcsp_adapter_utils_static.a PATHS "${__csp_lib_path}" NO_DEFAULT_PATH)
 
-find_library(CSP_PARQUETADAPTER_LIBRARY NAMES _parquetadapterimpl.so PATHS "${__csp_lib_path}" NO_DEFAULT_PATH)
-find_library(CSP_PARQUETADAPTER_STATIC_LIBRARY NAMES libcsp_parquet_adapter_static.a PATHS "${__csp_lib_path}" NO_DEFAULT_PATH)
+  find_library(CSP_KAFKAADAPTER_LIBRARY NAMES _kafkaadapterimpl.so PATHS "${__csp_lib_path}" NO_DEFAULT_PATH)
+  find_library(CSP_KAFKAADAPTER_STATIC_LIBRARY NAMES libcsp_kafka_adapter_static.a PATHS "${__csp_lib_path}" NO_DEFAULT_PATH)
+
+  find_library(CSP_PARQUETADAPTER_LIBRARY NAMES _parquetadapterimpl.so PATHS "${__csp_lib_path}" NO_DEFAULT_PATH)
+  find_library(CSP_PARQUETADAPTER_STATIC_LIBRARY NAMES libcsp_parquet_adapter_static.a PATHS "${__csp_lib_path}" NO_DEFAULT_PATH)
+
+  find_library(CSP_WEBSOCKETADAPTER_LIBRARY NAMES _websocketadapterimpl.so PATHS "${__csp_lib_path}" NO_DEFAULT_PATH)
+  find_library(CSP_WEBSOCKETADAPTER_STATIC_LIBRARY NAMES libcsp_websocket_client_adapter_static.a PATHS "${__csp_lib_path}" NO_DEFAULT_PATH)
+endif()
 
 if(CSP_INCLUDE_DIR AND CSP_LIBS_DIR AND CSP_AUTOGEN)
   set(CSP_FOUND 1 CACHE INTERNAL "CSP found")
@@ -99,5 +140,3 @@ endif()
 
 include(FindPackageHandleStandardArgs)
 find_package_handle_standard_args(CSP REQUIRED_VARS CSP_INCLUDE_DIR CSP_LIBS_DIR CSP_AUTOGEN VERSION_VAR __csp_version)
-
-find_package(csp_autogen)

--- a/cpp/csp/core/Platform.h
+++ b/cpp/csp/core/Platform.h
@@ -90,7 +90,6 @@ inline uint8_t ffs(uint64_t n)
 }
 
 #else
-
 #define CSPIMPL_EXPORT      __attribute__ ((visibility ("default")))
 #define CSPTYPESIMPL_EXPORT __attribute__ ((visibility ("default")))
 

--- a/csp/impl/types/container_type_normalizer.py
+++ b/csp/impl/types/container_type_normalizer.py
@@ -1,5 +1,6 @@
 import numpy
 import typing
+import typing_extensions
 
 import csp.typing
 from csp.impl.types.typing_utils import CspTypingUtils, FastList
@@ -70,6 +71,8 @@ class ContainerTypeNormalizer:
 
     @classmethod
     def normalized_type_to_actual_python_type(cls, typ, level=0):
+        if isinstance(typ, typing_extensions._AnnotatedAlias):
+            typ = CspTypingUtils.get_origin(typ)
         if CspTypingUtils.is_generic_container(typ):
             if CspTypingUtils.get_origin(typ) is FastList and level == 0:
                 return [cls.normalized_type_to_actual_python_type(typ.__args__[0], level + 1), True]

--- a/csp/tests/impl/test_struct.py
+++ b/csp/tests/impl/test_struct.py
@@ -7,6 +7,7 @@ import typing
 import unittest
 from datetime import date, datetime, time, timedelta
 from typing import Dict, List, Set, Tuple
+from typing_extensions import Annotated
 
 import csp
 from csp.impl.struct import define_nested_struct, define_struct, defineNestedStruct, defineStruct
@@ -2942,6 +2943,22 @@ class TestCspStruct(unittest.TestCase):
         self.assertIn("update", dir_output)
         self.assertIn("__metadata__", dir_output)
         self.assertEqual(dir_output, sorted(dir_output))
+
+    def test_annotations(self):
+        class StructWithAnnotations(csp.Struct):
+            b: Annotated[float, "test"]
+            d: Annotated[Dict[str, Annotated[int, "test_int"]], "test_dict"]
+            s: str
+
+        self.assertEqual(
+            StructWithAnnotations.metadata(typed=True),
+            {
+                "b": Annotated[float, "test"],
+                "d": Annotated[Dict[str, Annotated[int, "test_int"]], "test_dict"],
+                "s": str,
+            },
+        )
+        self.assertEqual(StructWithAnnotations.metadata(typed=False), {"b": float, "d": dict, "s": str})
 
 
 if __name__ == "__main__":

--- a/examples/05_cpp/2_cpp_node_with_struct/CMakeLists.txt
+++ b/examples/05_cpp/2_cpp_node_with_struct/CMakeLists.txt
@@ -13,6 +13,7 @@ else()
 endif()
 
 list(PREPEND CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/../../../cpp/cmake/modules")
+set(ENV{PYTHONPATH} "${CMAKE_SOURCE_DIR}/../../../:$ENV{PYTHONPATH}")
 
 set(CMAKE_MACOSX_RPATH TRUE)
 set(CMAKE_SKIP_RPATH FALSE)
@@ -100,6 +101,7 @@ find_package(CSP REQUIRED)
 message("${Cyan}Found CSP:\n\tincludes in: ${CSP_INCLUDE_DIR}\n\tlibraries in: ${CSP_LIBS_DIR}${ColorReset}")
 include_directories(${CSP_INCLUDE_DIR})
 
+find_package(csp_autogen REQUIRED)
 csp_autogen(mystruct.struct mystruct STRUCT_AUTOGEN_HEADER STRUCT_AUTOGEN_SOURCE)
 
 add_library(mystruct SHARED struct.cpp ${STRUCT_AUTOGEN_SOURCE})

--- a/examples/05_cpp/2_cpp_node_with_struct/README.md
+++ b/examples/05_cpp/2_cpp_node_with_struct/README.md
@@ -11,5 +11,5 @@ python setup.py build build_ext --inplace
 Run:
 
 ```bash
-python -m struct
+python -m mystruct
 ```

--- a/examples/05_cpp/2_cpp_node_with_struct/struct.cpp
+++ b/examples/05_cpp/2_cpp_node_with_struct/struct.cpp
@@ -36,7 +36,7 @@ DECLARE_CPPNODE(use_struct_generic)
       switchCspType(  m_fieldAccess -> type(), [this,&copy]( auto tag )
       {
         using ElemT  = typename decltype(tag)::type;
-        if(std::is_same<ElemT, binding_int_t>()) {
+        if(std::is_same<ElemT, int>()) {
           m_fieldAccess -> setValue( copy.get(), 0);
         }
       });


### PR DESCRIPTION
Resolves #373
See test case for usage/impact.

Annotations are particularly useful for adding information about validation and serialization at a field level (or any other field level metadata). Their use is completely optional and they are ignored pretty much everywhere unless you call Struct.metadata(typed=True). 