### PR TITLE
Throw on parse if an input is a Union of ts and scalars.

### DIFF
--- a/csp/impl/wiring/base_parser.py
+++ b/csp/impl/wiring/base_parser.py
@@ -135,6 +135,16 @@ class BaseParser(ast.NodeTransformer, metaclass=ABCMeta):
                     if tstype.isTsType(typ.__args__[0]):
                         return ArgKind.DYNAMIC_BASKET_TS, BasketKind.DYNAMIC_DICT
                     return ArgKind.BASKET_TS, BasketKind.DICT
+        elif CspTypingUtils.is_union_type(typ):
+            args = [arg for arg in typing.get_args(typ) if arg is not None and arg is not type(None)]
+            args_ts_status = [
+                argkind.is_any_ts() for argkind, _basket_kind in [cls._resolve_input_type_kind(arg) for arg in args]
+            ]
+            if all(args_ts_status):
+                return ArgKind.TS, None
+            elif not any(args_ts_status):
+                return ArgKind.SCALAR, None
+            raise ValueError(f"Cannot mix TS and non-TS types in a union {typ}")
         return ArgKind.SCALAR, None
 
     @staticmethod


### PR DESCRIPTION
Special case None, so `Optional[ts...` is allowed

This applies to both csp.graphs and csp.nodes

Addresses https://github.com/Point72/csp/issues/495