### PR TITLE
Revert symbol visibility changes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -172,7 +172,6 @@ else()
     if(CSP_BUILD_NO_CXX_ABI)
         set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -D_GLIBCXX_USE_CXX11_ABI=0")
     endif()
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fvisibility=hidden")
     if (COVERAGE)
         # TODO windows
         add_compile_options(--coverage)

--- a/Makefile
+++ b/Makefile
@@ -26,9 +26,6 @@ build-debug:  ## build the library ( DEBUG ) - May need a make clean when switch
 build-conda:  ## build the library in Conda
 	python setup.py build build_ext --csp-no-vcpkg --inplace
 
-build-conda-debug:  ## build the library ( DEBUG ) - in Conda
-	SKBUILD_CONFIGURE_OPTIONS="" DEBUG=1 python setup.py build build_ext --csp-no-vcpkg --inplace
-
 install:  ## install library
 	python -m pip install .
 

--- a/cpp/csp/adapters/kafka/KafkaAdapterManager.h
+++ b/cpp/csp/adapters/kafka/KafkaAdapterManager.h
@@ -47,7 +47,7 @@ protected:
 using KafkaStatusMessageType = csp::Enum<KafkaStatusMessageTypeTraits>;
 
 //Top level AdapterManager object for all kafka adapters in the engine
-class CSP_PUBLIC KafkaAdapterManager final : public csp::AdapterManager
+class KafkaAdapterManager final : public csp::AdapterManager
 {
 public:
     KafkaAdapterManager( csp::Engine * engine, const Dictionary & properties );

--- a/cpp/csp/adapters/parquet/DialectGenericListReaderInterface.h
+++ b/cpp/csp/adapters/parquet/DialectGenericListReaderInterface.h
@@ -25,7 +25,7 @@ public:
 };
 
 template< typename T >
-class CSP_PUBLIC TypedDialectGenericListReaderInterface : public DialectGenericListReaderInterface
+class TypedDialectGenericListReaderInterface : public DialectGenericListReaderInterface
 {
 public:
     using Ptr = std::shared_ptr<TypedDialectGenericListReaderInterface<T>>;

--- a/cpp/csp/adapters/parquet/ParquetInputAdapterManager.h
+++ b/cpp/csp/adapters/parquet/ParquetInputAdapterManager.h
@@ -18,7 +18,7 @@ namespace csp::adapters::parquet
 
 
 //Top level AdapterManager object for all parquet adapters in the engine
-class CSP_PUBLIC ParquetInputAdapterManager final : public csp::AdapterManager
+class ParquetInputAdapterManager final : public csp::AdapterManager
 {
 public:
     using GeneratorPtr = csp::Generator<std::string, csp::DateTime, csp::DateTime>::Ptr;

--- a/cpp/csp/adapters/parquet/ParquetOutputAdapterManager.h
+++ b/cpp/csp/adapters/parquet/ParquetOutputAdapterManager.h
@@ -21,7 +21,7 @@ class ParquetOutputFilenameAdapter;
 class ParquetDictBasketOutputWriter;
 
 //Top level AdapterManager object for all parquet adapters in the engine
-class CSP_PUBLIC ParquetOutputAdapterManager final : public csp::AdapterManager
+class ParquetOutputAdapterManager final : public csp::AdapterManager
 {
 public:
     using FileVisitorCallback = std::function<void(const std::string &)>;

--- a/cpp/csp/adapters/parquet/ParquetReaderColumnAdapter.cpp
+++ b/cpp/csp/adapters/parquet/ParquetReaderColumnAdapter.cpp
@@ -734,7 +734,7 @@ void ListColumnAdapter<ValueArrayType, ValueType>::readCurValue()
     if( this -> m_curChunkArray -> IsValid( curRow ) )
     {
         auto values      = this -> m_curChunkArray -> value_slice( curRow );
-        auto typedValues = std::static_pointer_cast<ValueArrayType>( values );
+        auto typedValues = std::dynamic_pointer_cast<ValueArrayType>( values );
 
         auto arrayValue     = m_listReader -> create( typedValues -> length() );
         auto* internalBuffer = m_listReader -> getRawDataBuffer( arrayValue );

--- a/cpp/csp/adapters/websocket/ClientAdapterManager.h
+++ b/cpp/csp/adapters/websocket/ClientAdapterManager.h
@@ -40,8 +40,10 @@ protected:
 
 using ClientStatusType = Enum<WebsocketClientStatusTypeTraits>;
 
-class CSP_PUBLIC ClientAdapterManager final : public AdapterManager
+class ClientAdapterManager final : public AdapterManager
 {
+
+
 public:
     ClientAdapterManager(
         Engine * engine,

--- a/cpp/csp/core/Exception.h
+++ b/cpp/csp/core/Exception.h
@@ -10,7 +10,7 @@
 namespace csp
 {
 
-class CSP_PUBLIC Exception : public std::exception
+class Exception : public std::exception
 {
 public:
     Exception( const char * exType, const std::string & description, const char * file, const char * func, int line ) :
@@ -59,7 +59,7 @@ private:
 };
 
 #define __FILENAME__ (strrchr(__FILE__, '/') ? strrchr(__FILE__, '/') + 1 : __FILE__)
-#define CSP_DECLARE_EXCEPTION( DerivedException, BaseException ) class CSP_PUBLIC DerivedException : public BaseException { public: DerivedException( const char * exType, const std::string &r, const char * file, const char * func, int line ) : BaseException( exType, r, file, func, line ) {} };
+#define CSP_DECLARE_EXCEPTION( DerivedException, BaseException ) class DerivedException : public BaseException { public: DerivedException( const char * exType, const std::string &r, const char * file, const char * func, int line ) : BaseException( exType, r, file, func, line ) {} };
 
 CSP_DECLARE_EXCEPTION( AssertionError,     Exception )
 CSP_DECLARE_EXCEPTION( RuntimeException,   Exception )

--- a/cpp/csp/core/Platform.h
+++ b/cpp/csp/core/Platform.h
@@ -14,8 +14,7 @@
 #undef ERROR
 #undef GetMessage
 
-#define CSP_LOCAL
-#define CSP_PUBLIC __declspec(dllexport)
+#define DLL_LOCAL
 
 #ifdef CSPTYPESIMPL_EXPORTS
 #define CSPTYPESIMPL_EXPORT __declspec(dllexport)
@@ -90,11 +89,11 @@ inline uint8_t ffs(uint64_t n)
 }
 
 #else
-#define CSPIMPL_EXPORT      __attribute__ ((visibility ("default")))
-#define CSPTYPESIMPL_EXPORT __attribute__ ((visibility ("default")))
 
-#define CSP_LOCAL  __attribute__ ((visibility ("hidden")))
-#define CSP_PUBLIC __attribute__ ((visibility ("default")))
+#define CSPIMPL_EXPORT
+#define CSPTYPESIMPL_EXPORT
+
+#define DLL_LOCAL __attribute__ ((visibility ("hidden")))
 
 #define START_PACKED
 #define END_PACKED __attribute__((packed))

--- a/cpp/csp/engine/AdapterManager.h
+++ b/cpp/csp/engine/AdapterManager.h
@@ -93,7 +93,7 @@ bool ManagedSimInputAdapter::pushNullTick()
     return true;
 }
 
-class CSP_PUBLIC AdapterManager : public EngineOwned
+class AdapterManager : public EngineOwned
 {
 public:
     AdapterManager( csp::Engine * );

--- a/cpp/csp/engine/Feedback.h
+++ b/cpp/csp/engine/Feedback.h
@@ -28,7 +28,7 @@ private:
 };
 
 template<typename T>
-class CSP_PUBLIC FeedbackInputAdapter final : public InputAdapter
+class FeedbackInputAdapter final : public InputAdapter
 {
 public:
     using InputAdapter::InputAdapter;

--- a/cpp/csp/engine/Struct.h
+++ b/cpp/csp/engine/Struct.h
@@ -756,13 +756,13 @@ private:
     void decref()
     {
 //Work around GCC12 bug mis-identifying this code as use-after-free
-#if defined(__linux__) && !defined(__clang__)
+#ifdef __linux__
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wuse-after-free"
 #endif
         if( --hidden() -> refcount == 0 )
             delete this;
-#if defined(__linux__) && !defined(__clang__)
+#ifdef __linux__
 #pragma GCC diagnostic pop
 #endif
     }

--- a/cpp/csp/python/Exception.h
+++ b/cpp/csp/python/Exception.h
@@ -8,7 +8,7 @@
 namespace csp::python
 {
 
-class CSP_PUBLIC PythonPassthrough : public csp::Exception
+class PythonPassthrough : public csp::Exception
 {
 public:
     PythonPassthrough( const char * exType, const std::string &r, const char * file,

--- a/cpp/csp/python/InitHelper.h
+++ b/cpp/csp/python/InitHelper.h
@@ -10,7 +10,7 @@
 namespace csp::python
 {
 
-class CSP_LOCAL InitHelper
+class DLL_LOCAL InitHelper
 {
 public:
     ~InitHelper() {}
@@ -111,21 +111,4 @@ inline bool InitHelper::execute( PyObject * module )
 }
 
 }
-
-//PyMODINIT_FUNC in Python <3.9 doesn't export the function/make visible
-//this is required since we build with hidden visibility by default
-//the below macro code can be removed once 3.8 support is dropped
-//
-//see similar issues:
-//https://github.com/scipy/scipy/issues/15996
-//https://github.com/mesonbuild/meson/pull/10369
-
-#if PY_VERSION_HEX < 0x03090000
-#ifdef PyMODINIT_FUNC
-#undef PyMODINIT_FUNC
-#endif
-
-#define PyMODINIT_FUNC extern "C" CSP_PUBLIC PyObject*
-#endif
-
 #endif

--- a/cpp/csp/python/PyCspEnum.h
+++ b/cpp/csp/python/PyCspEnum.h
@@ -27,7 +27,7 @@ struct CSPTYPESIMPL_EXPORT PyCspEnumMeta : public PyHeapTypeObject
     static PyTypeObject PyType;
 };
 
-//TODO Windows - need to figure out why adding CSP_PUBLIC to this class leads to weird compilation errors on CspEnumMeta's unordered_map...
+//TODO Windows - need to figure out why adding DLL_PUBLIC to this class leads to weird compilation errors on CspEnumMeta's unordered_map...
 
 //This is an extension of csp::CspEnumMeta for python dialect, we need it in order to 
 //keep a reference to the python enum type from conversion to/from csp::CspEnumMeta <-> PyObject properly

--- a/cpp/csp/python/adapters/CMakeLists.txt
+++ b/cpp/csp/python/adapters/CMakeLists.txt
@@ -35,7 +35,7 @@ if(CSP_BUILD_PARQUET_ADAPTER)
     endif()
     target_link_libraries(parquetadapterimpl csp_core csp_engine cspimpl csp_parquet_adapter)
     target_include_directories(parquetadapterimpl PUBLIC ${ARROW_INCLUDE_DIR} ${PARQUET_INCLUDE_DIR} "${VENDORED_PYARROW_ROOT}")
-    target_compile_definitions(parquetadapterimpl PUBLIC ARROW_PYTHON_STATIC -DARROW_PYTHON_EXPORT=)
+    target_compile_definitions(parquetadapterimpl PUBLIC ARROW_PYTHON_STATIC)
     install(TARGETS parquetadapterimpl RUNTIME DESTINATION ${CSP_RUNTIME_INSTALL_SUBDIR} )
 endif()
 

--- a/csp/build/csp_autogen.py
+++ b/csp/build/csp_autogen.py
@@ -152,7 +152,7 @@ namespace {self._namespace}
         cspenum_decls = "\n".join(f"    static {enum_name} {x.name};" for x in enum_type)
 
         out = f"""
-class CSP_PUBLIC {enum_name} : public csp::CspEnum
+class {enum_name} : public csp::CspEnum
 {{
 public:
     // Raw value quick access
@@ -315,7 +315,7 @@ private:
             )
 
         out = f"""
-class CSP_PUBLIC {struct_name} : public {base_class}
+class {struct_name} : public {base_class}
 {{
 public:
 


### PR DESCRIPTION
@svatasoiu and I have been trying for a while to get symbol visibility correct for users wanting to build extension modules. Unfortunately there have been some complications with Windows support so in the meantime, we will revert the hidden visibility change we made earlier.

Confirmed that the example extension modules work again after this reversion.