### PR TITLE
Allow static cast to Any

### DIFF
--- a/csp/baselib.py
+++ b/csp/baselib.py
@@ -5,7 +5,7 @@ import math
 import queue
 import threading
 from datetime import datetime, timedelta
-from typing import Callable, Dict, List, Optional, TypeVar, Union
+from typing import Any, Callable, Dict, List, Optional, TypeVar, Union
 
 import numpy as np
 import pytz
@@ -764,7 +764,14 @@ def static_cast(x: ts["T"], outType: "U") -> ts["U"]:
     as there will be no runtime type checking.
     """
     # Special case bool / int which are native types, but bool evaluates as a subclass of int
-    if not issubclass(outType, x.tstype.typ) or (outType is bool and x.tstype.typ is int):
+    # Allow Any to be cast to anything and vice versa
+    # matching the behavior of Any in the python docs
+    if (
+        x.tstype.typ is not Any
+        and outType is not Any
+        and not issubclass(outType, x.tstype.typ)
+        or (outType is bool and x.tstype.typ is int)
+    ):
         raise TypeError(f"Unable to csp.static_cast edge of type {x.tstype.typ.__name__} to {outType.__name__}")
     return Edge(ts[outType], nodedef=x.nodedef, output_idx=x.output_idx, basket_idx=x.basket_idx)
 

--- a/csp/tests/test_baselib.py
+++ b/csp/tests/test_baselib.py
@@ -5,7 +5,7 @@ import math
 import unittest
 from datetime import date, datetime, timedelta, timezone
 from enum import Enum, auto
-from typing import List
+from typing import Any, List
 
 import numpy as np
 
@@ -1230,6 +1230,19 @@ class TestBaselib(unittest.TestCase):
         # Runtime type check
         with self.assertRaisesRegex(TypeError, 'expected output type on .* to be of type "int" got type "float"'):
             csp.run(csp.dynamic_cast(x_float, int), starttime=datetime.utcnow(), endtime=timedelta())
+
+    def test_static_cast_any(self):
+        @csp.node
+        def my_node(x: ts[timedelta]) -> ts[int]:
+            return x
+
+        def g():
+            x = csp.const(1)
+            any_x = csp.static_cast(x, Any)
+            return my_node(any_x)
+
+        res = csp.run(g, starttime=datetime.utcnow(), endtime=timedelta(1))
+        self.assertEqual(res[0][0][1], 1)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Somewhat addresses #436

Kinda cursed, but by allowing static casting to/from typing.Any, we can mimic the behavior of typing.Any and allow ignoring the input type hints on csp nodes

I feel like this should almost never be used, but it seems easy enough to support.

So we can do stuff like this

```python
    def test_static_cast_any(self):
        @csp.node
        def my_node(x: ts[timedelta]) -> ts[int]:
            return x

        def g():
            x = csp.const(1)
            any_x = csp.static_cast(x, Any)
            return my_node(any_x)

        res = csp.run(g, starttime=datetime.utcnow(), endtime=timedelta(1))
        self.assertEqual(res[0][0][1], 1)
```