### PR TITLE
Improve performance of to_dict, and update docs

### DIFF
--- a/csp/impl/struct.py
+++ b/csp/impl/struct.py
@@ -256,15 +256,16 @@ class Struct(_csptypesimpl.PyStruct, metaclass=StructMeta):
         res = self._obj_to_python(self)
         return res
 
-    @classmethod
-    def postprocess_to_dict(self, obj):
-        """Postprocess hook for to_dict method
-
-        This method is invoked by to_dict after converting a struct to a dict
-        as an additional hook for users to modify the dict before it is returned
-        by the to_dict method
-        """
-        return obj
+    #  NOTE: Users can implement this method to customize the output of to_dict
+    #  @classmethod
+    #  def postprocess_to_dict(cls, obj):
+    #      """Postprocess hook for to_dict method
+    #
+    #      This method is invoked by to_dict after converting a struct to a dict
+    #      as an additional hook for users to modify the dict before it is returned
+    #      by the to_dict method
+    #      """
+    #      return obj
 
     def to_dict(self, callback=None):
         """Create a dictionary representation of the struct

--- a/docs/wiki/api-references/csp.Struct-API.md
+++ b/docs/wiki/api-references/csp.Struct-API.md
@@ -141,7 +141,9 @@ print(f"Using FastList field: value {s.a}, type {type(s.a)}, is Python list: {is
 - **`fromts(self, trigger=None, /, **kwargs)`**: similar to `collectts` above, `fromts` will create a ticking Struct timeseries from the valid values of all the provided inputs whenever any of them tick. `trigger` is an optional position-only argument which is used as a trigger timeseries for when to convert inputs into a struct tick. By default any input tick will generate a new struct of valid inputs
 - **`from_dict(self, dict)`**: convert a regular python dict to an instance of the struct
 - **`metadata(self)`**: returns the struct's metadata as a dictionary of key : type pairs
-- **`to_dict(self)`**: convert struct instance to a python dictionary
+- **`to_dict(self, callback=None)`**: convert struct instance to a python dictionary, if callback is not None it is invoked for any values encountered when processing the struct that are not basic Python types, datetime types, tuples, lists, sets, dicts, csp.Structs, or csp.Enums.
+- **`postprocess_to_dict(cls, obj)`**: if this method is defined on a `csp.Struct` class, the `to_dict` method will invoke this method on the dict obtained after processing the struct of this class to allow for further customization.
+- **`to_dict_depr(self)`**: convert struct instance to a python dictionary. \[DEPRECATED\]: This is a python only and slower implementation of to_dict which will be removed.
 - **`to_json(self, callback=lambda x: x)`**: convert struct instance to a json string, callback is invoked for any values encountered when processing the struct that are not basic Python types, datetime types, tuples, lists, dicts, csp.Structs, or csp.Enums. The callback should convert the unhandled type to a combination of the known types.
 - **`all_fields_set(self)`**: returns `True` if all the fields on the struct are set. Note that this will not recursively check sub-struct fields
 


### PR DESCRIPTION
This PR fixes #498 
- Remove unnecessary python round trip in to_dict
- Add documentation for to_dict, to_dict_depr, postprocess_to_dict methods

Some timing examples are shown below:
```
class A(csp.Struct):
  a: int
  b: str
  c: bool
  d: float
a = A(a=1, b="1", c=True, d=1.0)
# Original method
%timeit a.to_dict()         # 1.25 microseconds
# New method
%timeit a.to_dict()         # 0.99 microseconds

class E(csp.Struct):
  a: list
  b: dict
  c: tuple
  d: set
e = E(a=[1,2,3], b={1:1, 2:2, 3:3}, c=(1,2,3), d={1,2,3})
# Original method
%timeit a.to_dict()         # 3.01 microseconds
# New method
%timeit a.to_dict()         # 2.56 microseconds
```