### PR TITLE
Pin cmake to <4 as 4 is not compatible with external deps which allow <3.5

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -203,7 +203,8 @@ dependencies-vcpkg:  ## install dependencies via vcpkg
 	cd vcpkg && ./bootstrap-vcpkg.sh && ./vcpkg install
 
 dependencies-win:  ## install dependencies via windows
-	choco install cmake curl winflexbison ninja unzip zip --no-progress -y
+	choco install cmake --version=3.31.6
+	choco install curl winflexbison ninja unzip zip --no-progress -y
 
 ############################################################################################
 # Thanks to Francoise at marmelab.com for this


### PR DESCRIPTION
Test run: https://github.com/Point72/csp/actions/runs/14174868460/job/39707225211

Fixes #508 temporarily until vcpkg ports are updated to be cmake 4.0 compatible