### PR TITLE
Allow None output annotations for nodes and graphs (#625)

### DIFF
--- a/csp/impl/wiring/base_parser.py
+++ b/csp/impl/wiring/base_parser.py
@@ -307,6 +307,10 @@ class BaseParser(ast.NodeTransformer, metaclass=ABCMeta):
         # evaluate the returns statement
         output_dictionary_type = ContainerTypeNormalizer.normalize_type(self._eval_expr(returns))
 
+        # Handle None return type (no outputs)
+        if output_dictionary_type is None or output_dictionary_type is type(None):
+            return tuple()
+
         if not (isinstance(output_dictionary_type, type) and issubclass(output_dictionary_type, Outputs)):
             # try to wrap in outputs
             try:

--- a/csp/tests/impl/test_none_output.py
+++ b/csp/tests/impl/test_none_output.py
@@ -1,0 +1,14 @@
+import csp
+from datetime import datetime
+
+# Test case 1: Node with None output annotation
+@csp.node
+def n(x: csp.ts[int]) -> None:
+    print(x)
+
+# Test case 2: Graph with None output annotation
+@csp.graph
+def g() -> None:
+    n(csp.const(1))
+
+csp.run(g, datetime(2020, 1, 1))


### PR DESCRIPTION
# Fix: Allow `-> None` Output Annotations for Nodes and Graphs (#625)

This PR fixes an issue where annotating a `@csp.node` or `@csp.graph` function
with `-> None` caused a `CspParseError`:

Functions without outputs should accept a `None` return annotation, and this fix
implements that behavior correctly.

##  Changes
- Updated `BaseParser` to treat `-> None` return annotations as a valid
  “no outputs” case.
- Added test `test_none_output.py` under `csp/tests/impl/`
