### PR TITLE
Handle union and literal typing correctly in annotations

### DIFF
--- a/csp/impl/struct.py
+++ b/csp/impl/struct.py
@@ -152,17 +152,6 @@ class StructMeta(_csptypesimpl.PyStructMeta):
 
 class Struct(_csptypesimpl.PyStruct, metaclass=StructMeta):
     @classmethod
-    def type_adapter(cls):
-        # Late import to avoid autogen issues
-        from pydantic import TypeAdapter
-
-        internal_type_adapter = getattr(cls, "_pydantic_type_adapter", None)
-        if internal_type_adapter:
-            return internal_type_adapter
-        cls._pydantic_type_adapter = TypeAdapter(cls)
-        return cls._pydantic_type_adapter
-
-    @classmethod
     def metadata(cls, typed=False):
         if typed:
             return cls.__full_metadata_typed__
@@ -246,9 +235,7 @@ class Struct(_csptypesimpl.PyStruct, metaclass=StructMeta):
                 return obj_type(json)
 
     @classmethod
-    def from_dict(cls, json: dict, use_pydantic: bool = False):
-        if use_pydantic:
-            return cls.type_adapter().validate_python(json)
+    def from_dict(cls, json: dict):
         return cls._obj_from_python(json, cls)
 
     def to_dict_depr(self):

--- a/csp/impl/types/container_type_normalizer.py
+++ b/csp/impl/types/container_type_normalizer.py
@@ -81,21 +81,21 @@ class ContainerTypeNormalizer:
                 return [cls.normalized_type_to_actual_python_type(typ.__args__[0], level + 1), True]
             if origin is typing.List and level == 0:
                 return [cls.normalized_type_to_actual_python_type(typ.__args__[0], level + 1)]
-            if origin is typing.Literal:
-                # Import here to prevent circular import
-                from csp.impl.types.instantiation_type_resolver import UpcastRegistry
-
-                args = typing.get_args(typ)
-                typ = type(args[0])
-                for arg in args[1:]:
-                    typ = UpcastRegistry.instance().resolve_type(typ, type(arg), raise_on_error=False)
-                if typ:
-                    return typ
-                else:
-                    return object
             return cls._NORMALIZED_TYPE_MAPPING.get(CspTypingUtils.get_origin(typ), typ)
         elif CspTypingUtils.is_union_type(typ):
             return object
+        elif CspTypingUtils.is_literal_type(typ):
+            # Import here to prevent circular import
+            from csp.impl.types.instantiation_type_resolver import UpcastRegistry
+
+            args = typing.get_args(typ)
+            typ = type(args[0])
+            for arg in args[1:]:
+                typ = UpcastRegistry.instance().resolve_type(typ, type(arg), raise_on_error=False)
+            if typ:
+                return typ
+            else:
+                return object
         else:
             return typ
 

--- a/csp/impl/types/pydantic_types.py
+++ b/csp/impl/types/pydantic_types.py
@@ -1,7 +1,7 @@
 import sys
 import types
 import typing
-from typing import Any, ForwardRef, Generic, Optional, Type, TypeVar, Union, get_args, get_origin
+from typing import Any, ForwardRef, Generic, Literal, Optional, Type, TypeVar, Union, get_args, get_origin
 
 from pydantic import GetCoreSchemaHandler, ValidationInfo, ValidatorFunctionWrapHandler
 from pydantic_core import CoreSchema, core_schema
@@ -184,6 +184,8 @@ def adjust_annotations(
             return TsType[
                 adjust_annotations(args[0], top_level=False, in_ts=True, make_optional=False, forced_tvars=forced_tvars)
             ]
+        if origin is Literal:  # for literals, we stop converting
+            return Optional[annotation] if make_optional else annotation
         else:
             try:
                 if origin is CspTypeVar or origin is CspTypeVarType:

--- a/csp/impl/types/type_annotation_normalizer_transformer.py
+++ b/csp/impl/types/type_annotation_normalizer_transformer.py
@@ -51,6 +51,8 @@ class TypeAnnotationNormalizerTransformer(ast.NodeTransformer):
         return node
 
     def visit_Subscript(self, node):
+        # We choose to avoid parsing here
+        # to maintain current behavior of allowing empty lists in our types
         return node
 
     def visit_List(self, node):
@@ -98,17 +100,13 @@ class TypeAnnotationNormalizerTransformer(ast.NodeTransformer):
         return node
 
     def visit_Constant(self, node):
-        if not self._cur_arg:
+        if not self._cur_arg or not isinstance(node.value, str):
             return node
-
-        if self._cur_arg:
-            return ast.Call(
-                func=ast.Attribute(value=ast.Name(id="typing", ctx=ast.Load()), attr="TypeVar", ctx=ast.Load()),
-                args=[node],
-                keywords=[],
-            )
-        else:
-            return node
+        return ast.Call(
+            func=ast.Attribute(value=ast.Name(id="typing", ctx=ast.Load()), attr="TypeVar", ctx=ast.Load()),
+            args=[node],
+            keywords=[],
+        )
 
     def visit_Str(self, node):
         return self.visit_Constant(node)

--- a/csp/impl/types/typing_utils.py
+++ b/csp/impl/types/typing_utils.py
@@ -15,6 +15,25 @@ class FastList(typing.List, typing.Generic[T]):  # Need to inherit from Generic[
     def __init__(self):
         raise NotImplementedError("Can not init FastList class")
 
+    @classmethod
+    def __get_pydantic_core_schema__(cls, source_type, handler):
+        from pydantic_core import core_schema
+
+        # Late import to not interfere with autogen
+        args = typing.get_args(source_type)
+        if args:
+            inner_type = args[0]
+            list_schema = handler.generate_schema(typing.List[inner_type])
+        else:
+            list_schema = handler.generate_schema(typing.List)
+
+        def create_instance(raw_data, validator):
+            if isinstance(raw_data, FastList):
+                return raw_data
+            return validator(raw_data)  # just return a list
+
+        return core_schema.no_info_wrap_validator_function(function=create_instance, schema=list_schema)
+
 
 class CspTypingUtils39:
     _ORIGIN_COMPAT_MAP = {list: typing.List, set: typing.Set, dict: typing.Dict, tuple: typing.Tuple}
@@ -23,7 +42,7 @@ class CspTypingUtils39:
 
     @classmethod
     def is_generic_container(cls, typ):
-        return isinstance(typ, cls._GENERIC_ALIASES) and typ.__origin__ is not typing.Union
+        return isinstance(typ, cls._GENERIC_ALIASES) and typ.__origin__ not in (typing.Union, typing.Literal)
 
     @classmethod
     def is_type_spec(cls, val):
@@ -55,6 +74,10 @@ class CspTypingUtils39:
     @classmethod
     def is_union_type(cls, typ):
         return isinstance(typ, typing._GenericAlias) and typ.__origin__ is typing.Union
+
+    @classmethod
+    def is_literal_type(cls, typ):
+        return isinstance(typ, typing._GenericAlias) and typ.__origin__ is typing.Literal
 
     @classmethod
     def is_forward_ref(cls, typ):

--- a/csp/impl/types/typing_utils.py
+++ b/csp/impl/types/typing_utils.py
@@ -15,25 +15,6 @@ class FastList(typing.List, typing.Generic[T]):  # Need to inherit from Generic[
     def __init__(self):
         raise NotImplementedError("Can not init FastList class")
 
-    @classmethod
-    def __get_pydantic_core_schema__(cls, source_type, handler):
-        from pydantic_core import core_schema
-
-        # Late import to not interfere with autogen
-        args = typing.get_args(source_type)
-        if args:
-            inner_type = args[0]
-            list_schema = handler.generate_schema(typing.List[inner_type])
-        else:
-            list_schema = handler.generate_schema(typing.List)
-
-        def create_instance(raw_data, validator):
-            if isinstance(raw_data, FastList):
-                return raw_data
-            return validator(raw_data)  # just return a list
-
-        return core_schema.no_info_wrap_validator_function(function=create_instance, schema=list_schema)
-
 
 class CspTypingUtils39:
     _ORIGIN_COMPAT_MAP = {list: typing.List, set: typing.Set, dict: typing.Dict, tuple: typing.Tuple}

--- a/csp/tests/impl/types/test_pydantic_types.py
+++ b/csp/tests/impl/types/test_pydantic_types.py
@@ -1,6 +1,6 @@
 import sys
 from inspect import isclass
-from typing import Any, Callable, Dict, Generic, List, Optional, Type, TypeVar, Union, get_args, get_origin
+from typing import Any, Callable, Dict, Generic, List, Literal, Optional, Type, TypeVar, Union, get_args, get_origin
 from unittest import TestCase
 
 import csp
@@ -160,3 +160,12 @@ class TestAdjustAnnotations(TestCase):
         self.assertAnnotationsEqual(
             adjust_annotations(CspTypeVarType[T], forced_tvars={"T": float}), Union[Type[float], Type[int]]
         )
+
+    def test_literal(self):
+        self.assertAnnotationsEqual(adjust_annotations(Literal["a", "b"]), Literal["a", "b"])
+        self.assertAnnotationsEqual(
+            adjust_annotations(Literal["a", "b"], make_optional=True), Optional[Literal["a", "b"]]
+        )
+        self.assertAnnotationsEqual(adjust_annotations(Literal[123, "a"]), Literal[123, "a"])
+        self.assertAnnotationsEqual(adjust_annotations(Literal[123, None]), Literal[123, None])
+        self.assertAnnotationsEqual(adjust_annotations(ts[Literal[123, None]]), ts[Literal[123, None]])

--- a/csp/tests/test_type_checking.py
+++ b/csp/tests/test_type_checking.py
@@ -1039,60 +1039,6 @@ class TestTypeChecking(unittest.TestCase):
             with self.assertRaisesRegex(TypeError, msg):
                 csp.build_graph(graph_with_pipe_union, 3.14)
 
-    def test_literal_with_pipe_operator(self):
-        """Test combining Literal types with the pipe operator in Python 3.10+."""
-        if sys.version_info >= (3, 10) and USE_PYDANTIC:  # this doesn't work without pydantic type checking
-
-            def run_literal_pipe_test():
-                from typing import Literal
-
-                @csp.node
-                def node_with_literal_pipe(x: ts[int], choice: Literal["a", "b", "c"] | None | int) -> ts[str]:
-                    if csp.ticked(x):
-                        return str(choice) if choice is not None else "none"
-
-                @csp.graph
-                def graph_with_literal_pipe(choice: Literal["a", "b", "c"] | None | int) -> ts[str]:
-                    return csp.const(str(choice) if choice is not None else "none")
-
-                @csp.node
-                def dummy_node(x: ts["T"]):  # to avoid pruning
-                    if csp.ticked(x):
-                        ...
-
-                def graph():
-                    # These should work - valid literal values or None or int
-                    dummy_node(node_with_literal_pipe(csp.const(10), "a"))
-                    dummy_node(node_with_literal_pipe(csp.const(10), "b"))
-                    dummy_node(node_with_literal_pipe(csp.const(10), "c"))
-                    dummy_node(node_with_literal_pipe(csp.const(10), None))
-                    dummy_node(node_with_literal_pipe(csp.const(10), 12))
-
-                    graph_with_literal_pipe("a")
-                    graph_with_literal_pipe("b")
-                    graph_with_literal_pipe("c")
-                    graph_with_literal_pipe(None)
-                    graph_with_literal_pipe(12)
-
-                    msg = "(?s)2 validation errors for node_with_literal_pipe.*choice.*"
-                    with self.assertRaisesRegex(TypeError, msg):
-                        dummy_node(node_with_literal_pipe(csp.const(10), "d"))
-
-                csp.run(graph, starttime=datetime(2020, 2, 7, 9), endtime=datetime(2020, 2, 7, 9, 1))
-
-                # Test direct graph building
-                csp.build_graph(graph_with_literal_pipe, "a")
-                csp.build_graph(graph_with_literal_pipe, None)
-                csp.build_graph(graph_with_literal_pipe, 12)
-
-                # This should fail
-                msg = "(?s)2 validation errors for graph_with_literal_pipe.*choice.*"
-                with self.assertRaisesRegex(TypeError, msg):
-                    csp.build_graph(graph_with_literal_pipe, "d")
-
-            # Run the test
-            run_literal_pipe_test()
-
 
 if __name__ == "__main__":
     unittest.main()

--- a/csp/tests/test_type_checking.py
+++ b/csp/tests/test_type_checking.py
@@ -939,6 +939,106 @@ class TestTypeChecking(unittest.TestCase):
             result = CspTypingUtils.is_callable(input_type)
             self.assertEqual(result, expected)
 
+    def test_literal_typing(self):
+        """Test using Literal types for type checking in CSP nodes."""
+        from typing import Literal
+
+        @csp.node
+        def node_with_literal(x: ts[int], choice: Literal["a", "b", "c"]) -> ts[str]:
+            if csp.ticked(x):
+                return str(choice)
+
+        @csp.graph
+        def graph_with_literal(choice: Literal["a", "b", "c"]) -> ts[str]:
+            return csp.const(str(choice))
+
+        @csp.node
+        def dummy_node(x: ts["T"]):  # to avoid pruning
+            if csp.ticked(x):
+                pass
+
+        def graph():
+            # These should work - valid literal values
+            dummy_node(node_with_literal(csp.const(10), "a"))
+            dummy_node(node_with_literal(csp.const(10), "b"))
+            dummy_node(node_with_literal(csp.const(10), "c"))
+
+            graph_with_literal("a")
+            graph_with_literal("b")
+            graph_with_literal("c")
+
+            # This should fail with invalid literal value
+            # But only pydantic type checking catches this
+            if USE_PYDANTIC:
+                msg = "(?s)1 validation error for node_with_literal.*choice.*"
+                with self.assertRaisesRegex(TypeError, msg):
+                    dummy_node(node_with_literal(csp.const(10), "d"))
+
+        csp.run(graph, starttime=datetime(2020, 2, 7, 9), endtime=datetime(2020, 2, 7, 9, 1))
+
+        # Test direct graph building
+        csp.build_graph(graph_with_literal, "a")
+
+        # This should fail with invalid literal value
+        # But only pydantic type checking catches this
+        if USE_PYDANTIC:
+            msg = "(?s)1 validation error for graph_with_literal.*choice.*"
+            with self.assertRaisesRegex(TypeError, msg):
+                csp.build_graph(graph_with_literal, "d")
+
+    def test_union_with_pipe_operator(self):
+        """Test using the pipe operator for Union types in Python 3.10+."""
+        if sys.version_info >= (3, 10):  # pipe operator was introduced in Python 3.10
+
+            @csp.node
+            def node_with_pipe_union(x: ts[int], value: str | int | None) -> ts[str]:
+                if csp.ticked(x):
+                    return str(value) if value is not None else "none"
+
+            @csp.graph
+            def graph_with_pipe_union(value: str | int | None) -> ts[str]:
+                return csp.const(str(value) if value is not None else "none")
+
+            @csp.node
+            def dummy_node(x: ts["T"]):  # to avoid pruning
+                if csp.ticked(x):
+                    pass
+
+            def graph():
+                # These should work - valid union types (str, int, None)
+                dummy_node(node_with_pipe_union(csp.const(10), "hello"))
+                dummy_node(node_with_pipe_union(csp.const(10), 42))
+                dummy_node(node_with_pipe_union(csp.const(10), None))
+
+                graph_with_pipe_union("world")
+                graph_with_pipe_union(123)
+                graph_with_pipe_union(None)
+
+                # This should fail - float is not part of the union
+                if USE_PYDANTIC:
+                    # Pydantic provides a structured error message
+                    msg = "(?s)2 validation errors for node_with_pipe_union.*value.*"
+                else:
+                    # Non-Pydantic error has specific format to match
+                    msg = r"In function node_with_pipe_union: Expected str \| int \| None for argument 'value', got .* \(float\)"
+                with self.assertRaisesRegex(TypeError, msg):
+                    dummy_node(node_with_pipe_union(csp.const(10), 3.14))
+
+            csp.run(graph, starttime=datetime(2020, 2, 7, 9), endtime=datetime(2020, 2, 7, 9, 1))
+
+            # Test direct graph building
+            csp.build_graph(graph_with_pipe_union, "test")
+            csp.build_graph(graph_with_pipe_union, 42)
+            csp.build_graph(graph_with_pipe_union, None)
+
+            # This should fail - bool is not explicitly included in the union
+            if USE_PYDANTIC:
+                msg = "(?s)2 validation errors for graph_with_pipe_union.*value.*"
+            else:
+                msg = r"In function graph_with_pipe_union: Expected str \| int \| None for argument 'value', got .*"
+            with self.assertRaisesRegex(TypeError, msg):
+                csp.build_graph(graph_with_pipe_union, 3.14)
+
     def test_literal_with_pipe_operator(self):
         """Test combining Literal types with the pipe operator in Python 3.10+."""
         if sys.version_info >= (3, 10) and USE_PYDANTIC:  # this doesn't work without pydantic type checking


### PR DESCRIPTION
This fixes a few issues all related to handling Union and Literals in type annotations. Namely:

1.

fixes https://github.com/Point72/csp/issues/475

Previously, the AST parsing for type annotations was incorrectly converting "None" in the example above to be a TypeVar, and then when we called `exec` on the new transformed AST, an error was being thrown. We make sure that in the AST parsing, we only convert a string to a TypeVar. 

2. 
fixes #481

We also handle the case with Literal, where before if you had `Literal["a", "b"]`, "a" and "b" were incorrectly assumed to be CspTypeVar, when they should be the actual literal value. For adjusting the annotations, we stop now if we encounter a `Literal` annotation.


3.
fixes #482

Related to the `Literal` and `Union` typing, when `from_dict` on csp.Struct was called, we were skipping handling `Literal` and `Union`. We update the type normalization code to not treat `Literal` as a generic container. In `from_dict`, a `Union` has no validation performed on it, since under the hood the type normalizer returns `object`. For `Literal`, we perform (as we were before in adjusting the annotations themselves) a very basic type check. Namely, we just make sure that we pick a suitable parent class for all the values of `Literal` (as the type normalization does), and just check it is that class. The tests added demonstrate this, that we don't actually check for `Literal` when calling `from_dict`, but just make sure the types line up. So, if `Literal[1, 2]` exists, then a string passed for that field would error. The nuances of this behavior are addressed in this specific test case: https://github.com/Point72/csp/pull/478/files#diff-16e10f816ba9638999d038fb8bd076b4021e901b60e548b1bc392b6191026687R3907
