### PR TITLE
Fix conda build for gcc 14.3

### DIFF
--- a/cpp/csp/python/PyBasketInputProxy.cpp
+++ b/cpp/csp/python/PyBasketInputProxy.cpp
@@ -265,7 +265,7 @@ static void PyListBasketInputProxy_dealloc( PyListBasketInputProxy * self )
 {
     CSP_BEGIN_METHOD;
     self -> ~PyListBasketInputProxy();
-    Py_TYPE( self ) -> tp_free( self ); 
+    PyListBasketInputProxy::PyType.tp_free( self ); 
     CSP_RETURN;
 }
 
@@ -419,7 +419,7 @@ static void PyDictBasketInputProxy_dealloc( PyDictBasketInputProxy * self )
 {
     CSP_BEGIN_METHOD;
     self -> ~PyDictBasketInputProxy();
-    Py_TYPE( self ) -> tp_free( self ); 
+    PyDictBasketInputProxy::PyType.tp_free( self ); 
     CSP_RETURN;
 }
 
@@ -643,7 +643,7 @@ static void PyDynamicBasketInputProxy_dealloc( PyDynamicBasketInputProxy * self 
 {
     CSP_BEGIN_METHOD;
     self -> ~PyDynamicBasketInputProxy();
-    Py_TYPE( self ) -> tp_free( self ); 
+    PyDynamicBasketInputProxy::PyType.tp_free( self ); 
     CSP_RETURN;
 }
 

--- a/cpp/csp/python/PyBasketOutputProxy.cpp
+++ b/cpp/csp/python/PyBasketOutputProxy.cpp
@@ -37,7 +37,7 @@ static void PyListBasketOutputProxy_dealloc( PyListBasketOutputProxy * self )
 {
     CSP_BEGIN_METHOD;
     self -> ~PyListBasketOutputProxy();
-    Py_TYPE( self ) -> tp_free( self ); 
+    PyListBasketOutputProxy::PyType.tp_free( self ); 
     CSP_RETURN;
 }
 
@@ -182,7 +182,7 @@ static void PyDictBasketOutputProxy_dealloc( PyDictBasketOutputProxy * self )
 {
     CSP_BEGIN_METHOD;
     self -> ~PyDictBasketOutputProxy();
-    Py_TYPE( self ) -> tp_free( self ); 
+    PyDictBasketOutputProxy::PyType.tp_free( self ); 
     CSP_RETURN;
 }
 
@@ -306,7 +306,7 @@ static void PyDynamicBasketOutputProxy_dealloc( PyDynamicBasketOutputProxy * sel
 {
     CSP_BEGIN_METHOD;
     self -> ~PyDynamicBasketOutputProxy();
-    Py_TYPE( self ) -> tp_free( self );
+    PyDynamicBasketOutputProxy::PyType.tp_free( self );
     CSP_RETURN;
 }
 

--- a/cpp/csp/python/PyCspEnum.cpp
+++ b/cpp/csp/python/PyCspEnum.cpp
@@ -116,7 +116,7 @@ void PyCspEnumMeta_dealloc( PyCspEnumMeta * m )
 {
     CspTypeFactory::instance().removeCachedType( reinterpret_cast<PyTypeObject*>( m ) );
     m -> ~PyCspEnumMeta();
-    Py_TYPE( m ) -> tp_free( m );
+    PyCspEnumMeta::PyType.tp_free( m );
 }
 
 PyObject * PyCspEnumMeta_subscript( PyCspEnumMeta * self, PyObject * key )
@@ -187,7 +187,7 @@ PyTypeObject PyCspEnumMeta::PyType = {
 void PyCspEnum_dealloc( PyCspEnum * self )
 {
     self -> ~PyCspEnum();
-    Py_TYPE( self ) -> tp_free( self );
+    PyCspEnum::PyType.tp_free( self );
 }
 
 PyObject * PyCspEnum_new( PyTypeObject * type, PyObject *args, PyObject *kwds )

--- a/cpp/csp/python/PyOutputProxy.cpp
+++ b/cpp/csp/python/PyOutputProxy.cpp
@@ -24,7 +24,7 @@ static void PyOutputProxy_dealloc( PyOutputProxy * self )
     CSP_BEGIN_METHOD;
 
     ( self ) -> ~PyOutputProxy();
-    Py_TYPE( self ) -> tp_free( self ); 
+    PyOutputProxy::PyType.tp_free( self ); 
 
     CSP_RETURN;
 }

--- a/cpp/csp/python/PyStruct.cpp
+++ b/cpp/csp/python/PyStruct.cpp
@@ -241,7 +241,7 @@ void PyStructMeta_dealloc( PyStructMeta * m )
 {
     CspTypeFactory::instance().removeCachedType( reinterpret_cast<PyTypeObject*>( m ) );
     m -> ~PyStructMeta();
-    Py_TYPE( m ) -> tp_free( m );
+    PyStructMeta::PyType.tp_free( m );
 }
 
 PyObject * PyStructMeta_layout( PyStructMeta * m )
@@ -768,7 +768,7 @@ void PyStruct_dealloc( PyStruct * self )
     self -> struct_ -> setDialectPtr( nullptr );
 
     self -> ~PyStruct();
-    Py_TYPE( self ) -> tp_free( self );
+    PyStruct::PyType.tp_free( self );
 }
 
 void PyStruct_setattrs( PyStruct * self, PyObject * args, PyObject * kwargs, const char * methodName )

--- a/cpp/tests/core/test_dynamicbitset.cpp
+++ b/cpp/tests/core/test_dynamicbitset.cpp
@@ -1,5 +1,7 @@
 #include <gtest/gtest.h>
 #include <csp/core/DynamicBitSet.h>
+
+#include <algorithm>
 #include <unordered_set>
 #include <random>
 #include <vector>


### PR DESCRIPTION
GH Actions runners updated gcc from 13.3 to 14.3 which caused the scheduled build to failure. Two changes:

1. It looks like gcc 14.3 has an errant warning on CSP objects when calling `Py_TYPE( self )` in destructor/free functions. The function is inlined and accesses the `ob_type` member of the object, but the compiler thinks the object has been destroyed since we called its destructor on the line above. Example:
```raw
In function 'PyTypeObject* Py_TYPE(PyObject*)',
    inlined from 'void csp::python::PyStruct_dealloc(PyStruct*)' at /data01/home/ag11460/user/github/csp/cpp/csp/python/PyStruct.cpp:771:5:
/data01/home/ag11460/y/envs/csp/include/python3.12/object.h:220:16: error: '*(PyObject*)self._object::ob_type' is used uninitialized [-Werror=uninitialized]
  220 |     return ob->ob_type;
      |                ^~~~~~~
```

2. [Need to explicitly include the algorithm header in gcc14 ](https://gcc.gnu.org/gcc-14/porting_to.html#header-dep-changes)