### PR TITLE
Add missing astor package to development environment

### DIFF
--- a/conda/dev-environment-unix.yml
+++ b/conda/dev-environment-unix.yml
@@ -3,6 +3,7 @@ channels:
   - conda-forge
   - nodefaults
 dependencies:
+ - astor
  - bison
  - brotli
  - bump-my-version

--- a/conda/dev-environment-win.yml
+++ b/conda/dev-environment-win.yml
@@ -4,6 +4,7 @@ channels:
   - nodefaults
 dependencies:
 #  - bison  # not available on windows
+ - astor
  - brotli
  - bump-my-version
  - cmake


### PR DESCRIPTION
Used in our code for debugging ast modifications (debug_print=True requires this package)