### PR TITLE
Fix #569: Don't normalize scalar arguments in input adapters

### DIFF
--- a/csp/impl/wiring/adapters.py
+++ b/csp/impl/wiring/adapters.py
@@ -106,7 +106,7 @@ class InputAdapterDef(AdapterDef):
             engine,
             ContainerTypeNormalizer.normalized_type_to_actual_python_type(self._output_def.typ.typ),
             self._push_mode,
-            tuple(ContainerTypeNormalizer.normalized_type_to_actual_python_type(s) for s in self._scalars),
+            tuple(self._scalars),
         )
 
     def set_output_def(self, output_def):


### PR DESCRIPTION
## Summary

Fixes #569 by removing overly broad type normalization in input adapters.

Previously, `InputAdapterDef._create()` was normalizing all scalar arguments using `ContainerTypeNormalizer`, which converted typing generics (e.g., `Dict[str, int]`) to their runtime equivalents (e.g., `dict`). This was incorrect because:

1. Scalar arguments are regular Python function arguments, not C++ type info
2. The normalization should only apply to type info passed to C++, not user arguments  
3. Python adapters need access to the original type objects to work correctly

## Changes

- **csp/impl/wiring/adapters.py (line 109)**: Removed normalization of scalar arguments
  - Output type normalization (line 107) remains, as it's needed for C++ type mapping
  - Scalar arguments now pass through unchanged

- **csp/tests/impl/test_pushadapter.py**: Added regression test `test_annotation_arguments_preserved()`
  - Tests that `Dict[str, int]`, `List[int]` and other typing generics are preserved
  - Covers the specific use case from issue #569

## Impact

This fix applies to all input adapter types:
- `py_push_adapter_def`
- `py_pull_adapter_def`
- `py_managed_adapter_def`
- `py_pushpull_adapter_def`

Aligns with the suggestion in #569 that the framework should pass typing constructs directly instead of normalizing them away.

## Test Plan

- [x] Added regression test for type annotation preservation
- [ ] CI tests (will run on PR)
- [ ] Manual testing with complex type adapters