### PR TITLE
Update vcpkg baseline to fix build for gcc 14

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -193,11 +193,11 @@ dependencies-mac:  ## install dependencies for mac
 	HOMEBREW_NO_AUTO_UPDATE=1 brew bundle install
 	brew unlink bison flex && brew link --force bison flex
 
-dependencies-debian:  ## install dependencies for linux
-	apt-get install -y autoconf autoconf-archive automake bison cmake curl flex libtool ninja-build pkg-config tar unzip
+dependencies-debian:  ## install dependencies for linux - note that zip is needed by bootstrap_vcpkg.sh, do not remove
+	apt-get install -y autoconf autoconf-archive automake bison cmake curl flex libtool ninja-build pkg-config tar unzip zip
 
-dependencies-fedora:  ## install dependencies for linux
-	yum install -y autoconf autoconf-archive automake bison ccache cmake curl flex libtool perl-IPC-Cmd pkg-config tar unzip
+dependencies-fedora:  ## install dependencies for linux - note that zip is needed by bootstrap_vcpkg.sh, do not remove
+	yum install -y autoconf autoconf-archive automake bison ccache cmake curl flex libtool perl-IPC-Cmd pkg-config tar unzip zip
 
 dependencies-vcpkg:  ## install dependencies via vcpkg
 	cd vcpkg && ./bootstrap-vcpkg.sh && ./vcpkg install

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -2,7 +2,7 @@
   "name": "main",
   "version-string": "latest",
   "dependencies": [
-    { "name": "arrow", "version>=": "19.0.1" },
+    "arrow",
     "boost-beast",
     "boost-multi-index",
     "brotli",
@@ -37,5 +37,11 @@
     "thrift",
     "utf8proc"
   ],
-  "builtin-baseline": "0bf1354d6704ec797acea686d0250afc4036a082"
+  "overrides": [
+    {
+      "name": "arrow",
+      "version": "19.0.1"
+    }
+  ],
+  "builtin-baseline": "b94ade01f19e4436d8c8a16a5c52e8c802ef67dd"
 }


### PR DESCRIPTION
Pulls in patch for cyrus-sasl to include missing headers. At new baseline, we'd pull in arrow 21, so need to add an override for that as well.