### PR TITLE
Revert pinned cmake version on Windows builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -203,10 +203,8 @@ dependencies-fedora:  ## install dependencies for linux
 dependencies-vcpkg:  ## install dependencies via vcpkg
 	cd vcpkg && ./bootstrap-vcpkg.sh && ./vcpkg install
 
-## TODO remove pin on cmake below once we identify why 3.31.2 is failing OR cmake releases a new version which installs properly
 dependencies-win:  ## install dependencies via windows
-	choco install cmake --version=3.31.1
-	choco install curl winflexbison ninja unzip zip --no-progress -y
+	choco install cmake curl winflexbison ninja unzip zip --no-progress -y
 
 ############################################################################################
 # Thanks to Francoise at marmelab.com for this


### PR DESCRIPTION
This reverts commit 1054f5caaa7c2d041f91a458789a8fdae2a84305.

I noticed `main` builds like [this one](https://github.com/Point72/csp/actions/runs/12302042801/job/34437998343 ) were failing as of Friday with the following error message:

```
Failures
 - cmake - Failed to install cmake because a previous dependency failed.
 - cmake.install - A newer version of cmake.install (v3.31.2) is already installed.
 Use --allow-downgrade or --force to attempt to install older versions.
make: *** [Makefile:208: dependencies-win] Error 1
Error: Process completed with exit code 2.
```

I was going to add that flag but I first tried reverting the commit that pinned the cmake version, since we never knew why it was failing to install on GH Actions in the first place. Lo and behold the new cmake version (3.31.2) now seems to work on the GitHub builds, as [this full CI run](https://github.com/Point72/csp/actions/runs/12343128648) shows.