### PR TITLE
Configure codespell to ignore "thrOn", used in one of the examples

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -180,6 +180,10 @@ before-build = "make requirements"
 archs = "AMD64"
 skip = "*win32 *arm_64"
 
+[tool.codespell]
+skip = "*.cpp,*.h"
+ignore-words-list = "thron"
+
 [tool.isort]
 combine_as_imports = true
 include_trailing_comma = true


### PR DESCRIPTION
Previous runs of `make format` would return the following suggestions:

> examples/07_end_to_end/seismic_waveform.ipynb:591: thrOn ==> thrown, throne
examples/07_end_to_end/seismic_waveform.ipynb:594: thrOn ==> thrown, throne
examples/07_end_to_end/seismic_waveform.ipynb:631: thrOn ==> thrown, throne
examples/07_end_to_end/seismic_waveform.ipynb:636: thrOn ==> thrown, throne
examples/07_end_to_end/seismic_waveform.ipynb:671: thrOn ==> thrown, throne
examples/07_end_to_end/seismic_waveform.ipynb:673: thrOn ==> thrown, throne

This PR removes those suggestions, as "thrOn" is short for "threshold on" and comes from `obspy` terminology.