### PR TITLE
Pin pyarrow to <19 due to apparent incompatibility with vendored 16.0 Arrow C++ code on x86 macos

### DIFF
--- a/conda/dev-environment-unix.yml
+++ b/conda/dev-environment-unix.yml
@@ -31,7 +31,7 @@ dependencies:
  - pillow
  - polars
  - psutil
- - pyarrow=16
+ - pyarrow>=7,<19
  - pydantic>=2
  - pytest
  - pytest-asyncio

--- a/conda/dev-environment-win.yml
+++ b/conda/dev-environment-win.yml
@@ -30,7 +30,7 @@ dependencies:
  - pillow
  - polars
  - psutil
- - pyarrow=16
+ - pyarrow>=7,<19
  - pydantic>=2
  - pytest
  - pytest-asyncio

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ requires = [
     "cmake",
     "deprecated",  # Because used in csp.impl.struct, which is used in autogen
     "oldest-supported-numpy",
-    "pyarrow>=7.0.0",
+    "pyarrow>=7,<19",
     "ruamel.yaml",
     "scikit-build",
     "setuptools>=69,<74",
@@ -26,7 +26,7 @@ dependencies = [
     "packaging",
     "pandas",
     "psutil",
-    "pyarrow>=7.0.0",
+    "pyarrow>=7,<19",
     "pytz",
     "ruamel.yaml",
     "sqlalchemy",


### PR DESCRIPTION
It seems there is some ABI incompatibility on x86 Mac between our vendored C++ Pyarrow code (version 16.0) and the recently-released Pyarrow 19.0 Python code, which is resulting in files being produced from the ParquetWriter that are unreadable in Python. See: https://github.com/Point72/csp/actions/runs/12863970430/job/35865078010
 
Discussed with @timkpaine and there are two options: 1) pin back pyarrow to <19 to avoid the Python side upgrade and 2) upgrade our vendored C++ code to a higher version which is compatible. Due to other bugs in pyarrow 19 (see https://github.com/apache/arrow/issues/45283) we decided to hold back on the upgrade until pyarrow 20.0, which (based on previous schedules) should come out in 2-3 months.


 