### PR TITLE
Apply vcpkg patch for cyrus-sasl to fix build for gcc 14

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -200,7 +200,7 @@ dependencies-fedora:  ## install dependencies for linux
 	yum install -y autoconf autoconf-archive automake bison ccache cmake curl flex libtool perl-IPC-Cmd pkg-config tar unzip
 
 dependencies-vcpkg:  ## install dependencies via vcpkg
-	cd vcpkg && ./bootstrap-vcpkg.sh && ./vcpkg install
+	cd vcpkg && ./bootstrap-vcpkg.sh && ./vcpkg install --overlay-ports=../vcpkg-overlays/ports
 
 dependencies-win:  ## install dependencies via windows
 	choco install cmake --version=3.31.6 --allow-downgrade

--- a/setup.py
+++ b/setup.py
@@ -42,18 +42,6 @@ if CSP_USE_VCPKG:
         subprocess.call(["git", "clone", "https://github.com/Microsoft/vcpkg.git"])
     if not os.path.exists("vcpkg/ports"):
         subprocess.call(["git", "submodule", "update", "--init", "--recursive"])
-    if not os.path.exists("vcpkg/buildtrees"):
-        subprocess.call(["git", "pull"], cwd="vcpkg")
-        args = ["install"]
-        if VCPKG_TRIPLET is not None:
-            args.append(f"--triplet={VCPKG_TRIPLET}")
-
-        if os.name == "nt":
-            subprocess.call(["bootstrap-vcpkg.bat"], cwd="vcpkg", shell=True)
-            subprocess.call(["vcpkg.bat"] + args, cwd="vcpkg", shell=True)
-        else:
-            subprocess.call(["./bootstrap-vcpkg.sh"], cwd="vcpkg")
-            subprocess.call(["./vcpkg"] + args, cwd="vcpkg")
 
 
 python_version = f"{sys.version_info.major}.{sys.version_info.minor}"

--- a/vcpkg-configuration.json
+++ b/vcpkg-configuration.json
@@ -1,0 +1,3 @@
+{
+  "overlay-ports": ["vcpkg-overlays/ports"]
+}

--- a/vcpkg-overlays/ports/cyrus-sasl/configure.diff
+++ b/vcpkg-overlays/ports/cyrus-sasl/configure.diff
@@ -1,0 +1,81 @@
+diff --git a/libsasl2.pc.in b/libsasl2.pc.in
+index ddad76d..5192f74 100644
+--- a/libsasl2.pc.in
++++ b/libsasl2.pc.in
+@@ -9,4 +9,5 @@ URL: http://www.cyrussasl.org/
+ Version: @VERSION@
+ Cflags: -I${includedir}
+ Libs: -L${libdir} -lsasl2
+-Libs.private: @LIB_DOOR@ @SASL_DL_LIB@ @LIBS@
++Libs.private: @LIB_DOOR@ @SASL_DB_LIB@ @SASL_DL_LIB@ @LIBS@
++Requires.private: mit-krb5-gssapi
+diff --git a/m4/openssl.m4 b/m4/openssl.m4
+index 42b31af..301dca5 100644
+--- a/m4/openssl.m4
++++ b/m4/openssl.m4
+@@ -20,6 +20,12 @@ case "$with_openssl" in
+ 	no)
+ 	  with_openssl="no";;
+ 	*) 
++	  with_openssl="yes"
++	  PKG_CHECK_MODULES([LIBCRYPTO],[libcrypto],[],[AC_MSG_FAILURE([Cannot find OpenSSL])])
++	  CFLAGS="$CFLAGS $LIBCRYPTO_CFLAGS"
++	  LIBS="$LIBS $LIBCRYPTO_LIBS"
++	  ;;
++	orig)
+ 	  with_openssl="yes"
+ 	  dnl if openssl has been compiled with the rsaref2 libraries,
+ 	  dnl we need to include the rsaref libraries in the crypto check
+diff --git a/m4/sasl2.m4 b/m4/sasl2.m4
+index 80371ef..77133af 100644
+--- a/m4/sasl2.m4
++++ b/m4/sasl2.m4
+@@ -117,8 +117,7 @@ if test "$gssapi" != no; then
+ 
+   if test "$gss_impl" = "auto" -o "$gss_impl" = "mit"; then
+     gss_failed=0
+-    AC_CHECK_LIB(gssapi_krb5,gss_unwrap,gss_impl="mit",gss_failed=1,
+-                 ${GSSAPIBASE_LIBS} -lgssapi_krb5 -lkrb5 -lk5crypto -lcom_err ${LIB_SOCKET})
++    PKG_CHECK_MODULES([MIT_KRB5_GSSAPI],[mit-krb5-gssapi],[gss_impl="mit"],[AC_MSG_FAILURE([Cannot find MIT Kerberos])])
+     if test "$gss_impl" != "auto" -a "$gss_failed" = "1"; then
+       gss_impl="failed"
+     fi
+@@ -170,8 +169,9 @@ if test "$gssapi" != no; then
+   fi
+ 
+   if test "$gss_impl" = "mit"; then
+-    GSSAPIBASE_LIBS="$GSSAPIBASE_LIBS -lgssapi_krb5 -lkrb5 -lk5crypto -lcom_err"
+-    GSSAPIBASE_STATIC_LIBS="$GSSAPIBASE_LIBS $gssapi_dir/libgssapi_krb5.a $gssapi_dir/libkrb5.a $gssapi_dir/libk5crypto.a $gssapi_dir/libcom_err.a"
++    GSSAPIBASE_LIBS="$GSSAPIBASE_LIBS $MIT_KRB5_GSSAPI_LIBS"
++    GSSAPIBASE_STATIC_LIBS="$GSSAPIBASE_LIBS $MIT_KRB5_GSSAPI_LIBS"
++    CFLAGS="$CFLAGS $MIT_KRB5_GSSAPI_CFLAGS"
+   elif test "$gss_impl" = "heimdal"; then
+     CPPFLAGS="$CPPFLAGS"
+     GSSAPIBASE_LIBS="$GSSAPIBASE_LIBS -lgssapi -lkrb5 -lasn1 -lroken ${LIB_CRYPT} ${LIB_DES} -lcom_err"
+diff --git a/m4/sasldb.m4 b/m4/sasldb.m4
+index 5febf14..5848576 100644
+--- a/m4/sasldb.m4
++++ b/m4/sasldb.m4
+@@ -46,8 +46,9 @@ dnl named.  arg.
+        esac
+ 	;;
+   lmdb)
++    AX_PTHREAD()
+     AC_CHECK_HEADER(lmdb.h, [
+-		AC_CHECK_LIB(lmdb, mdb_env_create, SASL_DB_LIB="-llmdb"; enable_keep_db_open=yes, dblib="no")],
++		AC_CHECK_LIB(lmdb, mdb_env_create, SASL_DB_LIB="-llmdb $PTHREAD_CFLAGS $PTHREAD_LIBS"; enable_keep_db_open=yes, [AC_MSG_FAILURE([Cannot find lmdb])], [$PTHREAD_CFLAGS $PTHREAD_LIBS])],
+ 		dblib="no")
+ 	;;
+   ndbm)
+diff --git a/utils/Makefile.am b/utils/Makefile.am
+index 99c49e1..c34913f 100644
+--- a/utils/Makefile.am
++++ b/utils/Makefile.am
+@@ -43,6 +43,7 @@
+ ################################################################
+ 
+ all_sasl_libs = ../lib/libsasl2.la $(SASL_DB_LIB) $(LIB_SOCKET)
++all_sasl_libs += $(GSSAPIBASE_LIBS)
+ all_sasl_static_libs = ../lib/.libs/libsasl2.a $(SASL_DB_LIB) $(LIB_SOCKET) $(GSSAPIBASE_LIBS) $(GSSAPI_LIBS) $(SASL_KRB_LIB) $(LIB_DES) $(PLAIN_LIBS) $(SRP_LIBS) $(LIB_MYSQL) $(LIB_PGSQL) $(LIB_SQLITE)
+ 
+ sbin_PROGRAMS = @SASL_DB_UTILS@ @SMTPTEST_PROGRAM@ pluginviewer

--- a/vcpkg-overlays/ports/cyrus-sasl/fix-gcc14-time-includes.diff
+++ b/vcpkg-overlays/ports/cyrus-sasl/fix-gcc14-time-includes.diff
@@ -1,0 +1,39 @@
+From e0f1bbf570c6bd69f7842a2aa28f061c41a7c892 Mon Sep 17 00:00:00 2001
+From: Adam Glustein <adam.glustein@point72.com>
+Date: Tue, 2 Sep 2025 11:58:12 -0400
+Subject: [PATCH] Fix GCC 14 compatibility - add missing time.h includes
+
+---
+ lib/saslutil.c | 2 --
+ plugins/cram.c | 1 +
+ 2 files changed, 1 insertion(+), 2 deletions(-)
+
+diff --git a/lib/saslutil.c b/lib/saslutil.c
+index 46c628c7..5341cbb3 100644
+--- a/lib/saslutil.c
++++ b/lib/saslutil.c
+@@ -59,9 +59,7 @@
+ #ifdef HAVE_UNISTD_H
+ #include <unistd.h>
+ #endif
+-#ifdef HAVE_TIME_H
+ #include <time.h>
+-#endif
+ #include "saslint.h"
+ #include <saslutil.h>
+ 
+diff --git a/plugins/cram.c b/plugins/cram.c
+index d02e9baa..89c9308d 100644
+--- a/plugins/cram.c
++++ b/plugins/cram.c
+@@ -52,6 +52,7 @@
+ #include <sys/stat.h>
+ #endif
+ #include <fcntl.h>
++#include <time.h>
+ 
+ #include <sasl.h>
+ #include <saslplug.h>
+-- 
+2.43.5
+

--- a/vcpkg-overlays/ports/cyrus-sasl/portfile.cmake
+++ b/vcpkg-overlays/ports/cyrus-sasl/portfile.cmake
@@ -1,0 +1,111 @@
+# NOTE: We don't use vcpkg_from_github as it does not
+# include all the necessary source files
+vcpkg_download_distfile(ARCHIVE
+    URLS "https://github.com/cyrusimap/cyrus-sasl/releases/download/cyrus-sasl-${VERSION}/cyrus-sasl-${VERSION}.tar.gz"
+    FILENAME "cyrus-sasl-${VERSION}.tar.gz"
+    SHA512 db15af9079758a9f385457a79390c8a7cd7ea666573dace8bf4fb01bb4b49037538d67285727d6a70ad799d2e2318f265c9372e2427de9371d626a1959dd6f78
+)
+vcpkg_extract_source_archive(SOURCE_PATH
+    ARCHIVE "${ARCHIVE}"
+    PATCHES
+        configure.diff
+    fix-gcc14-time-includes.diff
+)
+
+if(VCPKG_TARGET_IS_WINDOWS AND NOT VCPKG_TARGET_IS_MINGW)
+    file(REMOVE "${SOURCE_PATH}/include/md5global.h")
+    file(COPY "${SOURCE_PATH}/win32/include/md5global.h" DESTINATION "${SOURCE_PATH}/include/md5global.h")
+
+    vcpkg_check_linkage(ONLY_DYNAMIC_LIBRARY) # only DLL build rules
+
+    set(STATIC_CRT_LINKAGE no)
+    if(VCPKG_CRT_LINKAGE STREQUAL "static")
+        set(STATIC_CRT_LINKAGE yes)
+    endif()
+
+    string(APPEND VCPKG_C_FLAGS " /DUNICODE /D_UNICODE /D_WINSOCK_DEPRECATED_NO_WARNINGS")
+    string(APPEND VCPKG_CXX_FLAGS " /DUNICODE /D_UNICODE /D_WINSOCK_DEPRECATED_NO_WARNINGS")
+
+    cmake_path(NATIVE_PATH CURRENT_INSTALLED_DIR CURRENT_INSTALLED_DIR_NATIVE)
+    cmake_path(NATIVE_PATH CURRENT_PACKAGES_DIR CURRENT_PACKAGES_DIR_NATIVE)
+    vcpkg_install_nmake(
+        SOURCE_PATH "${SOURCE_PATH}"
+        PROJECT_NAME "NTMakefile"
+        OPTIONS
+            STATIC=${STATIC_CRT_LINKAGE}
+            "SUBDIRS=lib plugins utils"
+            # Note https://www.cyrusimap.org/sasl/sasl/windows.html#limitations
+            GSSAPI=MITKerberos    # but "GSSAPI - tested using CyberSafe"
+            "GSSAPI_INCLUDE=${CURRENT_INSTALLED_DIR_NATIVE}\\include"
+            SASLDB=LMDB           # but "SASLDB - only SleepyCat version can be built"
+            "LMDB_INCLUDE=${CURRENT_INSTALLED_DIR_NATIVE}\\include"
+            SRP=1
+            DO_SRP_SETPASS=1
+            OTP=1
+            "OPENSSL_INCLUDE=${CURRENT_INSTALLED_DIR_NATIVE}\\include"
+            # Silence log messages about default initialization
+            "DB_LIB=unused"
+            "DB_INCLUDE=${CURRENT_PACKAGES_DIR_NATIVE}\\unused"
+            "DB_LIBPATH=${CURRENT_PACKAGES_DIR_NATIVE}\\unused"
+            "LDAP_INCLUDE=${CURRENT_PACKAGES_DIR_NATIVE}\\unused"
+            "LDAP_LIB_BASE=${CURRENT_PACKAGES_DIR_NATIVE}\\unused"
+            "SQLITE_INCLUDE=${CURRENT_PACKAGES_DIR_NATIVE}\\unused"
+            "SQLITE_LIBPATH=${CURRENT_PACKAGES_DIR_NATIVE}\\unused"
+            "SQLITE_INCLUDE3=${CURRENT_PACKAGES_DIR_NATIVE}\\unused"
+            "SQLITE_LIBPATH3=${CURRENT_PACKAGES_DIR_NATIVE}\\unused"
+        OPTIONS_RELEASE
+            CFG=Release
+            "prefix=${CURRENT_PACKAGES_DIR_NATIVE}"
+            "GSSAPI_LIBPATH=${CURRENT_INSTALLED_DIR_NATIVE}\\lib"
+            "LMDB_LIBPATH=${CURRENT_INSTALLED_DIR_NATIVE}\\lib"
+            "OPENSSL_LIBPATH=${CURRENT_INSTALLED_DIR_NATIVE}\\lib"
+        OPTIONS_DEBUG
+            CFG=Debug
+            "prefix=${CURRENT_PACKAGES_DIR_NATIVE}\\debug"
+            "GSSAPI_LIBPATH=${CURRENT_INSTALLED_DIR_NATIVE}\\debug\\lib"
+            "LMDB_LIBPATH=${CURRENT_INSTALLED_DIR_NATIVE}\\debug\\lib"
+            "OPENSSL_LIBPATH=${CURRENT_INSTALLED_DIR_NATIVE}\\debug\\lib"
+    )
+    vcpkg_copy_tools(TOOL_NAMES pluginviewer sasldblistusers2 saslpasswd2 testsuite AUTO_CLEAN)
+
+    block(SCOPE_FOR VARIABLES)
+        set(prefix      [[placeholder]])
+        set(exec_prefix [[${prefix}]])
+        set(libdir      [[${prefix}/lib]])
+        set(includedir  [[${prefix}/include]])
+        configure_file("${SOURCE_PATH}/libsasl2.pc.in" "${CURRENT_PACKAGES_DIR}/lib/pkgconfig/libsasl2.pc" @ONLY)
+        vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/lib/pkgconfig/libsasl2.pc" " -lsasl2" " -llibsasl")
+        if(NOT VCPKG_BUILD_TYPE)
+            file(MAKE_DIRECTORY "${CURRENT_PACKAGES_DIR}/debug/lib/pkgconfig")
+            file(COPY_FILE "${CURRENT_PACKAGES_DIR}/lib/pkgconfig/libsasl2.pc" "${CURRENT_PACKAGES_DIR}/debug/lib/pkgconfig/libsasl2.pc")
+        endif()
+    endblock()
+
+else()
+    vcpkg_find_acquire_program(PKGCONFIG)
+    set(ENV{PKG_CONFIG} "${PKGCONFIG}")
+
+    vcpkg_configure_make(
+        SOURCE_PATH "${SOURCE_PATH}"
+        AUTOCONFIG
+        OPTIONS
+            --enable-sample=no
+            --with-dblib=lmdb
+            --with-gss_impl=mit
+            --disable-macos-framework
+    )
+    vcpkg_install_make()
+endif()
+
+vcpkg_fixup_pkgconfig()
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/COPYING"
+    COMMENT [[
+The top-level COPYING file represents the license identified as BSD with
+Attribution and HPND disclaimer. However, various source files are under
+different licenses, including other BSD license variants, MIT license
+variants, OpenLDAP, OpenSSL and others.
+]])

--- a/vcpkg-overlays/ports/cyrus-sasl/vcpkg.json
+++ b/vcpkg-overlays/ports/cyrus-sasl/vcpkg.json
@@ -1,0 +1,14 @@
+{
+  "name": "cyrus-sasl",
+  "version": "2.1.28",
+  "port-version": 2,
+  "description": "Cyrus SASL is an implementation of SASL that makes it easy for application developers to integrate authentication mechanisms into their application in a generic way.",
+  "homepage": "https://github.com/cyrusimap/cyrus-sasl",
+  "license": null,
+  "supports": "linux | osx | (windows & !uwp)",
+  "dependencies": [
+    "krb5",
+    "lmdb",
+    "openssl"
+  ]
+}


### PR DESCRIPTION
This patch allows csp to be built in vcpkg with gcc 14 (see `vcpkg-overlays/ports/cyrus-sasl/fix-gcc14-time-includes.diff`).
Also removes some dead code from `setup.py` and applies the overlay properly in our build process.