### PR TITLE
Fix: pip installation of csp pulls in source files at top-level of environment

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,6 @@ import sys
 from shutil import which
 
 from setuptools import find_packages
-
 from skbuild import setup
 
 CSP_USE_VCPKG = os.environ.get("CSP_USE_VCPKG", "1").lower() in ("1", "on")


### PR DESCRIPTION
Fix for bug outlined in [#526 ](https://github.com/Point72/csp/issues/526)

Changes:
- Add exclude_source_files() function to filter CMake installation manifest
- Use cmake_process_manifest_hook to exclude source files during pip install
- Excludes CMakeLists.txt, pyproject.toml, setup.py, README.md, LICENSE, NOTICE, MANIFEST.in, vcpkg.json, Brewfile, Makefile, and source directories (cpp, ci, conda, examples, docs, vcpkg, .git)
- Fixes issue where pip install csp was installing source files at top-level of conda environment root
- Remove redundant os.path import

