### PR TITLE
Pin cmake on Windows builds to 3.31.1 as the new patch release is failing to install on GitHub Actions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -203,8 +203,10 @@ dependencies-fedora:  ## install dependencies for linux
 dependencies-vcpkg:  ## install dependencies via vcpkg
 	cd vcpkg && ./bootstrap-vcpkg.sh && ./vcpkg install
 
+## TODO remove pin on cmake below once we identify why 3.31.2 is failing OR cmake releases a new version which installs properly
 dependencies-win:  ## install dependencies via windows
-	choco install cmake curl winflexbison ninja unzip zip --no-progress -y
+	choco install cmake --version=3.31.1
+	choco install curl winflexbison ninja unzip zip --no-progress -y
 
 ############################################################################################
 # Thanks to Francoise at marmelab.com for this


### PR DESCRIPTION
Fixes the current build failures on main
Test branch running in CI here: https://github.com/Point72/csp/actions/runs/12262509483/job/34211976946