### PR TITLE
Increase leeway for test_alarm_leak, which uses more memory on GH Actions runs

### DIFF
--- a/csp/tests/test_engine.py
+++ b/csp/tests/test_engine.py
@@ -1196,8 +1196,8 @@ class TestEngine(unittest.TestCase):
             gc.collect()
         end_mem = proc_info.memory_info().rss
 
-        # 5MB leeway, the leak resulted in 50MB+ leak
-        self.assertLess(end_mem - start_mem, 5000000)
+        # 10MB leeway, the leak resulted in 50MB+ leak
+        self.assertLess(end_mem - start_mem, 10000000)
 
     def test_multiple_alarms_bug(self):
         @csp.node


### PR DESCRIPTION
I've noticed this test failing sporadically on our scheduled builds, like: https://github.com/Point72/csp/actions/runs/13366028175/job/37327469976. Since the comment states the leak would increase RSS memory by at least 50 MB, we can increase leeway from 5 MB to 10 MB to reduce noise from this test (for example, it used 7.3 MB in the failed run above).