### PR TITLE
Remove unused method and clean up unused imports

### DIFF
--- a/csp/impl/mem_cache.py
+++ b/csp/impl/mem_cache.py
@@ -76,21 +76,6 @@ class CspGraphObjectsMemCache(object):
             new_instance._user_objects.update(current_instance._user_objects)
         return new_instance
 
-    def get_object_stats(self, sort_by="count"):
-        assert sort_by is None or sort_by in ["name", "count"]
-        res = {}
-        for key in self._instantiated_objects.keys():
-            assert isinstance(key, GraphFunctionObjectKey)
-            name = key.func.__name__
-            res[name] = res.get(name, 0) + 1
-        if sort_by == "name":
-            res = dict(sorted(res.items(), key=lambda t: t[0]))
-        elif sort_by == "count":
-            res = dict(sorted(res.items(), key=lambda t: (-t[1], t[0])))
-        elif sort_by is not None:
-            raise RuntimeError(f"Unsupported sort_by value {sort_by}")
-        return res
-
     def __getitem__(self, key):
         assert isinstance(key, GraphFunctionObjectKey)
         return self._instantiated_objects.get(key, UNSET)

--- a/csp/tests/adapters/test_db.py
+++ b/csp/tests/adapters/test_db.py
@@ -1,4 +1,3 @@
-import os
 import unittest
 from datetime import date, datetime, time
 

--- a/csp/tests/adapters/test_websocket.py
+++ b/csp/tests/adapters/test_websocket.py
@@ -1,4 +1,3 @@
-import os
 import threading
 import unittest
 from datetime import datetime, timedelta

--- a/csp/tests/impl/test_pandas_accessor.py
+++ b/csp/tests/impl/test_pandas_accessor.py
@@ -3,7 +3,6 @@ from datetime import date, datetime, timedelta
 
 import numpy as np
 import pandas as pd
-import pytest
 
 import csp
 import csp.impl.pandas_accessor

--- a/csp/tests/impl/test_pulladapter.py
+++ b/csp/tests/impl/test_pulladapter.py
@@ -1,4 +1,3 @@
-import time
 import unittest
 from datetime import datetime, timedelta
 from typing import List

--- a/csp/tests/impl/test_struct.py
+++ b/csp/tests/impl/test_struct.py
@@ -1,7 +1,6 @@
 import enum
 import json
 import pickle
-import sys
 import unittest
 from datetime import date, datetime, time, timedelta
 from typing import Any, Dict, List, Literal, Optional, Set, Tuple, Union

--- a/csp/tests/impl/types/test_pydantic_type_resolver.py
+++ b/csp/tests/impl/types/test_pydantic_type_resolver.py
@@ -1,4 +1,4 @@
-from typing import Dict, Generic, List, Set, TypeVar, get_args, get_origin
+from typing import Dict, Generic, List, Set, TypeVar
 from unittest import TestCase
 
 import numpy as np

--- a/csp/tests/impl/types/test_pydantic_types.py
+++ b/csp/tests/impl/types/test_pydantic_types.py
@@ -1,4 +1,3 @@
-import sys
 from inspect import isclass
 from typing import Any, Callable, Dict, Generic, List, Literal, Optional, Type, TypeVar, Union, get_args, get_origin
 from unittest import TestCase

--- a/csp/tests/impl/types/test_tstype.py
+++ b/csp/tests/impl/types/test_tstype.py
@@ -1,9 +1,7 @@
-import sys
-from typing import Any, Dict, ForwardRef, Generic, List, Mapping, TypeVar, Union, get_args, get_origin
+from typing import Any, Dict, ForwardRef, Generic, List, TypeVar, Union
 from unittest import TestCase
 
 import numpy as np
-import pytest
 from pydantic import TypeAdapter
 
 import csp

--- a/csp/tests/impl/wiring/test_basket_outputs.py
+++ b/csp/tests/impl/wiring/test_basket_outputs.py
@@ -1,4 +1,3 @@
-import typing
 import unittest
 from datetime import datetime, timedelta
 from enum import Enum, auto

--- a/csp/tests/test_graph_mem_cache.py
+++ b/csp/tests/test_graph_mem_cache.py
@@ -1,5 +1,4 @@
 import copy
-import sys
 import unittest
 
 import csp

--- a/csp/tests/test_parsing.py
+++ b/csp/tests/test_parsing.py
@@ -1,4 +1,3 @@
-import sys
 import unittest
 from datetime import datetime, timedelta
 from typing import Callable, Dict, List

--- a/csp/tests/test_profiler.py
+++ b/csp/tests/test_profiler.py
@@ -4,14 +4,12 @@ import sys
 import tempfile
 import time as Time
 import unittest
-from datetime import date, datetime, time, timedelta
+from datetime import datetime, time, timedelta
 from functools import reduce
 from typing import List
 
 import numpy as np
 import pandas as pd
-import pytz
-
 import csp
 import csp.stats as stats
 from csp import profiler, ts

--- a/csp/tests/test_type_checking.py
+++ b/csp/tests/test_type_checking.py
@@ -1,7 +1,6 @@
 import os
 import pickle
 import re
-import sys
 import typing
 import unittest
 import warnings


### PR DESCRIPTION
## Summary
- Remove `CspGraphObjectsMemCache.get_object_stats()` in `csp/impl/mem_cache.py` — zero callers anywhere in the codebase
- Clean up unused imports across 13 test files (`sys` ×6, `os` ×2, `pytest` ×2, `time` ×1, `date` ×1, `pytz` ×1, `typing` ×1, `get_args`/`get_origin` from typing)

14 files changed, 32 lines removed.

## Verification
- Confirmed `get_object_stats` has zero references via project-wide grep
- All import removals verified as unused (no references in their respective files)
- Skipped `View._get_row_delta` since it may be a parent class override called by the perspective framework

Found with [Skylos](https://github.com/duriantaco/skylos), a dead code detection tool.

## Test plan
- [ ] Existing test suite passes (no behavioral changes, only unused code removed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)