### PR TITLE
Take self as argument in postprocess_to_dict

### DIFF
--- a/cpp/csp/python/PyStructToDict.cpp
+++ b/cpp/csp/python/PyStructToDict.cpp
@@ -170,10 +170,10 @@ PyObjectPtr StructToDictHelper::parseStructToDictRecursive( const StructPtr& sel
     }
 
     // Optional postprocess hook in python to allow caller to customize to_dict behavior for struct
-    PyObject * py_type = ( PyObject * ) meta -> pyType();
-    if( PyObject_HasAttrString( py_type, "postprocess_to_dict" ) )
+    auto py_struct = PyObjectPtr::own( toPython( self ) );
+    if( PyObject_HasAttrString( py_struct.get(), "postprocess_to_dict" ) )
     {
-        auto postprocess_dict_callable = PyObjectPtr::own( PyObject_GetAttrString( py_type, "postprocess_to_dict" ) );
+        auto postprocess_dict_callable = PyObjectPtr::own( PyObject_GetAttrString( py_struct.get(), "postprocess_to_dict" ) );
         new_dict = PyObjectPtr::check( PyObject_CallFunction( postprocess_dict_callable.get(), "(O)", new_dict.get() ) );
     }
     return new_dict;

--- a/csp/impl/struct.py
+++ b/csp/impl/struct.py
@@ -261,8 +261,7 @@ class Struct(_csptypesimpl.PyStruct, metaclass=StructMeta):
         return res
 
     #  NOTE: Users can implement this method to customize the output of to_dict
-    #  @classmethod
-    #  def postprocess_to_dict(cls, obj):
+    #  def postprocess_to_dict(self, obj):
     #      """Postprocess hook for to_dict method
     #
     #      This method is invoked by to_dict after converting a struct to a dict

--- a/csp/tests/impl/test_struct.py
+++ b/csp/tests/impl/test_struct.py
@@ -1522,20 +1522,27 @@ class TestCspStruct(unittest.TestCase):
         class MySubStruct(csp.Struct):
             i: int = 0
 
-            def postprocess_to_dict(obj):
+            def postprocess_to_dict(self, obj):
                 obj["postprocess_called"] = True
+                obj["postprocess_val"] = self.i
                 return obj
 
         class MyStruct(csp.Struct):
             i: int = 1
             mss: MySubStruct = MySubStruct()
 
-            def postprocess_to_dict(obj):
+            def postprocess_to_dict(self, obj):
                 obj["postprocess_called"] = True
+                obj["postprocess_val"] = self.i
                 return obj
 
-        test_struct = MyStruct()
-        result_dict = {"i": 1, "postprocess_called": True, "mss": {"i": 0, "postprocess_called": True}}
+        test_struct = MyStruct(i=5)
+        result_dict = {
+            "i": 5,
+            "postprocess_called": True,
+            "postprocess_val": 5,
+            "mss": {"i": 0, "postprocess_called": True, "postprocess_val": 0},
+        }
         self.assertEqual(test_struct.to_dict(), result_dict)
 
     def test_to_dict_preserve_enums(self):


### PR DESCRIPTION
This is a breaking change as it involves changing the API interface for `postprocess_to_dict`.

The current definition for `postprocess_to_dict` just takes the dictionary as argument.
With this PR, `postprocess_to_dict` will take struct instance (`self`) and the dictionary for that `struct` as arguments.

The previous API did not allow modifying the dictionary based on the state of the `struct` instance.