### PR TITLE
Correct adjustment of annotations on OutputBasket type. Fixes #483.

### DIFF
--- a/csp/impl/types/pydantic_types.py
+++ b/csp/impl/types/pydantic_types.py
@@ -1,6 +1,7 @@
 import sys
 import types
 import typing
+from inspect import isclass
 from typing import Any, ForwardRef, Generic, Literal, Optional, Type, TypeVar, Union, get_args, get_origin
 
 from pydantic import GetCoreSchemaHandler, ValidationInfo, ValidatorFunctionWrapHandler
@@ -140,7 +141,9 @@ def adjust_annotations(
     args = get_args(annotation)
     if isinstance(annotation, str):
         annotation = TypeVar(annotation)
-    elif isinstance(annotation, OutputBasketContainer):
+    elif isinstance(annotation, OutputBasketContainer) or (
+        isclass(annotation) and issubclass(annotation, OutputBasket)
+    ):
         return OutputBasket(
             typ=adjust_annotations(
                 annotation.typ, top_level=False, in_ts=False, make_optional=False, forced_tvars=forced_tvars

--- a/csp/tests/impl/types/test_pydantic_types.py
+++ b/csp/tests/impl/types/test_pydantic_types.py
@@ -135,9 +135,23 @@ class TestAdjustAnnotations(TestCase):
         container = Dict[ts[str], ts[float]]
         self.assertAnnotationsEqual(adjust_annotations(container), DynamicBasketPydantic[str, float])
 
-    def test_output_basket(self):
+    def test_output_basket_list(self):
         container = OutputBasketContainer(List[ts["T"]], shape=5, eval_type=OutputBasketContainer.EvalType.WITH_SHAPE)
-        self.assertAnnotationsEqual(adjust_annotations(container), OutputBasket(typ=List[ts[CspTypeVarType[T]]]))
+        output = OutputBasket(typ=List[ts[CspTypeVarType[T]]])
+        self.assertAnnotationsEqual(adjust_annotations(container), output)
+        self.assertAnnotationsEqual(
+            adjust_annotations(output, forced_tvars={"T": float}), OutputBasket(typ=List[ts[float]])
+        )
+
+    def test_output_basket_dict(self):
+        container = OutputBasketContainer(
+            Dict["K", ts["T"]], shape=5, eval_type=OutputBasketContainer.EvalType.WITH_SHAPE
+        )
+        output = OutputBasket(typ=Dict[CspTypeVar[K], ts[CspTypeVarType[T]]])
+        self.assertAnnotationsEqual(adjust_annotations(container), output)
+        self.assertAnnotationsEqual(
+            adjust_annotations(output, forced_tvars={"K": int, "T": float}), OutputBasket(typ=Dict[int, ts[float]])
+        )
 
     def test_other(self):
         self.assertAnnotationsEqual(adjust_annotations(List[str]), List[str])

--- a/csp/tests/test_basketlib.py
+++ b/csp/tests/test_basketlib.py
@@ -41,11 +41,15 @@ class TestBasket(unittest.TestCase):
             synced_auto_dict = basketlib.sync(
                 x={"a": random_floats1, "b": random_floats_async}, threshold=self.sync_threshold, output_incomplete=True
             )
+            synced_int_dict = basketlib.sync(
+                x={0: random_floats1, 1: random_floats_async}, threshold=self.sync_threshold, output_incomplete=True
+            )
 
             csp.add_graph_output("synced_py", synced_py[1])
             csp.add_graph_output("synced_cpp", synced_cpp[1])
             csp.add_graph_output("synced_auto_list", synced_auto_list[1])
             csp.add_graph_output("synced_auto_dict", synced_auto_dict["b"])
+            csp.add_graph_output("synced_int_dict", synced_int_dict[1])
 
         seed = time.time()
         print(f"Seeding with {seed}")
@@ -55,6 +59,7 @@ class TestBasket(unittest.TestCase):
         self.assertEqual(results["synced_py"], results["synced_cpp"])
         self.assertEqual(results["synced_py"], results["synced_auto_list"])
         self.assertEqual(results["synced_auto_list"], results["synced_auto_dict"])
+        self.assertEqual(results["synced_auto_dict"], results["synced_int_dict"])
 
     def test_basic(self):
         @csp.graph()


### PR DESCRIPTION
Fixes #483. Required for revalidation of output basket types when an int type is present.

The original adjustment of annotations converts `OutputBasketContainer` to `OutputBasket`. So when re-validating the `int`-based outputs after type var resolution, it needs to be able to handle the `OutputBasket` type, which it wasn't doing before. This PR fixes that issue, and also adds an explicit test for `csp.basketlib.sync` for a dict basket with int types, in addition to unit tests on the annotation adjustment. 
