### PR TITLE
Add support for unadjusted halflife-based EMA calculations

### DIFF
--- a/cpp/csp/cppnodes/statsimpl.cpp
+++ b/cpp/csp/cppnodes/statsimpl.cpp
@@ -299,7 +299,7 @@ EXPORT_TEMPLATE_CPPNODE( _rank,             SINGLE_ARG( _computeTwoArg<int64_t, 
 EXPORT_TEMPLATE_CPPNODE( _kurt,             SINGLE_ARG( _computeTwoArg<bool, Kurtosis> ) );
 EXPORT_TEMPLATE_CPPNODE( _ema_compute,      _computeEMA<EMA> );
 EXPORT_TEMPLATE_CPPNODE( _ema_adjusted,     _computeEMA<AdjustedEMA>);
-EXPORT_TEMPLATE_CPPNODE( _ema_debias_alpha, _computeEMA<AlphaDebiasEMA> );
+EXPORT_TEMPLATE_CPPNODE( _ema_alpha_debias, _computeEMA<AlphaDebiasEMA> );
 
 
 // The following nodes are written independently from _compute
@@ -533,10 +533,12 @@ DECLARE_CPPNODE ( _quantile )
 EXPORT_CPPNODE ( _quantile );
 
 template<typename C>
-DECLARE_CPPNODE( _exp_timewise )
+DECLARE_CPPNODE( _exp_halflife )
 {
     TS_INPUT( double, x );
     SCALAR_INPUT( TimeDelta, halflife );
+    SCALAR_INPUT( bool, adjust );
+
     TS_INPUT( Generic, trigger );
     TS_INPUT( Generic, sampler );
     TS_INPUT( Generic, reset );
@@ -545,11 +547,11 @@ DECLARE_CPPNODE( _exp_timewise )
     STATE_VAR( DataValidator<C>, s_computation );
     TS_OUTPUT( double );
 
-    INIT_CPPNODE( _exp_timewise ) { }
+    INIT_CPPNODE( _exp_halflife ) { }
 
     START()
     {
-        s_computation = DataValidator<C>( min_data_points, true, halflife, now() );
+        s_computation = DataValidator<C>( min_data_points, true, halflife, now(), adjust );
     }
 
     INVOKE()
@@ -571,8 +573,9 @@ DECLARE_CPPNODE( _exp_timewise )
     }
 };
 
-EXPORT_TEMPLATE_CPPNODE( _ema_timewise,         _exp_timewise<HalflifeEMA> );
-EXPORT_TEMPLATE_CPPNODE( _ema_debias_halflife,  _exp_timewise<HalflifeDebiasEMA> );
+EXPORT_TEMPLATE_CPPNODE( _ema_halflife,             _exp_halflife<HalflifeEMA> );
+EXPORT_TEMPLATE_CPPNODE( _ema_halflife_adjusted,    _exp_halflife<AdjustedHalflifeEMA> );
+EXPORT_TEMPLATE_CPPNODE( _ema_halflife_debias,      _exp_halflife<HalflifeDebiasEMA> );
 
 DECLARE_CPPNODE( _arg_min_max )
 {

--- a/cpp/csp/python/cspnpstatsimpl.cpp
+++ b/cpp/csp/python/cspnpstatsimpl.cpp
@@ -47,9 +47,10 @@ REGISTER_CPPNODE( csp::python,  _np_weighted_kurt );
 // EMA nodes
 REGISTER_CPPNODE( csp::python,  _np_ema_compute );
 REGISTER_CPPNODE( csp::python,  _np_ema_adjusted );
-REGISTER_CPPNODE( csp::python,  _np_ema_timewise );
-REGISTER_CPPNODE( csp::python,  _np_ema_debias_alpha );
-REGISTER_CPPNODE( csp::python,  _np_ema_debias_halflife );
+REGISTER_CPPNODE( csp::python,  _np_ema_halflife );
+REGISTER_CPPNODE( csp::python,  _np_ema_halflife_adjusted );
+REGISTER_CPPNODE( csp::python,  _np_ema_alpha_debias );
+REGISTER_CPPNODE( csp::python,  _np_ema_halflife_debias );
 
 
 static PyModuleDef _cspnpstatsimpl_module = {

--- a/cpp/csp/python/cspstatsimpl.cpp
+++ b/cpp/csp/python/cspstatsimpl.cpp
@@ -40,9 +40,10 @@ REGISTER_CPPNODE( csp::cppnodes,  _weighted_kurt );
 // EMA nodes
 REGISTER_CPPNODE( csp::cppnodes,  _ema_compute );
 REGISTER_CPPNODE( csp::cppnodes,  _ema_adjusted );
-REGISTER_CPPNODE( csp::cppnodes,  _ema_timewise );
-REGISTER_CPPNODE( csp::cppnodes,  _ema_debias_alpha );
-REGISTER_CPPNODE( csp::cppnodes,  _ema_debias_halflife );
+REGISTER_CPPNODE( csp::cppnodes,  _ema_halflife );
+REGISTER_CPPNODE( csp::cppnodes,  _ema_halflife_adjusted );
+REGISTER_CPPNODE( csp::cppnodes,  _ema_alpha_debias );
+REGISTER_CPPNODE( csp::cppnodes,  _ema_halflife_debias );
 
 static PyModuleDef _cspstatsimpl_module = {
     PyModuleDef_HEAD_INIT,

--- a/cpp/csp/python/npstatsimpl.cpp
+++ b/cpp/csp/python/npstatsimpl.cpp
@@ -681,7 +681,7 @@ EXPORT_TEMPLATE_CPPNODE( _np_rank,              SINGLE_ARG( _npComputeTwoArg<int
 EXPORT_TEMPLATE_CPPNODE( _np_kurt,              SINGLE_ARG( _npComputeTwoArg<bool, Kurtosis> ) );
 EXPORT_TEMPLATE_CPPNODE( _np_ema_compute,       _npComputeEMA<EMA> );
 EXPORT_TEMPLATE_CPPNODE( _np_ema_adjusted,      _npComputeEMA<AdjustedEMA>);
-EXPORT_TEMPLATE_CPPNODE( _np_ema_debias_alpha,  _npComputeEMA<AlphaDebiasEMA> );
+EXPORT_TEMPLATE_CPPNODE( _np_ema_alpha_debias,  _npComputeEMA<AlphaDebiasEMA> );
 
 // Bivariate
 template<typename C>
@@ -914,10 +914,12 @@ EXPORT_CPPNODE ( _np_quantile );
 
 // C: computation class
 template<typename C>
-DECLARE_CPPNODE( _np_exp_timewise )
+DECLARE_CPPNODE( _np_exp_halflife )
 {
     TS_INPUT( PyObjectPtr, x );
     SCALAR_INPUT( TimeDelta, halflife );
+    SCALAR_INPUT( bool, adjust );
+
     TS_INPUT( Generic, trigger );
     TS_INPUT( Generic, sampler );
     TS_INPUT( Generic, reset );
@@ -929,7 +931,7 @@ DECLARE_CPPNODE( _np_exp_timewise )
 
     TS_OUTPUT( PyObjectPtr );
 
-    INIT_CPPNODE( _np_exp_timewise ) { }
+    INIT_CPPNODE( _np_exp_halflife ) { }
 
     INVOKE()
     {
@@ -948,7 +950,7 @@ DECLARE_CPPNODE( _np_exp_timewise )
                 s_elem.reserve( s_shp.m_n );
                 for( int64_t j = 0; j < s_shp.m_n; j++ )
                 {
-                    s_elem.emplace_back( DataValidator<C>( min_data_points, true, halflife, now() - TimeDelta::fromMicroseconds( 1 ) ) );
+                    s_elem.emplace_back( DataValidator<C>( min_data_points, true, halflife, now() - TimeDelta::fromMicroseconds( 1 ), adjust ) );
                 }
                 s_first = false;
             }
@@ -964,8 +966,9 @@ DECLARE_CPPNODE( _np_exp_timewise )
     }
 };
 
-EXPORT_TEMPLATE_CPPNODE( _np_ema_timewise, _np_exp_timewise<HalflifeEMA> );
-EXPORT_TEMPLATE_CPPNODE( _np_ema_debias_halflife, _np_exp_timewise<HalflifeDebiasEMA> );
+EXPORT_TEMPLATE_CPPNODE( _np_ema_halflife,          _np_exp_halflife<HalflifeEMA> );
+EXPORT_TEMPLATE_CPPNODE( _np_ema_halflife_adjusted, _np_exp_halflife<AdjustedHalflifeEMA> );
+EXPORT_TEMPLATE_CPPNODE( _np_ema_halflife_debias,   _np_exp_halflife<HalflifeDebiasEMA> );
 
 template<typename C>
 DECLARE_CPPNODE( _np_matrix_compute )

--- a/csp/stats.py
+++ b/csp/stats.py
@@ -1228,50 +1228,92 @@ def _np_ema_adjusted(
     return 0
 
 
-@csp.node(cppimpl=_cspstatsimpl._ema_timewise)
-def _ema_timewise(
-    x: ts[float], halflife: timedelta, trigger: ts[object], sampler: ts[object], reset: ts[object], min_data_points: int
+@csp.node(cppimpl=_cspstatsimpl._ema_halflife)
+def _ema_halflife(
+    x: ts[float],
+    halflife: timedelta,
+    adjust: bool,
+    trigger: ts[object],
+    sampler: ts[object],
+    reset: ts[object],
+    min_data_points: int,
 ) -> ts[float]:
-    raise NotImplementedError("_ema_timewise only implemented in C++")
+    raise NotImplementedError("_ema_halflife only implemented in C++")
     return 0
 
 
-@csp.node(cppimpl=_cspnpstatsimpl._np_ema_timewise)
-def _np_ema_timewise(
+@csp.node(cppimpl=_cspstatsimpl._ema_halflife_adjusted)
+def _ema_halflife_adjusted(
+    x: ts[float],
+    halflife: timedelta,
+    adjust: bool,
+    trigger: ts[object],
+    sampler: ts[object],
+    reset: ts[object],
+    min_data_points: int,
+) -> ts[float]:
+    raise NotImplementedError("_ema_halflife_adjusted only implemented in C++")
+    return 0
+
+
+@csp.node(cppimpl=_cspnpstatsimpl._np_ema_halflife)
+def _np_ema_halflife(
     x: ts[np.ndarray],
     halflife: timedelta,
+    adjust: bool,
     trigger: ts[object],
     sampler: ts[object],
     reset: ts[object],
     min_data_points: int,
 ) -> ts[np.ndarray]:
-    raise NotImplementedError("_np_ema_timewise only implemented in C++")
+    raise NotImplementedError("_np_ema_halflife only implemented in C++")
     return 0
 
 
-@csp.node(cppimpl=_cspstatsimpl._ema_debias_halflife)
-def _ema_debias_halflife(
-    x: ts[float], halflife: timedelta, trigger: ts[object], sampler: ts[object], reset: ts[object], min_data_points: int
-) -> ts[float]:
-    raise NotImplementedError("_ema_debias_halflife only implemented in C++")
-    return 0
-
-
-@csp.node(cppimpl=_cspnpstatsimpl._np_ema_debias_halflife)
-def _np_ema_debias_halflife(
+@csp.node(cppimpl=_cspnpstatsimpl._np_ema_halflife_adjusted)
+def _np_ema_halflife_adjusted(
     x: ts[np.ndarray],
     halflife: timedelta,
+    adjust: bool,
     trigger: ts[object],
     sampler: ts[object],
     reset: ts[object],
     min_data_points: int,
 ) -> ts[np.ndarray]:
-    raise NotImplementedError("_np_ema_debias_halflife only implemented in C++")
+    raise NotImplementedError("_np_ema_halflife_adjusted only implemented in C++")
     return 0
 
 
-@csp.node(cppimpl=_cspstatsimpl._ema_debias_alpha)
-def _ema_debias_alpha(
+@csp.node(cppimpl=_cspstatsimpl._ema_halflife_debias)
+def _ema_halflife_debias(
+    x: ts[float],
+    halflife: timedelta,
+    adjust: bool,
+    trigger: ts[object],
+    sampler: ts[object],
+    reset: ts[object],
+    min_data_points: int,
+) -> ts[float]:
+    raise NotImplementedError("_ema_halflife_debias only implemented in C++")
+    return 0
+
+
+@csp.node(cppimpl=_cspnpstatsimpl._np_ema_halflife_debias)
+def _np_ema_halflife_debias(
+    x: ts[np.ndarray],
+    halflife: timedelta,
+    adjust: bool,
+    trigger: ts[object],
+    sampler: ts[object],
+    reset: ts[object],
+    min_data_points: int,
+) -> ts[np.ndarray]:
+    raise NotImplementedError("_np_ema_halflife_debias only implemented in C++")
+    return 0
+
+
+@csp.node(cppimpl=_cspstatsimpl._ema_alpha_debias)
+def _ema_alpha_debias(
     additions: ts[List[float]],
     removals: ts[List[float]],
     alpha: float,
@@ -1282,12 +1324,12 @@ def _ema_debias_alpha(
     reset: ts[object],
     min_data_points: int,
 ) -> ts[float]:
-    raise NotImplementedError("_ema_debias_alpha only implemented in C++")
+    raise NotImplementedError("_ema_alpha_debias only implemented in C++")
     return 0
 
 
-@csp.node(cppimpl=_cspnpstatsimpl._np_ema_debias_alpha)
-def _np_ema_debias_alpha(
+@csp.node(cppimpl=_cspnpstatsimpl._np_ema_alpha_debias)
+def _np_ema_alpha_debias(
     additions: ts[List[np.ndarray]],
     removals: ts[List[np.ndarray]],
     alpha: float,
@@ -1298,7 +1340,7 @@ def _np_ema_debias_alpha(
     reset: ts[object],
     min_data_points: int,
 ) -> ts[np.ndarray]:
-    raise NotImplementedError("_np_ema_debias_alpha only implemented in C++")
+    raise NotImplementedError("_np_ema_alpha_debias only implemented in C++")
     return 0
 
 
@@ -1321,18 +1363,18 @@ def _ema_debias(
         if not horizon:
             horizon = 0
         if x.tstype.typ is float:
-            return _ema_debias_alpha(
+            return _ema_alpha_debias(
                 additions, removals, alpha, ignore_na, horizon, adjust, trigger, reset, min_data_points
             )
         else:
-            return _np_ema_debias_alpha(
+            return _np_ema_alpha_debias(
                 additions, removals, alpha, ignore_na, horizon, adjust, trigger, reset, min_data_points
             )
 
     if x.tstype.typ is float:
-        return _ema_debias_halflife(x, halflife, trigger, sampler, reset, min_data_points)
+        return _ema_halflife_debias(x, halflife, adjust, trigger, sampler, reset, min_data_points)
 
-    return _np_ema_debias_halflife(x, halflife, trigger, sampler, reset, min_data_points)
+    return _np_ema_halflife_debias(x, halflife, adjust, trigger, sampler, reset, min_data_points)
 
 
 @csp.node(cppimpl=_cspstatsimpl._cross_sectional_as_list)
@@ -2912,9 +2954,11 @@ def ema(
     edge = None
     if series.tstype.typ is float:
         if halflife:
-            edge = _ema_timewise(
-                series, halflife, trigger, sampler, reset, min_data_points
-            )  # ignore na does not matter, same functionality for this case
+            # ignore na does not matter for the halflife case; adjust parameter does not need to be passed here either, set as False
+            if adjust:
+                edge = _ema_halflife_adjusted(series, halflife, False, trigger, sampler, reset, min_data_points)
+            else:
+                edge = _ema_halflife(series, halflife, False, trigger, sampler, reset, min_data_points)
         elif adjust:
             edge = _ema_adjusted(
                 updates.additions,
@@ -2933,7 +2977,10 @@ def ema(
             )
     elif series.tstype.typ in [Numpy1DArray[float], NumpyNDArray[float]]:
         if halflife:
-            edge = _np_ema_timewise(series, halflife, trigger, sampler, reset, min_data_points)
+            if adjust:
+                edge = _np_ema_halflife_adjusted(series, halflife, False, trigger, sampler, reset, min_data_points)
+            else:
+                edge = _np_ema_halflife(series, halflife, False, trigger, sampler, reset, min_data_points)
         elif adjust:
             edge = _np_ema_adjusted(
                 updates.additions,

--- a/csp/tests/test_stats.py
+++ b/csp/tests/test_stats.py
@@ -6,10 +6,11 @@ from datetime import datetime, timedelta
 import numpy as np
 import numpy.testing
 import pandas as pd
+from pandas.testing import assert_series_equal
 
 import csp
 from csp.stats import _window_updates
-from csp.typing import Numpy1DArray, NumpyNDArray
+from csp.typing import Numpy1DArray
 
 
 def list_nparr_to_matrix(x):
@@ -18,6 +19,25 @@ def list_nparr_to_matrix(x):
 
 def aae(exp, act):
     np.testing.assert_almost_equal(np.array(exp, dtype=object)[:, 1], np.array(act, dtype=object)[:, 1], decimal=7)
+
+
+def generate_random_data(n, mu, sigma, pnan):
+    orig_state = np.random.get_state()
+    np.random.seed(42)  # for reproducibility
+    times = np.empty(n, dtype=object)
+    values = np.random.normal(mu, sigma, size=n)
+    deltas = np.random.uniform(low=0.0, high=10.0, size=n)
+
+    times[0] = datetime(2020, 1, 1)
+    for i in range(1, n):
+        times[i] = times[i - 1] + timedelta(seconds=deltas[i])
+        if np.random.random() > (1 - pnan):
+            values[i] = float("nan")
+    np.random.set_state(orig_state)
+
+    if pnan:
+        values[0] = float("nan")  # force edge condition
+    return times, values
 
 
 class TestStats(unittest.TestCase):
@@ -3709,6 +3729,59 @@ class TestStats(unittest.TestCase):
 
         # Assert 2: weighted variance should equal unweighted variance
         np.testing.assert_equal(results["variance"], results["weighted_variance"])
+
+    def test_unadjusted_ewm_halflife(self):
+        import polars as pl
+
+        N_DATA_POINTS = 100
+        N_ELEM_NP = 3
+        # polars does not ignore nan's in its ewm_mean_by (so need to generate data w/o nans)
+        times, values = generate_random_data(N_DATA_POINTS, mu=0, sigma=1, pnan=0)
+
+        @csp.graph
+        def graph():
+            test_data_float = csp.curve(typ=float, data=(times, values))
+            test_data_np = csp.curve(
+                typ=np.ndarray,
+                data=(times, np.array([np.array([values[k] for j in range(N_ELEM_NP)]) for k in range(N_DATA_POINTS)])),
+            )
+
+            # EMA: float/np
+            float_ema = csp.stats.ema(test_data_float, halflife=timedelta(seconds=5), adjust=False)
+            np_ema = csp.stats.ema(test_data_np, halflife=timedelta(seconds=5), adjust=False)
+            csp.add_graph_output("float_ema", float_ema)
+            csp.add_graph_output("np_ema", np_ema)
+
+            # EMA var (debiased): float/np
+            float_ema_var = csp.stats.ema_var(test_data_float, halflife=timedelta(seconds=20), adjust=False)
+            float_ema_var_adjusted = csp.stats.ema_var(test_data_float, halflife=timedelta(seconds=20), adjust=True)
+            np_ema_var = csp.stats.ema_var(test_data_np, halflife=timedelta(seconds=20), adjust=False)
+            csp.add_graph_output("float_ema_var", float_ema_var)
+            csp.add_graph_output("np_ema_var", np_ema_var)
+            csp.add_graph_output("float_ema_var_adjusted", float_ema_var_adjusted)
+
+        res = csp.run(graph, starttime=times[0] - timedelta(seconds=1), endtime=times[-1], output_numpy=True)
+
+        golden = (
+            pl.Series(values=values)
+            .ewm_mean_by(by=pl.Series(values=list(times)), half_life=timedelta(seconds=5))
+            .to_pandas()
+        )
+        assert_series_equal(golden, pd.Series(res["float_ema"][1]), check_names=False)
+        for element in range(N_ELEM_NP):
+            assert_series_equal(golden, pd.Series(np.stack(res["np_ema"][1])[:, element]), check_names=False)
+
+        # sanity check for variance (no open-source impl to compare to)
+        with self.assertRaises(AssertionError):
+            assert_series_equal(
+                pd.Series(res["float_ema_var"][1]), pd.Series(res["float_ema_var_adjusted"][1]), check_names=False
+            )
+        for element in range(N_ELEM_NP):
+            assert_series_equal(
+                pd.Series(res["float_ema_var"][1]),
+                pd.Series(np.stack(res["np_ema_var"][1])[:, element]),
+                check_names=False,
+            )
 
 
 if __name__ == "__main__":

--- a/docs/wiki/api-references/Statistical-Nodes-API.md
+++ b/docs/wiki/api-references/Statistical-Nodes-API.md
@@ -1696,11 +1696,11 @@ Args:
 - **min_periods**: the minimum allowable number of ticks to use before outputting data. The default is 1 for any EMA function.
 
 - **alpha**: the EMA weight parameter specified directly.
-  If *adjust = True,* EMA is calculated such that
+  If `adjust = True` and `alpha` is specified, then the EMA is calculated such that
 
   $$EMA(t) = \\frac{\\sum\\limits\_{t=-n}^{0} (1-\\alpha)^{-t} x(-t)}{\\sum\\limits\_{t=-n}^{0} (1-\\alpha)^{-t}}$$
 
-  If `adjust = False`, EMA is calculated such that
+  If `adjust = False` and `alpha` is specified, the EMA is calculated such that
 
   $$EMA(t) = (1-\\alpha)EMA(t-1) + \\alpha x(t)$$
   $$EMA(t=0) = x(0)$$
@@ -1717,19 +1717,26 @@ Args:
 
     $$\\alpha = \\frac{1}{1+com}$$
 
-  - **halflife**: Halflife is different from the other parameters. Half-life is a timedelta argument that specifies the half-life of observation weights. Half-life is useful when observations are irregularly spaced and a better estimate is needed to properly weight more recent data. Let $t\_{-1}$ be the time of the last observation.
+  - **halflife**: Halflife is different from the other parameters. Half-life is a timedelta argument that specifies the half-life of observation weights. Half-life is useful when observations are irregularly spaced and a better estimate is needed to properly weight more recent data. Let $$t\_{-1}$$ be the time of the last observation.
 
-    Then:
+    Then, if `adjust = True`:
 
     $$\\lambda(t)  = 1 - \\exp(\\frac{-(t-t\_{-1})\*\\ln(2)}{halflife})$$
+
     $$EMA(t) = \\frac{ \\lambda(t)\*EMA(t-1) + x(t)}{\\text{normalization constant}}$$
+
+    and if `adjust = False`:
+
+    $$EMA(t) = \\lambda(t)EMA(t-1) + (1-\\lambda(t))x(t)$$
+
+    $$EMA(t=0) = x(0)$$
 
     Something to note is that the `ignore_na` flag does not matter if a halflife interval is specified.
     The behavior would be the same in both cases, since an absolute time interval is being used to re-weight the moving average, not a tick interval.
 
     **Exactly one of alpha, span, com, halflife must be given**
 
-- **adjust**: if True, early observations are adjusted to give a more "smoothed" estimate of the EMA. The difference is that if `adjust=True`, then each new observation receives a relative weight of 1. If adjust = False, each new observation receives a relative weight of alpha.
+- **adjust**: if True, early observations are adjusted to give a more "smoothed" estimate of the EMA. The difference is that if `adjust = True`, then each new observation receives a relative weight of 1. If `adjust = False`, each new observation receives a relative weight of `alpha` (if alpha is specified) or $$1-\\lambda(t)$$ (if halflife is specified).
 
   - `adjust=True` means that:
 
@@ -1741,7 +1748,7 @@ Args:
 
   $$\\text{and thus } EMA(t=0) = x(0)$$
 
-  Adjust only applies with tick specified intervals, not time specified intervals. Time specified intervals (i.e. half-life) do not need adjustment as they are, by definition, already adjusted.
+  In the time-specified decay case (halflife), the same equations apply with the replacement of $$1-\\lambda(t)$$ for $$\\alpha$$.
 
 - **horizon**: the maximum number of ticks to use in the computation. For example, if horizon = 10, then only the 10 most recent data points are used. If not specified, all data points for x are used, with early ticks decaying exponentially in weighting. Horizon will be ignored with a half-life (time-based) interval.
 


### PR DESCRIPTION
Closes #564. Also adds support for unbiased, unadjusted halflife (co)variance and cleans up some other things in the stats code.