### PR TITLE
Update pypi classifiers and README icon for 3.13

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 [![PyPI](https://img.shields.io/pypi/v/csp.svg?style=flat)](https://pypi.python.org/pypi/csp)
 [![License](https://img.shields.io/badge/license-Apache--2.0-green)](https://github.com/Point72/csp/LICENSE)
 [![Build Status](https://github.com/Point72/csp/actions/workflows/build.yml/badge.svg)](https://github.com/Point72/csp/actions/workflows/build.yml)
-[![Python Versions](https://img.shields.io/badge/python-3.9_%7C_3.10_%7C_3.11_%7C_3.12-blue)](https://github.com/Point72/csp/blob/main/pyproject.toml)
+[![Python Versions](https://img.shields.io/badge/python-3.9_%7C_3.10_%7C_3.11_%7C_3.12_%7C_3.13-blue)](https://github.com/Point72/csp/blob/main/pyproject.toml)
 
 <br/>
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,6 +45,7 @@ classifiers = [
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
 ]
 
 


### PR DESCRIPTION
Note that these changes are only cosmetic, you can install csp on 3.13 fine from pypi