### PR TITLE
address functiondef args warning

### DIFF
--- a/csp/impl/wiring/graph_parser.py
+++ b/csp/impl/wiring/graph_parser.py
@@ -164,8 +164,9 @@ class GraphParser(BaseParser):
         )
         self.generic_visit(self._funcdef)
 
-        newfuncdef = ast.FunctionDef(name=self._funcdef.name, body=self._funcdef.body, returns=None)
-        newfuncdef.args = self._funcdef.args
+        newfuncdef = ast.FunctionDef(
+            name=self._funcdef.name, args=self._funcdef.args, body=self._funcdef.body, returns=None
+        )
         newfuncdef.decorator_list = []
 
         ast.fix_missing_locations(newfuncdef)

--- a/csp/impl/wiring/node_parser.py
+++ b/csp/impl/wiring/node_parser.py
@@ -857,9 +857,13 @@ class NodeParser(BaseParser):
         start_and_body = [ast.Expr(value=ast.Yield(value=None))] + del_vars + start_and_body
         newbody = init_block + start_and_body
 
-        newfuncdef = ast.FunctionDef(name=self._name, body=newbody, returns=None)
-        newfuncdef.args = self._create_ast_args(
-            posonlyargs=[], args=[], kwonlyargs=[], defaults=[], vararg=None, kwarg=None, kw_defaults=[]
+        newfuncdef = ast.FunctionDef(
+            name=self._name,
+            args=self._create_ast_args(
+                posonlyargs=[], args=[], kwonlyargs=[], defaults=[], vararg=None, kwarg=None, kw_defaults=[]
+            ),
+            body=newbody,
+            returns=None,
         )
         newfuncdef.decorator_list = []
 


### PR DESCRIPTION
`FunctionDef.__init__` has an `args` argument that was unused in these two spots, leading to the below warning. Not sure if there was a specific reason to leave these separate. The BaseParser passes [args directly](https://github.com/Point72/csp/blob/main/csp/impl/wiring/base_parser.py#L554) and there doesn't appear to be any impact on tests.

Warning(s)
```
csp/csp/impl/wiring/graph_parser.py:167: DeprecationWarning: FunctionDef.__init__ missing 1 required positional argument: 'args'. This will become an error in Python 3.15.
    newfuncdef = ast.FunctionDef(name=self._funcdef.name, body=self._funcdef.body, returns=None)
```
```
csp/csp/impl/wiring/node_parser.py:860: DeprecationWarning: FunctionDef.__init__ missing 1 required positional argument: 'args'. This will become an error in Python 3.15.
    newfuncdef = ast.FunctionDef(name=self._name, body=newbody, returns=None)

```