### PR TITLE
migrate examples to the utc_now utility instead of datetime.utcnow()

### DIFF
--- a/examples/02_intermediate/e1_feedback.py
+++ b/examples/02_intermediate/e1_feedback.py
@@ -1,11 +1,12 @@
 #
 # The csp.feedback construct is used to introduce cycles in the acyclical graph
 #
-from datetime import datetime, timedelta
+from datetime import timedelta
 
 import csp
 import csp.showgraph
 from csp import ts
+from csp.utils.datetime import utc_now
 
 
 class Order(csp.Struct):
@@ -80,7 +81,7 @@ def main():
     if show_graph:
         csp.showgraph.show_graph(my_graph)
     else:
-        csp.run(my_graph, starttime=datetime.utcnow(), endtime=timedelta(seconds=5), realtime=False)
+        csp.run(my_graph, starttime=utc_now(), endtime=timedelta(seconds=5), realtime=False)
 
 
 if __name__ == "__main__":

--- a/examples/03_using_adapters/kafka/e1_kafka.py
+++ b/examples/03_using_adapters/kafka/e1_kafka.py
@@ -10,6 +10,7 @@ from csp.adapters.kafka import (
     ProtoMessageMapper,
     RawTextMessageMapper,
 )
+from csp.utils.datetime import utc_now
 
 
 class JSONMessage(csp.Struct):
@@ -224,9 +225,9 @@ def text_consumer_graph():
 
 
 if __name__ == "__main__":
-    # csp.run( json_graph, starttime = datetime.utcnow(), endtime = timedelta( seconds = 10 ), realtime = True )
-    # csp.run( json_producer_graph, starttime = datetime.utcnow(), endtime = timedelta( seconds = 10 ), realtime = True )
-    # csp.run( proto_graph, starttime = datetime.utcnow(), endtime = timedelta( seconds = 10 ), realtime = True )
-    # csp.run( proto_graph_multiple_subscribers, starttime = datetime.utcnow(), endtime = timedelta( seconds = 10 ), realtime = True )
-    # csp.run( kerberos_consumer_graph, starttime = datetime.utcnow(), endtime = timedelta( seconds = 100 ), realtime = True )
-    csp.run(text_consumer_graph, starttime=datetime.utcnow(), endtime=timedelta(seconds=10), realtime=True)
+    # csp.run( json_graph, starttime = utc_now(), endtime = timedelta( seconds = 10 ), realtime = True )
+    # csp.run( json_producer_graph, starttime = utc_now(), endtime = timedelta( seconds = 10 ), realtime = True )
+    # csp.run( proto_graph, starttime = utc_now(), endtime = timedelta( seconds = 10 ), realtime = True )
+    # csp.run( proto_graph_multiple_subscribers, starttime = utc_now(), endtime = timedelta( seconds = 10 ), realtime = True )
+    # csp.run( kerberos_consumer_graph, starttime = utc_now(), endtime = timedelta( seconds = 100 ), realtime = True )
+    csp.run(text_consumer_graph, starttime=utc_now(), endtime=timedelta(seconds=10), realtime=True)

--- a/examples/03_using_adapters/websocket/e1_websocket_client.py
+++ b/examples/03_using_adapters/websocket/e1_websocket_client.py
@@ -1,8 +1,9 @@
 import sys
-from datetime import datetime, timedelta
+from datetime import timedelta
 
 import csp
 from csp.adapters.websocket import RawTextMessageMapper, Status, WebsocketAdapterManager
+from csp.utils.datetime import utc_now
 
 
 @csp.node
@@ -30,7 +31,7 @@ if __name__ == "__main__":
 
     csp.run(
         g,
-        starttime=datetime.utcnow(),
+        starttime=utc_now(),
         endtime=timedelta(minutes=1),
         realtime=True,
         uri=sys.argv[1],

--- a/examples/03_using_adapters/websocket/e2_websocket_output.py
+++ b/examples/03_using_adapters/websocket/e2_websocket_output.py
@@ -4,6 +4,7 @@ from datetime import datetime, timedelta
 import csp
 from csp import ts
 from csp.adapters.websocket import WebsocketTableAdapter
+from csp.utils.datetime import utc_now
 
 """ To view the output see sample html code below """
 
@@ -59,7 +60,7 @@ num_keys = 10
 
 
 def main():
-    csp.run(my_graph, port, num_keys, starttime=datetime.utcnow(), endtime=timedelta(seconds=360), realtime=True)
+    csp.run(my_graph, port, num_keys, starttime=utc_now(), endtime=timedelta(seconds=360), realtime=True)
 
 
 """ Sample html to view the data.  Note to put your machine name on the websocket line below

--- a/examples/04_writing_adapters/e1_generic_push_adapter.py
+++ b/examples/04_writing_adapters/e1_generic_push_adapter.py
@@ -5,9 +5,10 @@ from a non-csp engine thread into the csp engine.
 
 import threading
 import time
-from datetime import datetime, timedelta
+from datetime import timedelta
 
 import csp
+from csp.utils.datetime import utc_now
 
 
 # This will be run be some separate thread
@@ -53,7 +54,7 @@ def my_graph():
 
 
 def main():
-    csp.run(my_graph, realtime=True, starttime=datetime.utcnow(), endtime=timedelta(seconds=2))
+    csp.run(my_graph, realtime=True, starttime=utc_now(), endtime=timedelta(seconds=2))
 
 
 if __name__ == "__main__":

--- a/examples/04_writing_adapters/e4_pushinput.py
+++ b/examples/04_writing_adapters/e4_pushinput.py
@@ -8,12 +8,13 @@ see e5_adaptermanager_pushinput.py
 
 import threading
 import time
-from datetime import datetime, timedelta
+from datetime import timedelta
 
 import csp
 from csp import ts
 from csp.impl.pushadapter import PushInputAdapter
 from csp.impl.wiring import py_push_adapter_def
+from csp.utils.datetime import utc_now
 
 
 # The Impl object is created at runtime when the graph is converted into the runtime engine
@@ -68,7 +69,7 @@ def my_graph():
 
 
 def main():
-    csp.run(my_graph, realtime=True, starttime=datetime.utcnow(), endtime=timedelta(seconds=2))
+    csp.run(my_graph, realtime=True, starttime=utc_now(), endtime=timedelta(seconds=2))
 
 
 if __name__ == "__main__":

--- a/examples/04_writing_adapters/e5_adaptermanager_pushinput.py
+++ b/examples/04_writing_adapters/e5_adaptermanager_pushinput.py
@@ -7,13 +7,14 @@ that you want to connect to once, but provide data to/from many input/output ada
 import random
 import threading
 import time
-from datetime import datetime, timedelta
+from datetime import timedelta
 
 import csp
 from csp import ts
 from csp.impl.adaptermanager import AdapterManagerImpl
 from csp.impl.pushadapter import PushInputAdapter
 from csp.impl.wiring import py_push_adapter_def
+from csp.utils.datetime import utc_now
 
 
 class MyData(csp.Struct):
@@ -152,7 +153,7 @@ def my_graph():
 
 
 def main():
-    csp.run(my_graph, starttime=datetime.utcnow(), endtime=timedelta(seconds=2), realtime=True)
+    csp.run(my_graph, starttime=utc_now(), endtime=timedelta(seconds=2), realtime=True)
 
 
 if __name__ == "__main__":

--- a/examples/04_writing_adapters/e6_outputadapter.py
+++ b/examples/04_writing_adapters/e6_outputadapter.py
@@ -3,13 +3,14 @@ This is a simple example to demonstrate a basic output adapter. It also shows th
 functionality with a single node.
 """
 
-from datetime import datetime, timedelta
+from datetime import timedelta
 from json import dumps
 
 import csp
 from csp import ts
 from csp.impl.outputadapter import OutputAdapter
 from csp.impl.wiring import py_output_adapter_def
+from csp.utils.datetime import utc_now
 
 
 class MyBufferWriterAdapterImpl(OutputAdapter):
@@ -62,7 +63,7 @@ def my_graph():
 def main():
     csp.run(
         my_graph,
-        starttime=datetime.utcnow(),
+        starttime=utc_now(),
         endtime=timedelta(seconds=2),
         realtime=True,
     )

--- a/examples/04_writing_adapters/e7_adaptermanager_inputoutput.py
+++ b/examples/04_writing_adapters/e7_adaptermanager_inputoutput.py
@@ -13,7 +13,7 @@ import random
 import threading
 import time
 import typing
-from datetime import datetime, timedelta
+from datetime import timedelta
 
 import csp
 from csp import ts
@@ -21,6 +21,7 @@ from csp.impl.adaptermanager import AdapterManagerImpl
 from csp.impl.outputadapter import OutputAdapter
 from csp.impl.pushadapter import PushInputAdapter
 from csp.impl.wiring import py_output_adapter_def, py_push_adapter_def
+from csp.utils.datetime import utc_now
 
 T = typing.TypeVar("T")
 
@@ -167,7 +168,7 @@ def my_graph():
 
 
 def main():
-    csp.run(my_graph, starttime=datetime.utcnow(), endtime=timedelta(seconds=2), realtime=True)
+    csp.run(my_graph, starttime=utc_now(), endtime=timedelta(seconds=2), realtime=True)
 
 
 if __name__ == "__main__":

--- a/examples/06_advanced/e1_dynamic.py
+++ b/examples/06_advanced/e1_dynamic.py
@@ -1,7 +1,8 @@
-from datetime import datetime, timedelta
+from datetime import timedelta
 
 import csp
 from csp import ts
+from csp.utils.datetime import utc_now
 
 # This example demonstrates the advanced concept of dynamic graphs. Dynamic graphs provide the ability to extend the shape of the graph during runtime,
 # which is useful when you may not necessarily know what you will be processing at start
@@ -70,7 +71,7 @@ def main_graph():
 
 
 def main():
-    csp.run(main_graph, starttime=datetime.utcnow().replace(microsecond=0), endtime=timedelta(seconds=10))
+    csp.run(main_graph, starttime=utc_now().replace(microsecond=0), endtime=timedelta(seconds=10))
 
 
 if __name__ == "__main__":

--- a/examples/06_advanced/e2_pandas_extension.py
+++ b/examples/06_advanced/e2_pandas_extension.py
@@ -13,6 +13,7 @@ import csp.impl.pandas_accessor  # This registers the "csp" accessors on pd.Seri
 from csp.impl.pandas_ext_type import TsDtype
 from csp.random import brownian_motion
 from csp.stats import numpy_to_list
+from csp.utils.datetime import utc_now
 
 
 def main():
@@ -66,7 +67,7 @@ def main():
     print(weighted_price)
     print()
     print("Run the weighted price as a graph...")
-    for timestamp, value in weighted_price.run(starttime=datetime.utcnow(), endtime=timedelta(seconds=6)):
+    for timestamp, value in weighted_price.run(starttime=utc_now(), endtime=timedelta(seconds=6)):
         print(timestamp, value)
     print()
     print()
@@ -77,7 +78,7 @@ def main():
         print(df_agg)
         print()
         print("Run the aggregate frame as of now")
-        print(df_agg.csp.run(datetime.utcnow(), timedelta(seconds=6)))
+        print(df_agg.csp.run(utc_now(), timedelta(seconds=6)))
         print()
     print()
     print()


### PR DESCRIPTION
Migrates the examples to use the `utc_now` utility instead of `datetime.utcnow`