### PR TITLE
Allow using pydantic for from_dict, schema for FastList

### DIFF
--- a/csp/impl/struct.py
+++ b/csp/impl/struct.py
@@ -148,6 +148,17 @@ class StructMeta(_csptypesimpl.PyStructMeta):
 
 class Struct(_csptypesimpl.PyStruct, metaclass=StructMeta):
     @classmethod
+    def type_adapter(cls):
+        # Late import to avoid autogen issues
+        from pydantic import TypeAdapter
+
+        internal_type_adapter = getattr(cls, "_pydantic_type_adapter", None)
+        if internal_type_adapter:
+            return internal_type_adapter
+        cls._pydantic_type_adapter = TypeAdapter(cls)
+        return cls._pydantic_type_adapter
+
+    @classmethod
     def metadata(cls, typed=False):
         if typed:
             return cls.__full_metadata_typed__
@@ -191,7 +202,8 @@ class Struct(_csptypesimpl.PyStruct, metaclass=StructMeta):
         if CspTypingUtils.is_generic_container(obj_type):
             if CspTypingUtils.get_origin(obj_type) in (typing.List, typing.Set, typing.Tuple, FastList):
                 return_type = ContainerTypeNormalizer.normalized_type_to_actual_python_type(obj_type)
-                (expected_item_type,) = obj_type.__args__
+                # We only take the first item, so like for a Tuple, we would ignore arguments after
+                expected_item_type = obj_type.__args__[0]
                 return_type = list if isinstance(return_type, list) else return_type
                 return return_type(cls._obj_from_python(v, expected_item_type) for v in json)
             elif CspTypingUtils.get_origin(obj_type) is typing.Dict:
@@ -223,7 +235,9 @@ class Struct(_csptypesimpl.PyStruct, metaclass=StructMeta):
                 return obj_type(json)
 
     @classmethod
-    def from_dict(cls, json: dict):
+    def from_dict(cls, json: dict, use_pydantic: bool = False):
+        if use_pydantic:
+            return cls.type_adapter().validate_python(json)
         return cls._obj_from_python(json, cls)
 
     def to_dict_depr(self):

--- a/csp/impl/struct.py
+++ b/csp/impl/struct.py
@@ -149,12 +149,13 @@ class StructMeta(_csptypesimpl.PyStructMeta):
 class Struct(_csptypesimpl.PyStruct, metaclass=StructMeta):
     @classmethod
     def type_adapter(cls):
-        # Late import to avoid autogen issues
-        from pydantic import TypeAdapter
-
         internal_type_adapter = getattr(cls, "_pydantic_type_adapter", None)
         if internal_type_adapter:
             return internal_type_adapter
+
+        # Late import to avoid autogen issues
+        from pydantic import TypeAdapter
+
         cls._pydantic_type_adapter = TypeAdapter(cls)
         return cls._pydantic_type_adapter
 

--- a/csp/impl/types/typing_utils.py
+++ b/csp/impl/types/typing_utils.py
@@ -15,6 +15,25 @@ class FastList(typing.List, typing.Generic[T]):  # Need to inherit from Generic[
     def __init__(self):
         raise NotImplementedError("Can not init FastList class")
 
+    @classmethod
+    def __get_pydantic_core_schema__(cls, source_type, handler):
+        from pydantic_core import core_schema
+
+        # Late import to not interfere with autogen
+        args = typing.get_args(source_type)
+        if args:
+            inner_type = args[0]
+            list_schema = handler.generate_schema(typing.List[inner_type])
+        else:
+            list_schema = handler.generate_schema(typing.List)
+
+        def create_instance(raw_data, validator):
+            if isinstance(raw_data, FastList):
+                return raw_data
+            return validator(raw_data)  # just return a list
+
+        return core_schema.no_info_wrap_validator_function(function=create_instance, schema=list_schema)
+
 
 class CspTypingUtils39:
     _ORIGIN_COMPAT_MAP = {list: typing.List, set: typing.Set, dict: typing.Dict, tuple: typing.Tuple}

--- a/csp/impl/types/typing_utils.py
+++ b/csp/impl/types/typing_utils.py
@@ -32,7 +32,15 @@ class FastList(typing.List, typing.Generic[T]):  # Need to inherit from Generic[
                 return raw_data
             return validator(raw_data)  # just return a list
 
-        return core_schema.no_info_wrap_validator_function(function=create_instance, schema=list_schema)
+        return core_schema.no_info_wrap_validator_function(
+            function=create_instance,
+            schema=list_schema,
+            serialization=core_schema.plain_serializer_function_ser_schema(
+                lambda val: list(v for v in val),
+                return_schema=list_schema,
+                when_used="json",
+            ),
+        )
 
 
 class CspTypingUtils39:


### PR DESCRIPTION
Allow utilizing pydantic validaiton in `from_dict` via a new boolean flag. Add a core schema for the FastList to work with pydantic.

Running some simple benchmarks, it seems that the default `to_dict` and `to_json` for csp Structs are significantly faster than going the pydantic route. While pydantic does allow for custom serialization and deserialization, the callbacks in `to_dict` and `to_json` allow that flexibility as well. Thus, for most use-cases, I believe those are probably preferred.

However, going through pydantic for `from_dict` is faster and more correct than the current csp implementation (more correct as in respects the type annotations more strictly). Thus, it should be preferred. However, this might cause breaking changes for users, so I propose we introduce it as an optional flag in the `from_dict` function, and then later down the road switch the default to be `True` to use pydantic validation for constructing csp Structs from dicts. Here are some plots noting the benchmark results

![image](https://github.com/user-attachments/assets/d24519fb-b0d5-4c04-8877-10d03eb6da2a)

![image](https://github.com/user-attachments/assets/49f4b539-a829-4b20-9853-2ff918bccb0e)

![image](https://github.com/user-attachments/assets/1ac314e6-a55a-4a79-a5f3-5bc088b98896)

![image](https://github.com/user-attachments/assets/02c4cc90-8220-47fa-b61d-e0cfdbd9e7f0)

![image](https://github.com/user-attachments/assets/02c0a9a0-c215-4ffa-b1c2-fbd3d6cb8fcd)

![image](https://github.com/user-attachments/assets/95489f9b-a167-4e15-aaf0-b8199a182e66)

![image](https://github.com/user-attachments/assets/f257975d-f755-4872-8f37-7d2e89641905)

![image](https://github.com/user-attachments/assets/9ecd317e-a745-4323-b5b6-0bfe538b6f29)

