### PR TITLE
Print out full input values in pydantic ValidationErrors

### DIFF
--- a/csp/impl/wiring/graph.py
+++ b/csp/impl/wiring/graph.py
@@ -2,7 +2,7 @@ import inspect
 import types
 
 from csp.impl.constants import UNSET
-from csp.impl.error_handling import ExceptionContext
+from csp.impl.error_handling import ExceptionContext, fmt_errors
 from csp.impl.mem_cache import csp_memoized_graph_object, function_full_name
 from csp.impl.types.instantiation_type_resolver import GraphOutputTypeResolver
 from csp.impl.wiring.graph_parser import GraphParser
@@ -102,8 +102,7 @@ class GraphDefMeta(type):
                 try:
                     _ = output_model.model_validate(outputs_dict, context=context)
                 except ValidationError as e:
-                    processed_msg = str(e).replace(OUTPUT_PREFIX, "")
-                    raise TypeError(f"Output type validation error(s).\n{processed_msg}") from None
+                    raise TypeError(f"Output type validation error(s).\n{fmt_errors(e, OUTPUT_PREFIX)}") from None
             else:
                 _ = GraphOutputTypeResolver(
                     function_name=self._signature._name,

--- a/csp/impl/wiring/signature.py
+++ b/csp/impl/wiring/signature.py
@@ -2,6 +2,7 @@ import itertools
 import os
 
 from csp.impl.constants import UNSET
+from csp.impl.error_handling import fmt_errors
 from csp.impl.types import tstype
 from csp.impl.types.common_definitions import ArgKind, InputDef, OutputBasketContainer, OutputDef
 from csp.impl.types.generic_values_resolver import GenericValuesResolver
@@ -222,8 +223,7 @@ class Signature:
         try:
             input_model = self._input_model.model_validate(new_kwargs, context=context)
         except ValidationError as e:
-            processed_msg = str(e).replace(INPUT_PREFIX, "")
-            raise TypeError(f"Input type validation error(s).\n{processed_msg}") from None
+            raise TypeError(f"Input type validation error(s).\n{fmt_errors(e, INPUT_PREFIX)}") from None
         # Normally, you would just grab the non-alarm ts and sclar inputs off the input model, but there are two complexities
         # 1. AttachType is initially classified as a ts input but needs to be returned as a scalar input (for historical reasons)
         # 2. Pydantic does a shallow copy on validation, which is different from csp behavior, and especially certain

--- a/csp/tests/impl/test_error_handling.py
+++ b/csp/tests/impl/test_error_handling.py
@@ -1,0 +1,94 @@
+import unittest
+
+from pydantic import BaseModel, Field, ValidationError
+
+from csp.impl.error_handling import (
+    INPUT_VALUE_TRUNCATE_LENGTH,
+    fmt_errors,
+    truncate_input_value,
+)
+
+
+class TestTruncateInputValue(unittest.TestCase):
+    def test_short_value_unchanged(self):
+        short_value = "short"
+        self.assertEqual(truncate_input_value(short_value), short_value)
+
+    def test_exact_length_unchanged(self):
+        exact_value = "x" * INPUT_VALUE_TRUNCATE_LENGTH
+        self.assertEqual(truncate_input_value(exact_value), exact_value)
+
+    def test_long_value_truncated(self):
+        long_value = "START" + "x" * INPUT_VALUE_TRUNCATE_LENGTH + "END"
+        result = truncate_input_value(long_value)
+        self.assertLess(len(result), INPUT_VALUE_TRUNCATE_LENGTH)
+        self.assertIn("...", result)
+        self.assertTrue(result.startswith("START"))
+        self.assertTrue(result.endswith("END"))
+
+
+class TestFmtErrors(unittest.TestCase):
+    """
+    Tests that verify our custom formatting matches pydantic's standard error messages.
+    """
+
+    def test_string_type_error_matches_pydantic(self):
+        class Model(BaseModel):
+            field: str
+
+        try:
+            Model(field=123)  # type: ignore
+        except ValidationError as e:
+            pydantic_msg = str(e)
+            custom_msg = fmt_errors(e, "")
+            self.assertEqual(pydantic_msg, custom_msg)
+
+    def test_list_type_error_matches_pydantic(self):
+        class Model(BaseModel):
+            items: list[int]
+
+        try:
+            Model(items="not_a_list")  # type: ignore
+        except ValidationError as e:
+            pydantic_msg = str(e)
+            custom_msg = fmt_errors(e, "")
+            self.assertEqual(pydantic_msg, custom_msg)
+
+    def test_nested_model_error_matches_pydantic(self):
+        class Inner(BaseModel):
+            value: int
+
+        class Outer(BaseModel):
+            inner: Inner
+
+        try:
+            Outer(inner={"value": "not_an_int"})  # type: ignore
+        except ValidationError as e:
+            pydantic_msg = str(e)
+            custom_msg = fmt_errors(e, "")
+            self.assertEqual(pydantic_msg, custom_msg)
+
+    def test_list_item_error_location_matches_pydantic(self):
+        class Model(BaseModel):
+            items: list[int]
+
+        try:
+            Model(items=[1, "bad", 3])  # type: ignore
+        except ValidationError as e:
+            pydantic_msg = str(e)
+            custom_msg = fmt_errors(e, "")
+            self.assertEqual(pydantic_msg, custom_msg)
+
+    def test_default_factory_not_called_matches_pydantic(self):
+        class Model(BaseModel):
+            a: int = Field(gt=10)
+            b: int = Field(default_factory=lambda data: data["a"])
+
+        try:
+            Model(a=1)
+            breakpoint()
+        except ValidationError as e:
+            pydantic_msg = str(e)
+            custom_msg = fmt_errors(e, "")
+            self.assertEqual(pydantic_msg, custom_msg)
+            print(pydantic_msg)


### PR DESCRIPTION
### Issue
By default, Pydantic truncates the string representations of the input values to 50 characters in its `ValidationError`s (see [here](https://github.com/pydantic/pydantic-core/blob/15b9c7b4293e76b5bd7ec52b4598a2da5b78b482/src/errors/validation_exception.rs#L548)). Since the full repr of csp types like `csp.impl.wiring.edge.Edge` can be quite long, a lot of the useful information is often lost. For example, consider the following graph
```python
import csp

@csp.node
def test(x: csp.ts[int]): ...

csp.build_graph(test, x=csp.const("hello"))
```
Currently pydantic will print out
```
1 validation error for test
x
  Value error, cannot validate ts[str] as ts[int]: <class 'str'> is not a subclass of <class 'int'>. [type=value_error, input_value=Edge( tstype=csp.impl.typ...t_idx=0, basket_idx=-1 ), input_type=Edge]
    For further information visit https://errors.pydantic.dev/2.12/v/value_error
```
With this PR, the input values will no longer be truncated in the error messages, and in addition, the input types will also include the full module names (i.e., `csp.impl.wiring.edge.Edge` vs. `Edge`)
```
x
  Value error, cannot validate ts[str] as ts[int]: <class 'str'> is not a subclass of <class 'int'>. [type=value_error, input_value=Edge( tstype=csp.impl.types.tstype.TsType[str], nodedef=<csp.impl.wiring.adapters.csp.const object at 0x7f3c10052120>, output_idx=0, basket_idx=-1 ), input_type=csp.impl.wiring.edge.Edge]
    For further information visit https://errors.pydantic.dev/2.12/v/value_error
```