### PR TITLE
fixes #579 - PyStruct type refcount bug

### DIFF
--- a/cpp/csp/python/PyStruct.cpp
+++ b/cpp/csp/python/PyStruct.cpp
@@ -44,7 +44,7 @@ private:
 DialectStructMeta::DialectStructMeta( PyTypeObject * pyType, const std::string & name,
                                       const Fields & flds, std::shared_ptr<StructMeta> base ) :
     StructMeta( name, flds, base ),
-    m_pyType( pyType )
+    m_pyType( PyTypeObjectPtr::incref( pyType ) )
 {
 }
 
@@ -173,12 +173,13 @@ static PyObject * PyStructMeta_new( PyTypeObject *subtype, PyObject *args, PyObj
     }
 
     /*back reference to the struct type that will be accessible on the csp struct -> meta()
-      DialectStructMeta will hold a borrowed reference to the type to avoid a circular dep
+      DialectStructMeta needs a strong reference to the type.  This creates a known strong circular dep
+      whiech effectively will keep the struct type instances around beyond their need
 
       This is the layout of references between all these types
                               StructMeta (shared_ptr) <-------- strong ref
                                   |                              |
-                           DialectStructMeta ---> weak ref to PyStructMeta ( the PyType )
+                           DialectStructMeta --> strong ref to PyStructMeta ( the PyType )
                                  /\                              /\
                                   |                              |
                                   | (strong ref )                |

--- a/cpp/csp/python/PyStruct.h
+++ b/cpp/csp/python/PyStruct.h
@@ -28,18 +28,18 @@ public:
                        const Fields & fields, std::shared_ptr<StructMeta> base = nullptr );
     ~DialectStructMeta() {}
 
-    PyTypeObject * pyType() const { return m_pyType; }
+    PyTypeObject * pyType() const { return m_pyType.get(); }
 
     const StructField * field( PyObject * attr ) const
     {
-        PyObject * field = PyDict_GetItem( ( ( PyStructMeta * ) m_pyType ) -> attrDict.get(), attr );
+        PyObject * field = PyDict_GetItem( ( ( PyStructMeta * ) m_pyType.get() ) -> attrDict.get(), attr );
         if( likely( field != nullptr ) )
             return ( StructField * ) PyCapsule_GetPointer( field, nullptr );
         return nullptr;
     }
 
 private:
-    PyTypeObject * m_pyType;   //borrowed reference from type that is holding this instance
+    PyTypeObjectPtr m_pyType;
 };
 
 

--- a/csp/tests/impl/test_struct.py
+++ b/csp/tests/impl/test_struct.py
@@ -4242,6 +4242,27 @@ class TestCspStruct(unittest.TestCase):
         validated_child_struct = MyStructB.type_adapter().validate_python(dict(y="a"))
         self.assertEqual(validated_child_struct, MyStructB(y="a"))
 
+    def test_struct_type_lifetime(self):
+        """Was a crashing bug: https://github.com/Point72/csp/issues/579"""
+        import gc
+
+        class T(csp.Struct):
+            s: csp.Struct
+
+        def foo2():
+            meta = {"A": str, "B": int}
+            DynStruct = defineStruct("DynStruct", meta)
+            t = T(s=DynStruct(A="testing"))
+            del DynStruct
+            gc.collect(0)
+            return t
+
+        s = foo2()
+        self.assertEqual(s.s.A, "testing")
+        del s.s
+        del s
+        gc.collect(0)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Note that there is no good way to avoid just keeping strong circular references here, effectively "leaking" dynamic struct types.