### PR TITLE
Fix table formatting in the examples README

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -11,7 +11,7 @@
     <tbody>
         <!-- Basic -->
         <tr>
-            <td rowspan=4><a href="./01_basics/">Basics</a></td>
+            <td rowspan=5><a href="./01_basics/">Basics</a></td>
             <td><a href="./01_basics/e1_basic.py">Basic Graph</a></td>
             <td>Basic sum of constant integers</td>
         </tr>


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/642d691a-e569-4c47-8528-0e5a27e89f42)

Fixes the formatting issue for "Complete Example (Retail)"