### PR TITLE
fixes #488 - allow StructMeta copyFrom / deepcopyFrom / updateFrom to…

### DIFF
--- a/cpp/csp/engine/Struct.h
+++ b/cpp/csp/engine/Struct.h
@@ -634,6 +634,9 @@ public:
 
     //returns true if derived == base or if derived is a derived type of base
     static bool isDerivedType( const StructMeta * derived, const StructMeta * base );
+    //Given two types x and y this will return one or the other based on which is a base class of the other.
+    //if x derives from y, returns y.  if y derives from x, returns x.  Otherwise this returns null.  NOTE this wont return a common ancestor
+    static const StructMeta * commonBase( const StructMeta * x, const StructMeta * y );
 
     template<typename T>
     std::shared_ptr<typename StructField::upcast<T>::type> getMetaField( const char * fieldname, const char * expectedtype );

--- a/csp/tests/impl/test_struct.py
+++ b/csp/tests/impl/test_struct.py
@@ -692,6 +692,15 @@ class TestCspStruct(unittest.TestCase):
                     for key in blank.metadata().keys():
                         self.assertEqual(getattr(blank, key), getattr(source, key), (typ, typ2, key))
 
+                    # Test other direction ( derived copy from base )
+                    blank = typ2()
+                    source = typ()
+                    for key in typ.metadata().keys():
+                        setattr(source, key, values[key])
+                    blank.copy_from(source)
+                    for key in source.metadata().keys():
+                        self.assertEqual(getattr(blank, key), getattr(source, key), (typ, typ2, key))
+
     def test_copy_from_unsets(self):
         source = DerivedMixed(i=1, f=2.3, i2=4, s2="woodchuck")
         dest1 = DerivedMixed(i=5, b=True, l2=[1, 2, 3])
@@ -711,6 +720,13 @@ class TestCspStruct(unittest.TestCase):
         self.assertTrue(dest2.f == 2.3)  # adds
         self.assertFalse(hasattr(dest2, "s"))  # unsets
         self.assertFalse(hasattr(dest2, "a1"))
+
+        # from base class -> derived
+        dest2 = BaseMixed(i=6, s="banana", a1=[4, 5, 6])
+        dest3 = DerivedMixed(i=5, b=True)
+        dest3.copy_from(dest2)
+        self.assertTrue(dest3.i == 6)  # overrides already set value
+        self.assertFalse(hasattr(dest3, "b"))  # unsets
 
     def test_deepcopy_from(self):
         source = StructWithLists(
@@ -750,6 +766,14 @@ class TestCspStruct(unittest.TestCase):
         self.assertTrue(dest2.f == 2.3)  # adds
         self.assertTrue(dest2.s == "banana")  # no unsets
         self.assertTrue(dest2.a1 == [4, 5, 6])
+
+        # update from base class
+        dest3 = DerivedMixed()
+        dest3.update_from(dest2)
+        self.assertTrue(dest3.i == 1)  # overrides already set value
+        self.assertTrue(dest3.f == 2.3)  # adds
+        self.assertTrue(dest3.s == "banana")  # no unsets
+        self.assertTrue(dest3.a1 == [4, 5, 6])
 
     def test_update(self):
         dest = DerivedMixed(i2=5, b=True, l2=[1, 2, 3], s="foo")


### PR DESCRIPTION
… work on base types as well