### PR TITLE
Scheduled CI builds for CSP conda end-to-end tests

### DIFF
--- a/.github/workflows/conda.yml
+++ b/.github/workflows/conda.yml
@@ -18,6 +18,9 @@ on:
       - README.md
       - "docs/**"
   workflow_dispatch:
+  schedule:
+    # Run conda CI on Monday and Thursday at 1:25am EST (06:25 UTC)
+    - cron: '25 6 * * 1,4'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}


### PR DESCRIPTION
This PR schedules automatic builds/tests for conda end-to-end tests every Mon/Thurs at 1:25 am EST. The goal is to catch issues causing build failures quickly so that PRs don't get stuck on unrelated dependency/build issues.