### PR TITLE
Support protobuf 5

### DIFF
--- a/conda/dev-environment-unix.yml
+++ b/conda/dev-environment-unix.yml
@@ -20,7 +20,7 @@ dependencies:
  - libarrow=16
  - libboost>=1.80.0
  - libboost-headers>=1.80.0
- - libprotobuf<5
+ - libprotobuf
  - librdkafka
  - lz4-c
  - mamba

--- a/conda/dev-environment-win.yml
+++ b/conda/dev-environment-win.yml
@@ -18,7 +18,7 @@ dependencies:
  - libarrow=16
  - libboost>=1.80.0
  - libboost-headers>=1.80.0
- - libprotobuf<5
+ - libprotobuf
  - librdkafka
  - lz4-c
  - make

--- a/cpp/csp/adapters/utils/ProtobufHelper.cpp
+++ b/cpp/csp/adapters/utils/ProtobufHelper.cpp
@@ -3,6 +3,7 @@
 #include <csp/core/Platform.h>
 #include <csp/core/System.h>
 #include <csp/engine/PartialSwitchCspType.h>
+#include <absl/strings/string_view.h>
 
 namespace proto = google::protobuf;
 
@@ -28,12 +29,12 @@ public:
         return m_pool.FindFileByName( filename );
     }
 
-    void AddError( const std::string& filename, int line, int column,
-                   const std::string& message ) override
+    void RecordError( absl::string_view filename, int line, int column,
+                      absl::string_view message ) override
     {
-        CSP_THROW( RuntimeException, "Failed to load proto schema " << filename << ":" << line << ":" << column << ": " << message );
+        CSP_THROW( RuntimeException, "Failed to load proto schema " << std::string(filename) << ":" << line << ":" << column << ": " << message );
     }
-    
+
 private:
     proto::DescriptorPoolDatabase                 m_wellKnownTypesDatabase;
     proto::compiler::SourceTreeDescriptorDatabase m_database;


### PR DESCRIPTION
Change should be backward compatible with protobuf 4 (`AddError` was present but deprecated, `RecordError` present)

This is enforced (for now) via CI as conda has 5 but vcpkg has 4 (xref https://github.com/microsoft/vcpkg/pull/39800)