### PR TITLE
Upgrade ubuntu runner version for test_dependencies, builds are failing as its retired

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -650,7 +650,7 @@ jobs:
       strategy:
         matrix:
           os:
-            - ubuntu-20.04
+            - ubuntu-24.04
           python-version:
             - 3.9
           package:


### PR DESCRIPTION
GH Actions removed the ubuntu 20.04 runner on 2025-04-15, this is causing "test_dependencies" to fail https://github.com/actions/runner-images/issues/11101

Kicked off full run here: https://github.com/Point72/csp/actions/runs/14598551138