### PR TITLE
Do not use class method for model validator for pydantic 2.12

### DIFF
--- a/csp/impl/wiring/signature.py
+++ b/csp/impl/wiring/signature.py
@@ -76,11 +76,11 @@ class Signature:
                 for defn in outputs
             }
 
-            def validate_tvars(cls, values, info: ValidationInfo):
+            def validate_tvars(self, info: ValidationInfo):
                 if not isinstance(info.context, TVarValidationContext):
                     raise TypeError("Validation context is not a TVarValidationContext")
                 info.context.resolve_tvars()
-                return info.context.revalidate(values)
+                return info.context.revalidate(self)
 
             def track_fields(cls, v, info):
                 if not isinstance(info.context, TVarValidationContext):

--- a/csp/tests/impl/types/test_pydantic_type_resolver.py
+++ b/csp/tests/impl/types/test_pydantic_type_resolver.py
@@ -208,9 +208,9 @@ class MyModel(BaseModel):
     ts_2: TsType[CspTypeVarType[T]]
 
     @model_validator(mode="after")
-    def validate_tvars(cls, values, info: ValidationInfo):
+    def validate_tvars(self, info: ValidationInfo):
         info.context.resolve_tvars()
-        return info.context.revalidate(values)
+        return info.context.revalidate(self)
 
     @field_validator("*", mode="before")
     @classmethod


### PR DESCRIPTION
According to this PR: https://github.com/pydantic/pydantic/pull/11957

model_validators shouldn't be class methods.


Follows the example here:
https://github.com/pydantic/pydantic/blob/v2.12.0/tests/test_model_validator.py#L85

from the pydantic test suite to have a model validator that takes a `ValidationInfo` parameter

(as-of time of writing)
```python
def test_model_validator_after() -> None:
    class Model(BaseModel):
        x: int
        y: int

        @model_validator(mode='after')
        def val_model(self, info: ValidationInfo) -> Model:
            assert not info.context
            self.x += 1
            self.y += 1
            return self

    assert Model(x=1, y=2).model_dump() == {'x': 2, 'y': 3}
    assert Model.model_validate(Model(x=1, y=2)).model_dump() == {'x': 3, 'y': 4}
```