### PR TITLE
Remove macos-12 runner as it is fully unsupported as of 2024-12-03 

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -174,7 +174,7 @@ jobs:
         matrix:
           os:
             - ubuntu-24.04 # https://github.com/actions/runner-images/blob/main/images/ubuntu/Ubuntu2404-Readme.md
-            - macos-12 # https://github.com/actions/runner-images/blob/main/images/macos/macos-12-Readme.md
+            - macos-13 # https://github.com/actions/runner-images/blob/main/images/macos/macos-13-Readme.md
             - macos-14 # https://github.com/actions/runner-images/blob/main/images/macos/macos-14-arm64-Readme.md
             - windows-2019 # https://github.com/actions/runner-images/blob/main/images/windows/Windows2019-Readme.md
           python-version:
@@ -267,7 +267,7 @@ jobs:
 
             # avoid unnecessary use of mac resources
             - is-full-run: false
-              os: macos-12
+              os: macos-13
 
             - is-full-run: false
               os: macos-14
@@ -323,7 +323,7 @@ jobs:
             CIBW_ENVIRONMENT_MACOS: CCACHE_DIR="/Users/runner/work/csp/csp/.ccache" VCPKG_DEFAULT_BINARY_CACHE="${{ env.VCPKG_DEFAULT_BINARY_CACHE }}" VCPKG_DOWNLOADS="${{ env.VCPKG_DOWNLOADS }}"
             CIBW_ARCHS_MACOS: x86_64
             CIBW_BUILD_VERBOSITY: 3
-          if: ${{ matrix.os == 'macos-12' }}
+          if: ${{ matrix.os == 'macos-13' }}
 
         - name: Python Build Steps (Macos arm)
           run: make dist-py-cibw
@@ -439,7 +439,7 @@ jobs:
         matrix:
           os:
             - ubuntu-24.04
-            - macos-12
+            - macos-13
             - macos-14
             - windows-2019
           python-version:
@@ -479,7 +479,7 @@ jobs:
 
             # avoid unnecessary use of mac resources
             - is-full-run: false
-              os: macos-12
+              os: macos-13
 
             - is-full-run: false
               os: macos-14

--- a/.github/workflows/conda.yml
+++ b/.github/workflows/conda.yml
@@ -34,7 +34,7 @@ jobs:
           os:
             - ubuntu-24.04
             - macos-14
-            - macos-12
+            - macos-13
             - windows-2019
       runs-on: ${{ matrix.os }}
       steps:


### PR DESCRIPTION
as per actions/runner-images#10721
Fixes #406 