### PR TITLE
Allow csp.Struct as a generic field member to be autogened.  Fixes cr…

### DIFF
--- a/cpp/csp/python/PyStruct.cpp
+++ b/cpp/csp/python/PyStruct.cpp
@@ -272,7 +272,8 @@ static PyObjectPtr PyStructMeta_typeinfo( const CspType * type )
     {
         auto const * structType = static_cast<const CspStructType*>( type );
         auto const * structMeta = static_cast<const DialectStructMeta*>( structType -> meta().get() );
-        if( PyDict_SetItemString( out.get(), "pytype", ( PyObject * ) structMeta -> pyType() ) < 0 )
+        PyObject * pyType = structMeta ? ( PyObject * ) structMeta -> pyType() : Py_None;
+        if( PyDict_SetItemString( out.get(), "pytype", pyType ) < 0 )
             CSP_THROW( PythonPassthrough, "" );
     }
     else if( type -> type() == CspType::Type::ARRAY )

--- a/csp/build/csp_autogen.py
+++ b/csp/build/csp_autogen.py
@@ -19,6 +19,9 @@ from csp.impl.struct import Struct  # noqa: E402
 
 
 def struct_type(type_info):
+    # If struct pytype is None then we are dealing with a generic csp.Struct field type
+    if type_info["pytype"] is None:
+        return "csp::StructPtr"
     return f"""csp::autogen::{type_info["pytype"].__name__}::Ptr"""
 
 

--- a/csp/tests/impl/test_struct.py
+++ b/csp/tests/impl/test_struct.py
@@ -4201,6 +4201,18 @@ class TestCspStruct(unittest.TestCase):
                 with self.assertRaises(ValidationError):
                     TypeAdapter(PipeTypesConfig).validate_python(case)
 
+    def test__metadata_info(self):
+        class MyStruct(DerivedMixed):
+            typed: BaseNative
+            generic: csp.Struct
+
+        metadata_info = MyStruct._metadata_info()
+        self.assertEqual(metadata_info["is_native"], False)
+        typed_field = [f for f in metadata_info["fields"] if f["fieldname"] == "typed"][0]
+        generic_field = [f for f in metadata_info["fields"] if f["fieldname"] == "generic"][0]
+        self.assertEqual(typed_field["type"]["pytype"], BaseNative)
+        self.assertEqual(generic_field["type"]["pytype"], None)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
…ash on _metadata_info in this case