### PR TITLE
Minor fixes to development instructions using conda

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,9 @@ requirements:  ## install python dev and runtime dependencies
 develop: requirements  ## install dependencies and build library
 	python -m pip install -e .[develop]
 
+develop-conda: ## install just the local library when developing in conda
+	CSP_USE_VCPKG=OFF pip install -U -e . --no-deps --no-build-isolation
+
 build:  ## build the library
 	CSP_ENABLE_ASAN=$(ASAN) CSP_ENABLE_UBSAN=$(UBSAN) python setup.py build build_ext --inplace
 

--- a/docs/wiki/dev-guides/Build-CSP-from-Source.md
+++ b/docs/wiki/dev-guides/Build-CSP-from-Source.md
@@ -96,7 +96,7 @@ micromamba activate csp
 make build-conda
 
 # finally install into the csp conda environment
-make develop
+make develop-conda
 ```
 
 ### A note about dependencies


### PR DESCRIPTION
We should not be running `make develop` as part of the local conda build - rather, we want to *only* install the local build of `csp` with none of its dependencies or build-time packages.