### PR TITLE
Add build support for arrow/parquet 20 and 21

### DIFF
--- a/conda/dev-environment-unix.yml
+++ b/conda/dev-environment-unix.yml
@@ -18,7 +18,7 @@ dependencies:
  - graphviz
  - gtest
  - httpx>=0.20,<1
- - libarrow<20
+ - libarrow<22
  - libboost>=1.80.0
  - libboost-headers>=1.80.0
  - librdkafka
@@ -34,7 +34,7 @@ dependencies:
  - pillow
  - polars
  - psutil
- - pyarrow>=15,<20
+ - pyarrow>=15,<22
  - pydantic>=2
  - pytest
  - pytest-asyncio

--- a/conda/dev-environment-win.yml
+++ b/conda/dev-environment-win.yml
@@ -18,7 +18,7 @@ dependencies:
  - graphviz
  - gtest
  - httpx>=0.20,<1
- - libarrow<20
+ - libarrow<22
  - libboost>=1.80.0
  - libboost-headers>=1.80.0
  - librdkafka
@@ -34,7 +34,7 @@ dependencies:
  - pillow
  - polars
  - psutil
- - pyarrow>=15,<20
+ - pyarrow>=15,<22
  - pydantic>=2
  - pytest
  - pytest-asyncio

--- a/cpp/csp/adapters/parquet/ParquetFileWriterWrapper.cpp
+++ b/cpp/csp/adapters/parquet/ParquetFileWriterWrapper.cpp
@@ -2,6 +2,7 @@
 #include <csp/adapters/parquet/ParquetStatusUtils.h>
 #include <arrow/io/file.h>
 #include <arrow/table.h>
+#include <arrow/util/config.h>
 #include <parquet/arrow/writer.h>
 
 namespace csp::adapters::parquet
@@ -16,8 +17,11 @@ void ParquetFileWriterWrapper::openImpl( const std::string &fileName, const std:
 
     ::parquet::WriterProperties::Builder builder;
     builder.compression( resolveCompression( compression ));
+#if ARROW_VERSION_MAJOR == 20 || ARROW_VERSION_MAJOR == 21
+    builder.version(::parquet::ParquetVersion::PARQUET_2_6 );
+#else
     builder.version(::parquet::ParquetVersion::PARQUET_2_0 );
-
+#endif
     ::parquet::ArrowWriterProperties::Builder arrowBuilder;
     arrowBuilder.store_schema();
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ requires = [
     "cmake<3.27",
     "deprecated",  # Because used in csp.impl.struct, which is used in autogen
     "numpy>=2,<2.1",  # oldest numpy 2 we can
-    "pyarrow>=15,<20",
+    "pyarrow>=15,<22",
     "ruamel.yaml",
     "scikit-build",
     "setuptools>=69,<74",
@@ -26,7 +26,7 @@ dependencies = [
     "pandas<2.3; python_version<'3.10'",
     "pandas; python_version>='3.10'",
     "psutil",
-    "pyarrow>=15,<20",
+    "pyarrow>=15,<22",
     "pydantic>=2",
     "pytz",
     "ruamel.yaml",

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -40,7 +40,7 @@
   "overrides": [
     {
       "name": "arrow",
-      "version": "19.0.1"
+      "version": "21.0.0"
     }
   ],
   "builtin-baseline": "b94ade01f19e4436d8c8a16a5c52e8c802ef67dd"


### PR DESCRIPTION
tested against 20 locally, moving vcpkg and conda to 21 (for https://github.com/conda-forge/csp-feedstock/pull/79)