### PR TITLE
Kafka improvements: add Burst mode support and optional kinit command

### DIFF
--- a/cpp/csp/adapters/kafka/KafkaInputAdapter.cpp
+++ b/cpp/csp/adapters/kafka/KafkaInputAdapter.cpp
@@ -91,8 +91,7 @@ void KafkaInputAdapter::processMessage( RdKafka::Message* message, bool live, cs
     if( ts.type != RdKafka::MessageTimestamp::MSG_TIMESTAMP_NOT_AVAILABLE )
         msgTime = DateTime::fromMilliseconds( ts.timestamp );
 
-    auto tsType = ( pushMode() == PushMode::BURST ? static_cast<const CspArrayType *>( type() ) -> elemType() -> type() : type() -> type() );
-    if( tsType == CspType::Type::STRUCT )
+    if( dataType() -> type() == CspType::Type::STRUCT )
     {
         auto tick = m_converter -> asStruct( message -> payload(), message -> len() );
 
@@ -118,7 +117,7 @@ void KafkaInputAdapter::processMessage( RdKafka::Message* message, bool live, cs
         if( shouldProcessMessage( pushLive, msgTime ) )
             pushTick(pushLive, msgTime, std::move(tick), batch);
     }
-    else if( tsType == CspType::Type::STRING )
+    else if( dataType() -> type() == CspType::Type::STRING )
     {
         bool pushLive = shouldPushLive(live, msgTime);
         if( shouldProcessMessage( pushLive, msgTime ) )

--- a/csp/adapters/kafka.py
+++ b/csp/adapters/kafka.py
@@ -51,7 +51,6 @@ class KafkaAdapterManager:
         sasl_kerberos_principal="",
         ssl_ca_location="",
         sasl_kerberos_service_name="kafka",
-        sasl_kerberos_kinit_cmd=None,
         rd_kafka_conf_options=None,
         debug: bool = False,
         poll_timeout: timedelta = timedelta(seconds=1),
@@ -111,8 +110,6 @@ class KafkaAdapterManager:
                     "ssl.ca.location": ssl_ca_location,
                 }
             )
-            if sasl_kerberos_kinit_cmd is not None:
-                self._properties["rd_kafka_conf_properties"]["sasl.kerberos.kinit.cmd"] = sasl_kerberos_kinit_cmd
 
         rd_kafka_conf_options = rd_kafka_conf_options.copy() if rd_kafka_conf_options else {}
         if debug:

--- a/csp/tests/adapters/test_kafka.py
+++ b/csp/tests/adapters/test_kafka.py
@@ -314,7 +314,7 @@ class TestKafka:
         )["data"]
         assert len(res) == len(expected)
 
-    @pytest.fixture(autouse=True)
+    @pytest.mark.skipif(not os.environ.get("CSP_TEST_KAFKA"), reason="Skipping kafka adapter tests")
     def test_raw_pubsub(self, kafkaadapter):
         @csp.node
         def data(x: ts[object]) -> ts[bytes]:
@@ -464,3 +464,58 @@ class TestKafka:
 
         with pytest.raises(ValueError):
             csp.run(graph_sub, starttime=datetime.utcnow(), endtime=timedelta(seconds=2), realtime=True)
+
+    @pytest.mark.skipif(not os.environ.get("CSP_TEST_KAFKA"), reason="Skipping kafka adapter tests")
+    def test_push_mode(self, kafkaadapter, kafkabroker):
+        class BasicData(csp.Struct):
+            a: int
+            b: bool
+
+        topic = f"test_burst.{os.getpid()}"
+        _precreate_topic(topic)
+        msg_mapper = JSONTextMessageMapper(datetime_type=DateTimeType.UINT64_MICROS)
+        count = 10
+
+        def pub_graph():
+            i = csp.count(csp.timer(timedelta(seconds=0.1)))
+            struct = BasicData.collectts(a=i, b=(i > 0))
+            kafkaadapter.publish(msg_mapper, topic, "foo", struct)
+            stop = csp.count(struct) == count
+            stop = csp.filter(stop, stop)
+            csp.stop_engine(stop)
+
+        csp.run(pub_graph, starttime=datetime.utcnow(), endtime=timedelta(seconds=5), realtime=True)
+
+        def sub_graph():
+            kafkaadapter = KafkaAdapterManager(broker=kafkabroker, start_offset=KafkaStartOffset.EARLIEST)
+            stop_flags = []
+            for key, push_mode in (
+                ("burst", csp.PushMode.BURST),
+                ("last", csp.PushMode.LAST_VALUE),
+            ):
+                data = kafkaadapter.subscribe(
+                    BasicData,
+                    msg_mapper=msg_mapper,
+                    topic=topic,
+                    key="foo",
+                    push_mode=push_mode,
+                )
+                csp.add_graph_output(key, data)
+                stop_flags.append(csp.count(data) == 1)
+
+            stop = csp.and_(*stop_flags)
+            csp.stop_engine(csp.filter(stop, stop))
+
+        res = csp.run(sub_graph, starttime=datetime.utcnow(), endtime=timedelta(seconds=5), realtime=True)
+        burst = res["burst"]
+        assert len(burst) == 1
+        assert isinstance(burst[0][1], list)
+        assert len(burst[0][1]) == 10
+        assert all([rv == BasicData(a=i + 1, b=True) for i, rv in enumerate(burst[0][1])])
+
+        last = res["last"]
+        assert len(last) == 1
+        assert isinstance(last[0][1], BasicData)
+        assert last[0][1] == BasicData(a=count, b=True)
+
+        # non-collapsing is tested in other tests


### PR DESCRIPTION
The `sasl_kerberos_kinit_cmd` option is for running with credentials from a certificate file. Since the keytab is not set, initialization will fail with Kafka's default logic that tries to refresh the Kerberos ticket (https://docs.confluent.io/platform/current/clients/librdkafka/html/md_CONFIGURATION.html)