### PR TITLE
Avoid numerical imprecision for rolling variance in the case all values are identical

### DIFF
--- a/cpp/csp/cppnodes/statsimpl.h
+++ b/cpp/csp/cppnodes/statsimpl.h
@@ -449,7 +449,7 @@ class Variance
 
         // Below variables are used to eliminate numerical errors when all values in the window are identical
         double m_lastValue;
-        int64_t m_consecutiveValueCount = 0;
+        int64_t m_consecutiveValueCount;
 };
 
 class WeightedVariance
@@ -472,7 +472,7 @@ class WeightedVariance
                 return;
             
             // See comment in Variance::add on handling homogeneous data streams
-            m_consecutiveValueCount = ( m_count && x == m_lastValue ? m_consecutiveValueCount + 1 : 1 );
+            m_consecutiveValueCount = ( m_consecutiveValueCount && x == m_lastValue ? m_consecutiveValueCount + 1 : 1 );
             m_lastValue = x;
 
             m_count++;

--- a/cpp/csp/cppnodes/statsimpl.h
+++ b/cpp/csp/cppnodes/statsimpl.h
@@ -445,7 +445,7 @@ class Variance
             if( m_count > m_ddof )
             {
                 // Check if all values are identical
-                if( m_consecutiveValueCount >= m_count )
+                if( m_consecutiveValueCount >= m_count [[unlikely]])
                     return 0.0;
                 return ( m_unnormVar < 0 ? 0 : m_unnormVar / ( m_count - m_ddof ) );
             }
@@ -532,8 +532,8 @@ class WeightedVariance
         {
             if( m_wsum > m_ddof )
             {
-                // Check if all values are identical (pandas approach)
-                if( m_count == 1 || m_consecutiveValueCount >= m_count )
+                // Check if all values are identical
+                if( m_consecutiveValueCount >= m_count [[unlikely]])
                     return 0.0;
                 return ( m_unnormWVar < 0 ? 0 : m_unnormWVar / ( m_wsum - m_ddof ) );
             }

--- a/csp/tests/test_stats.py
+++ b/csp/tests/test_stats.py
@@ -3721,7 +3721,7 @@ class TestStats(unittest.TestCase):
         @csp.graph
         def graph():
             # Generate data with identical values in each 10 second window, 20 times to get some error accumulated
-            data = csp.curve(float, [(st + timedelta(seconds=i + 1), get_val(i + 1)) for i in range(K * N)])
+            data = csp.curve(float, [(st + timedelta(seconds=i + 1), get_val(i)) for i in range(K * N)])
 
             # Generate random weights
             w = np.random.uniform(low=0.1, high=1.0, size=K * N)

--- a/csp/tests/test_stats.py
+++ b/csp/tests/test_stats.py
@@ -3670,47 +3670,9 @@ class TestStats(unittest.TestCase):
         )
         np.testing.assert_allclose(res["ema_std"][1], golden_ema_std, atol=1e-10)
 
-        golden_ema_std = np.array(
-            [
-                pd.Series(values[max(0, j - horizon + 1) : j + 1]).ewm(alpha=alpha, ignore_na=True).std().iloc[-1]
-                for j in range(N)
-            ]
-        )
-        np.testing.assert_allclose(res["ema_std"][1], golden_ema_std, atol=1e-10)
-
     def test_identical_values_variance(self):
         """Test that variance and weighted variance are exactly 0 when all values in window are identical"""
         st = datetime(2023, 1, 1, 9, 0, 0)
-
-        @csp.node
-        def generate_data() -> csp.ts[float]:
-            """Generate data with periods of identical values"""
-            with csp.alarms():
-                alarm = csp.alarm(bool)
-
-            with csp.start():
-                # Period 1: 5 ticks of -1.0
-                for i in range(5):
-                    csp.schedule_alarm(alarm, timedelta(seconds=i * 10), True)
-
-                # Period 2: 5 ticks of -2.0
-                for i in range(5):
-                    csp.schedule_alarm(alarm, timedelta(minutes=1, seconds=i * 10), True)
-
-                # Period 3: 5 ticks of -3.0
-                for i in range(5):
-                    csp.schedule_alarm(alarm, timedelta(minutes=2, seconds=i * 10), True)
-
-            if csp.ticked(alarm):
-                current_time = csp.now()
-                seconds = (current_time - st).total_seconds()
-
-                if seconds < 60:
-                    return -1.0  # Period 1
-                elif seconds < 120:
-                    return -2.0  # Period 2
-                else:
-                    return -3.0  # Period 3
 
         K = 10
         N = 20


### PR DESCRIPTION
Moved from #554, closes #552 