### PR TITLE
Add support for Annotated to struct type.

### DIFF
--- a/conda/dev-environment-unix.yml
+++ b/conda/dev-environment-unix.yml
@@ -52,6 +52,7 @@ dependencies:
  - threadpoolctl
  - tornado
  - twine
+ - typing-extensions
  - unzip
  - wheel
  - zip

--- a/conda/dev-environment-win.yml
+++ b/conda/dev-environment-win.yml
@@ -50,4 +50,5 @@ dependencies:
  - threadpoolctl
  - tornado
  - twine
+ - typing-extensions
  - wheel

--- a/csp/impl/types/container_type_normalizer.py
+++ b/csp/impl/types/container_type_normalizer.py
@@ -1,5 +1,6 @@
 import numpy
 import typing
+import typing_extensions
 
 import csp.typing
 from csp.impl.types.typing_utils import CspTypingUtils, FastList
@@ -70,6 +71,8 @@ class ContainerTypeNormalizer:
 
     @classmethod
     def normalized_type_to_actual_python_type(cls, typ, level=0):
+        if isinstance(typ, typing_extensions._AnnotatedAlias):
+            typ = CspTypingUtils.get_origin(typ)
         if CspTypingUtils.is_generic_container(typ):
             if CspTypingUtils.get_origin(typ) is FastList and level == 0:
                 return [cls.normalized_type_to_actual_python_type(typ.__args__[0], level + 1), True]

--- a/csp/tests/impl/test_struct.py
+++ b/csp/tests/impl/test_struct.py
@@ -7,6 +7,7 @@ import typing
 import unittest
 from datetime import date, datetime, time, timedelta
 from typing import Dict, List, Set, Tuple
+from typing_extensions import Annotated
 
 import csp
 from csp.impl.struct import define_nested_struct, define_struct, defineNestedStruct, defineStruct
@@ -2942,6 +2943,22 @@ class TestCspStruct(unittest.TestCase):
         self.assertIn("update", dir_output)
         self.assertIn("__metadata__", dir_output)
         self.assertEqual(dir_output, sorted(dir_output))
+
+    def test_annotations(self):
+        class StructWithAnnotations(csp.Struct):
+            b: Annotated[float, "test"]
+            d: Annotated[Dict[str, Annotated[int, "test_int"]], "test_dict"]
+            s: str
+
+        self.assertEqual(
+            StructWithAnnotations.metadata(typed=True),
+            {
+                "b": Annotated[float, "test"],
+                "d": Annotated[Dict[str, Annotated[int, "test_int"]], "test_dict"],
+                "s": str,
+            },
+        )
+        self.assertEqual(StructWithAnnotations.metadata(typed=False), {"b": float, "d": dict, "s": str})
 
 
 if __name__ == "__main__":

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,6 +7,7 @@ requires = [
     "ruamel.yaml",
     "scikit-build",
     "setuptools>=69,<74",
+    "typing-extensions",
 ]
 build-backend="setuptools.build_meta"
 
@@ -29,6 +30,7 @@ dependencies = [
     "pytz",
     "ruamel.yaml",
     "sqlalchemy",
+    "typing-extensions",
 ]
 
 classifiers = [


### PR DESCRIPTION
Resolves https://github.com/Point72/csp/issues/373
See test case for usage/impact.

Annotations are particularly useful for adding information about validation and serialization at a field level (or any other field level metadata). Their use is completely optional and they are ignored pretty much everywhere unless you call Struct.metadata(typed=True).