### PR TITLE
Add automatic full CI builds that run twice a week

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,5 +1,12 @@
 name: Build Status
 
+env:
+  # Run full CI Monday and Thursday at 3:25am EST (08:25 UTC)
+  # Note: do not run scheduled jobs on the hour exactly, per:
+  # https://docs.github.com/en/actions/writing-workflows/choosing-when-your-workflow-runs/events-that-trigger-workflows#schedule
+  # GitHub Actions schedules can sometimes delay by up to 15 minutes due to platform load
+  FULL_CI_SCHEDULE: '25 8 * * 1,4'
+
 on:
   push:
     branches:
@@ -26,6 +33,8 @@ on:
         required: false
         type: boolean
         default: false
+  schedule:
+    - cron: '25 8 * * 1,4'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
@@ -60,7 +69,7 @@ jobs:
 
       outputs:
         COMMIT_MESSAGE: ${{ steps.setup.outputs.COMMIT_MSG }}
-        FULL_RUN: ${{ steps.setuppush.outputs.FULL_RUN || steps.setuppr.outputs.FULL_RUN || steps.setupmanual.outputs.FULL_RUN }}
+        FULL_RUN: ${{ steps.setuppush.outputs.FULL_RUN || steps.setuppr.outputs.FULL_RUN || steps.setupmanual.outputs.FULL_RUN || steps.setupschedule.outputs.FULL_RUN }}
 
       steps:
         - name: Checkout
@@ -109,6 +118,17 @@ jobs:
           env:
             FULL_RUN: ${{ github.event.inputs.ci-full }}
           if: ${{ github.event_name == 'workflow_dispatch' }}
+        
+        - name: Display and Setup Build Args (Schedule)
+          id: setupschedule
+          run: |
+            echo "Commit Message: $COMMIT_MSG"
+            echo "Full Run: $FULL_RUN"
+            echo "COMMIT_MSG=$COMMIT_MSG" >> $GITHUB_OUTPUT
+            echo "FULL_RUN=$FULL_RUN" >> $GITHUB_OUTPUT
+          env:
+            FULL_RUN: ${{ github.event.schedule == env.FULL_CI_SCHEDULE }}
+          if: ${{ github.event_name == 'schedule' }}
 
     ########################################################
     #......................................................#


### PR DESCRIPTION
These workflows will run on Mondays and Thursdays at 08:25 UTC (3:25 am EST). @timkpaine mentioned that daily builds will fill up our build cache and as a result slow down main/PR builds, so I think biweekly is enough to catch issues as they arise (considering we do not have super frequent commits). However, the frequency we run these full builds can be discussed more.