### PR TITLE
Add zlib dependency to conda dev environment and update websocket code for boost 1.87

### DIFF
--- a/conda/dev-environment-unix.yml
+++ b/conda/dev-environment-unix.yml
@@ -57,3 +57,4 @@ dependencies:
  - unzip
  - wheel
  - zip
+ - zlib

--- a/conda/dev-environment-win.yml
+++ b/conda/dev-environment-win.yml
@@ -53,3 +53,4 @@ dependencies:
  - twine
  - typing-extensions
  - wheel
+ - zlib

--- a/cpp/csp/adapters/websocket/WebsocketEndpoint.cpp
+++ b/cpp/csp/adapters/websocket/WebsocketEndpoint.cpp
@@ -21,7 +21,7 @@ void WebsocketEndpoint::setOnSendFail(string_cb on_send_fail)
 void WebsocketEndpoint::run()
 {
 
-    m_ioc.reset();
+    m_ioc.restart();
     if(m_properties.get<bool>("use_ssl")) {
         ssl::context ctx{ssl::context::sslv23};
         ctx.set_verify_mode(ssl::context::verify_peer );


### PR DESCRIPTION
This adds `zlib` as a direct dependency of the conda environment file rather than having it pulled in transitively from `thrift`, which is itself pulled in transitively from `arrow`. GH Actions was finding a outdated `zlib` version (1.3) in the conda end-to-end test without having it directly listed in the environment, although I'm not sure why 🤷. 

Also, as we haven't run a conda build for about 3 weeks, boost upgraded from 1.86.0 to 1.87.0 in December which is causing a build failure in the websocket code. This is a one-line fix.