### PR TITLE
Release v0.15.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@
 # Project Configuration #
 #########################
 cmake_minimum_required(VERSION 3.20.0)
-project(csp VERSION "0.14.1")
+project(csp VERSION "0.15.0")
 set(CMAKE_CXX_STANDARD 20)
 
 ###################################################################################################################################################

--- a/csp/__init__.py
+++ b/csp/__init__.py
@@ -31,7 +31,7 @@ from csp.showgraph import show_graph
 
 from . import stats
 
-__version__ = "0.14.1"
+__version__ = "0.15.0"
 
 
 def get_include_path():

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ name = "csp"
 authors = [{name = "the csp authors", email = "CSPOpenSource@point72.com"}]
 description="csp is a high performance reactive stream processing library, written in C++ and Python"
 readme = "README.md"
-version = "0.14.1"
+version = "0.15.0"
 requires-python = ">=3.10"
 
 dependencies = [
@@ -118,7 +118,7 @@ slack = [
 ]
 
 [tool.bumpversion]
-current_version = "0.14.1"
+current_version = "0.15.0"
 commit = false
 tag = false
 commit_args = "-s"

--- a/setup.py
+++ b/setup.py
@@ -149,7 +149,7 @@ print(f"CMake Args: {cmake_args}")
 
 setup(
     name="csp",
-    version="0.14.1",
+    version="0.15.0",
     packages=["csp"],
     cmake_install_dir="csp",
     cmake_args=cmake_args,


### PR DESCRIPTION
This is the same release as `0.14.1` but with a new version number - `0.14.1` was not compatible with `0.14.0` due to C-ABI changes that I missed, specifically the change to the constructor signature of `PushInputAdapter`.

We decided to yank `0.14.1` and replace it with `0.15.0` as this correctly signifies the build vs. runtime incompatibility.

Full CI run (from prior PR): https://github.com/Point72/csp/actions/runs/23158560886