### PR TITLE
Handle `Any` type properly in pydantic type checking. Fixes #468

### DIFF
--- a/csp/impl/types/pydantic_types.py
+++ b/csp/impl/types/pydantic_types.py
@@ -35,6 +35,14 @@ class CspTypeVarType(Generic[_T]):
     @classmethod
     def __get_pydantic_core_schema__(cls, source_type: Any, handler: GetCoreSchemaHandler) -> CoreSchema:
         typ = _check_source_type(cls, source_type)
+        if not typ or not typ[0].isalpha():
+            if typ and typ[0] == "~":
+                raise SyntaxError(
+                    f"Invalid generic type: {typ}. The generic type annotation (i.e. `~T`) is only allowed at the top level (i.e. `value: '~T'`)."
+                )
+            raise SyntaxError(
+                f"Invalid generic type: {typ}. Generic types in csp must start with an alphabetic character."
+            )
 
         def _validator(v: Any, info: ValidationInfo) -> Any:
             # info.context should be an instance of TVarValidationContext, but we don't check for performance
@@ -55,6 +63,14 @@ class CspTypeVar(Generic[_T]):
     @classmethod
     def __get_pydantic_core_schema__(cls, source_type: Any, handler: GetCoreSchemaHandler) -> CoreSchema:
         tvar = _check_source_type(cls, source_type)
+        if not tvar or not tvar[0].isalpha():
+            if tvar and tvar[0] == "~":
+                raise SyntaxError(
+                    f"Invalid generic type: {tvar}. The generic type annotation (i.e. `~T`) is only allowed at the top level (i.e. `value: '~T'`)."
+                )
+            raise SyntaxError(
+                f"Invalid generic type: {tvar}. Generic types in csp must start with an alphabetic character. "
+            )
 
         def _validator(v: Any, info: ValidationInfo) -> Any:
             # info.context should be an instance of TVarValidationContext, but we don't check for performance

--- a/csp/tests/impl/types/test_pydantic_type_resolver.py
+++ b/csp/tests/impl/types/test_pydantic_type_resolver.py
@@ -91,6 +91,12 @@ class TestPydanticTypeResolver_CspTypeVar(TestCase):
         context.resolve_tvars()
         self.assertDictEqual(context.tvars, {"T": float})
 
+    def test_bad_variable_name(self):
+        self.assertRaises(SyntaxError, lambda: CspTypeVar[""])
+        self.assertRaises(SyntaxError, TypeAdapter, CspTypeVar["~T"])
+        self.assertRaises(SyntaxError, TypeAdapter, CspTypeVar["1"])
+        _ = TypeAdapter(CspTypeVar["T1"])
+
 
 class TestPydanticTypeResolver_CspTypeVarType(TestCase):
     def test_one_value(self):
@@ -181,6 +187,12 @@ class TestPydanticTypeResolver_CspTypeVarType(TestCase):
         ta.validate_python(csp.null_ts(List[float]), context=context)
         context.resolve_tvars()
         self.assertDictEqual(context.tvars, {"T": float})
+
+    def test_bad_variable_name(self):
+        self.assertRaises(SyntaxError, lambda: CspTypeVarType[""])
+        self.assertRaises(SyntaxError, TypeAdapter, CspTypeVarType["~T"])
+        self.assertRaises(SyntaxError, TypeAdapter, CspTypeVarType["1"])
+        _ = TypeAdapter(CspTypeVarType["T1"])
 
 
 T = TypeVar("T")

--- a/csp/tests/impl/types/test_tstype.py
+++ b/csp/tests/impl/types/test_tstype.py
@@ -2,7 +2,7 @@ import numpy as np
 import pytest
 import sys
 from pydantic import TypeAdapter
-from typing import Dict, ForwardRef, Generic, List, Mapping, TypeVar, Union, get_args, get_origin
+from typing import Any, Dict, ForwardRef, Generic, List, Mapping, TypeVar, Union, get_args, get_origin
 from unittest import TestCase
 
 import csp
@@ -104,6 +104,18 @@ class TestTsTypeValidation(TestCase):
         ta = TypeAdapter(TsType[float])
         ta.validate_python(csp.null_ts(float), context=context)
         ta.validate_python(None, context=context)
+
+    def test_any(self):
+        ta = TypeAdapter(TsType[Any])
+        ta.validate_python(csp.null_ts(float))
+        ta.validate_python(csp.null_ts(object))
+        ta.validate_python(csp.null_ts(List[str]))
+        ta.validate_python(csp.null_ts(Dict[str, List[float]]))
+
+        # https://docs.python.org/3/library/typing.html#the-any-type
+        # "Notice that no type checking is performed when assigning a value of type Any to a more precise type."
+        ta = TypeAdapter(TsType[float])
+        ta.validate_python(csp.null_ts(Any))
 
 
 class TestOutputValidation(TestCase):


### PR DESCRIPTION
Also improve error messages when incorrectly using  generic type (improves error messages for #469).