### PR TITLE
Add nodes to convert between csp.Structs and Arrow RecordBatches

### DIFF
--- a/cpp/cmake/modules/FindDepsArrowAdapter.cmake
+++ b/cpp/cmake/modules/FindDepsArrowAdapter.cmake
@@ -3,3 +3,25 @@ cmake_minimum_required(VERSION 3.7.2)
 # ARROW
 find_package(Arrow REQUIRED)
 include_directories(${ARROW_INCLUDE_DIR})
+
+# Resolve Arrow link targets based on platform and vcpkg configuration.
+# Sets CSP_ARROW_LINK_LIBS for use in target_link_libraries().
+# On Windows with vcpkg, also applies the ws2_32.dll fix and defines ARROW_STATIC.
+if(WIN32)
+    if(CSP_USE_VCPKG)
+        set(CSP_ARROW_LINK_LIBS Arrow::arrow_static)
+        add_compile_definitions(ARROW_STATIC)
+    else()
+        # Until we manage to get the fix for ws2_32.dll in arrow-16 into conda, manually fix the error here
+        get_target_property(LINK_LIBS Arrow::arrow_shared INTERFACE_LINK_LIBRARIES)
+        string(REPLACE "ws2_32.dll" "ws2_32" FIXED_LINK_LIBS "${LINK_LIBS}")
+        set_target_properties(Arrow::arrow_shared PROPERTIES INTERFACE_LINK_LIBRARIES "${FIXED_LINK_LIBS}")
+        set(CSP_ARROW_LINK_LIBS arrow_shared)
+    endif()
+else()
+    if(CSP_USE_VCPKG)
+        set(CSP_ARROW_LINK_LIBS arrow_static)
+    else()
+        set(CSP_ARROW_LINK_LIBS arrow)
+    endif()
+endif()

--- a/cpp/csp/adapters/CMakeLists.txt
+++ b/cpp/csp/adapters/CMakeLists.txt
@@ -3,6 +3,10 @@ if(CSP_BUILD_KAFKA_ADAPTER)
     add_subdirectory(kafka)
 endif()
 
+if(CSP_BUILD_ARROW_ADAPTER)
+    add_subdirectory(arrow)
+endif()
+
 if(CSP_BUILD_PARQUET_ADAPTER)
     add_subdirectory(parquet)
 endif()

--- a/cpp/csp/adapters/arrow/ArrowFieldReader.cpp
+++ b/cpp/csp/adapters/arrow/ArrowFieldReader.cpp
@@ -1,0 +1,480 @@
+// Concrete FieldReader implementations for all scalar Arrow types.
+//
+// Most readers use LambdaReader<ArrowArrayT> — a single template that
+// takes a read-one-row callable at construction.  Only readers with
+// extra state (EnumFromString, Dict*, NestedStruct) are separate classes.
+
+#include <csp/adapters/arrow/ArrowFieldReader.h>
+#include <csp/engine/CspType.h>
+#include <csp/engine/CspEnum.h>
+
+#include <arrow/array.h>
+#include <arrow/type.h>
+#include <arrow/util/float16.h>
+
+namespace csp::adapters::arrow
+{
+
+// Registered factory for list FieldReaders (set by Python-aware layer).
+static ListFieldReaderFactory s_listFieldReaderFactory;
+
+void registerListFieldReaderFactory( ListFieldReaderFactory factory )
+{
+    s_listFieldReaderFactory = std::move( factory );
+}
+
+namespace
+{
+
+// Columnar bulk-read helper: dispatches fn(arr, row, struct*) for each row,
+// skipping nulls when null_count > 0.
+template<typename ArrowArrayT, typename Fn>
+void readColumn( const ArrowArrayT & typed, std::vector<StructPtr> & structs, int64_t numRows, Fn && fn )
+{
+    if( typed.null_count() == 0 )
+        for( int64_t i = 0; i < numRows; ++i )
+            fn( typed, i, structs[i].get() );
+    else
+        for( int64_t i = 0; i < numRows; ++i )
+            if( typed.IsValid( i ) )
+                fn( typed, i, structs[i].get() );
+}
+
+// Helper: compute nanosecond multiplier for a given arrow::TimeUnit
+int64_t timeUnitMultiplier( ::arrow::TimeUnit::type unit )
+{
+    switch( unit )
+    {
+        case ::arrow::TimeUnit::SECOND: return csp::NANOS_PER_SECOND;
+        case ::arrow::TimeUnit::MILLI:  return csp::NANOS_PER_MILLISECOND;
+        case ::arrow::TimeUnit::MICRO:  return csp::NANOS_PER_MICROSECOND;
+        case ::arrow::TimeUnit::NANO:   return 1LL;
+        default:
+            CSP_THROW( TypeError, "Unexpected arrow TimeUnit: " << static_cast<int>( unit ) );
+    }
+}
+
+// --- Generic lambda-based reader (covers Primitive, HalfFloat, StringLike, Nanos, Date) ---
+// ExtractFn signature: ValueT(const ArrowArrayT &, int64_t row)
+
+template<typename ArrowArrayT, typename ValueT, typename ExtractFn>
+class LambdaReader final : public TypedFieldReader<ValueT>
+{
+    using Base = TypedFieldReader<ValueT>;
+public:
+    LambdaReader( const std::string & columnName, const StructFieldPtr & field,
+                  ExtractFn extractFn )
+        : Base( columnName, field ), m_extractFn( std::move( extractFn ) ) {}
+
+    void readAll( std::vector<StructPtr> & structs, int64_t numRows ) override
+    {
+        auto & typed = static_cast<const ArrowArrayT &>( *this -> m_column );
+        auto & f = this -> m_field;
+        if( typed.null_count() == 0 )
+            for( int64_t i = 0; i < numRows; ++i )
+                f -> template setValue<ValueT>( structs[i].get(), m_extractFn( typed, i ) );
+        else
+            for( int64_t i = 0; i < numRows; ++i )
+                if( typed.IsValid( i ) )
+                    f -> template setValue<ValueT>( structs[i].get(), m_extractFn( typed, i ) );
+        this -> m_row = numRows;
+    }
+
+protected:
+    bool doExtract( int64_t row, ValueT & out ) override
+    {
+        auto & typed = static_cast<const ArrowArrayT &>( *this -> m_column );
+        if( typed.IsValid( row ) )
+        {
+            out = m_extractFn( typed, row );
+            return true;
+        }
+        return false;
+    }
+
+private:
+    ExtractFn  m_extractFn;
+};
+
+// Factory: creates a LambdaReader, deducing function types
+template<typename ArrowArrayT, typename ValueT, typename ExtractFn>
+std::unique_ptr<FieldReader> makeReader( const std::string & name, const StructFieldPtr & field,
+                                         ExtractFn && extractFn )
+{
+    return std::make_unique<LambdaReader<ArrowArrayT, ValueT,
+                                         std::decay_t<ExtractFn>>>(
+        name, field, std::forward<ExtractFn>( extractFn ) );
+}
+
+// Factory: primitive numeric reader (static_cast Value(i) to CspT)
+template<typename CspT, typename ArrowArrayT>
+std::unique_ptr<FieldReader> makePrimitiveReader( const std::string & name, const StructFieldPtr & f )
+{
+    return makeReader<ArrowArrayT, CspT>( name, f,
+        []( auto & arr, int64_t i ) -> CspT {
+            return static_cast<CspT>( arr.Value( i ) );
+        } );
+}
+
+// Factory: string/binary reader (GetView → std::string)
+template<typename ArrowArrayT>
+std::unique_ptr<FieldReader> makeStringReader( const std::string & name, const StructFieldPtr & f )
+{
+    return makeReader<ArrowArrayT, std::string>( name, f,
+        []( auto & arr, int64_t i ) -> std::string {
+            auto view = arr.GetView( i );
+            return std::string( view.data(), view.size() );
+        } );
+}
+
+// Factory: nanosecond-based temporal reader (Value * multiplier → CspT::fromNanoseconds)
+template<typename CspT, typename ArrowArrayT>
+std::unique_ptr<FieldReader> makeNanosReader( const std::string & name, const StructFieldPtr & f, int64_t mult )
+{
+    return makeReader<ArrowArrayT, CspT>( name, f,
+        [mult]( auto & arr, int64_t i ) -> CspT {
+            return CspT::fromNanoseconds( static_cast<int64_t>( arr.Value( i ) ) * mult );
+        } );
+}
+
+// --- Enum from string column (needs m_enumMeta + m_tmpStr state) ---
+
+template<typename ArrowStringArrayT>
+class EnumFromStringReader final : public TypedFieldReader<CspEnum>
+{
+    using Base = TypedFieldReader<CspEnum>;
+public:
+    EnumFromStringReader( const std::string & columnName, const StructFieldPtr & field )
+        : Base( columnName, field ),
+          m_enumMeta( std::static_pointer_cast<const CspEnumType>( field -> type() ) -> meta() ) {}
+
+    void readAll( std::vector<StructPtr> & structs, int64_t numRows ) override
+    {
+        auto & typed = static_cast<const ArrowStringArrayT &>( *this -> m_column );
+        readColumn( typed, structs, numRows, [this]( auto & arr, int64_t i, Struct * s ) {
+            auto view = arr.GetView( i );
+            m_tmpStr.assign( view.data(), view.size() );
+            this -> m_field -> template setValue<CspEnum>( s, m_enumMeta -> fromString( m_tmpStr.c_str() ) );
+        } );
+        this -> m_row = numRows;
+    }
+
+protected:
+    bool doExtract( int64_t row, CspEnum & out ) override
+    {
+        auto & typed = static_cast<const ArrowStringArrayT &>( *this -> m_column );
+        if( typed.IsValid( row ) )
+        {
+            auto view = typed.GetView( row );
+            m_tmpStr.assign( view.data(), view.size() );
+            out = m_enumMeta -> fromString( m_tmpStr.c_str() );
+            return true;
+        }
+        return false;
+    }
+
+private:
+    std::shared_ptr<const CspEnumMeta> m_enumMeta;
+    mutable std::string                m_tmpStr;
+};
+
+// --- Dictionary-encoded string ---
+
+class DictStringReader final : public TypedFieldReader<std::string>
+{
+    using Base = TypedFieldReader<std::string>;
+public:
+    using Base::Base;
+
+    void readAll( std::vector<StructPtr> & structs, int64_t numRows ) override
+    {
+        auto & typed = static_cast<const ::arrow::DictionaryArray &>( *m_column );
+        const auto * dict = &static_cast<const ::arrow::StringArray &>( *typed.dictionary() );
+        readColumn( typed, structs, numRows, [this, dict]( auto & arr, int64_t i, Struct * s ) {
+            auto view = dict -> GetView( arr.GetValueIndex( i ) );
+            m_field -> template setValue<std::string>( s, std::string( view.data(), view.size() ) );
+        } );
+        m_row = numRows;
+    }
+
+protected:
+    bool doExtract( int64_t row, std::string & out ) override
+    {
+        auto & typed = static_cast<const ::arrow::DictionaryArray &>( *m_column );
+        if( row == 0 )
+            m_dict = &static_cast<const ::arrow::StringArray &>( *typed.dictionary() );
+        if( typed.IsValid( row ) )
+        {
+            auto view = m_dict -> GetView( typed.GetValueIndex( row ) );
+            out.assign( view.data(), view.size() );
+            return true;
+        }
+        return false;
+    }
+
+private:
+    const ::arrow::StringArray * m_dict = nullptr;
+};
+
+// --- Dictionary-encoded enum ---
+
+class DictEnumReader final : public TypedFieldReader<CspEnum>
+{
+    using Base = TypedFieldReader<CspEnum>;
+public:
+    DictEnumReader( const std::string & columnName, const StructFieldPtr & field )
+        : Base( columnName, field ),
+          m_enumMeta( std::static_pointer_cast<const CspEnumType>( field -> type() ) -> meta() ) {}
+
+    void readAll( std::vector<StructPtr> & structs, int64_t numRows ) override
+    {
+        auto & typed = static_cast<const ::arrow::DictionaryArray &>( *m_column );
+        const auto * dict = &static_cast<const ::arrow::StringArray &>( *typed.dictionary() );
+        readColumn( typed, structs, numRows, [this, dict]( auto & arr, int64_t i, Struct * s ) {
+            auto view = dict -> GetView( arr.GetValueIndex( i ) );
+            m_tmpStr.assign( view.data(), view.size() );
+            m_field -> template setValue<CspEnum>( s, m_enumMeta -> fromString( m_tmpStr.c_str() ) );
+        } );
+        m_row = numRows;
+    }
+
+protected:
+    bool doExtract( int64_t row, CspEnum & out ) override
+    {
+        auto & typed = static_cast<const ::arrow::DictionaryArray &>( *m_column );
+        if( row == 0 )
+            m_dict = &static_cast<const ::arrow::StringArray &>( *typed.dictionary() );
+        if( typed.IsValid( row ) )
+        {
+            auto view = m_dict -> GetView( typed.GetValueIndex( row ) );
+            m_tmpStr.assign( view.data(), view.size() );
+            out = m_enumMeta -> fromString( m_tmpStr.c_str() );
+            return true;
+        }
+        return false;
+    }
+
+private:
+    std::shared_ptr<const CspEnumMeta> m_enumMeta;
+    const ::arrow::StringArray *       m_dict = nullptr;
+    mutable std::string                m_tmpStr;
+};
+
+// --- Nested struct (recursive) ---
+
+class NestedStructReader final : public TypedFieldReader<StructPtr>
+{
+    using Base = TypedFieldReader<StructPtr>;
+public:
+    NestedStructReader( const std::string & columnName, const StructFieldPtr & field,
+                        const std::shared_ptr<::arrow::DataType> & arrowType,
+                        std::shared_ptr<const StructMeta> explicitMeta = nullptr )
+        : Base( columnName, field )
+    {
+        m_nestedMeta = explicitMeta ? std::move( explicitMeta )
+                                    : std::static_pointer_cast<const CspStructType>( field -> type() ) -> meta();
+        auto structType = std::static_pointer_cast<::arrow::StructType>( arrowType );
+
+        m_childReaders.reserve( structType -> num_fields() );
+        for( int i = 0; i < structType -> num_fields(); ++i )
+        {
+            auto childArrowField = structType -> field( i );
+            auto childStructField = m_nestedMeta -> field( childArrowField -> name() );
+            if( !childStructField )
+                CSP_THROW( RuntimeException, "Nested arrow struct field '" << childArrowField -> name()
+                                              << "' not found on CSP struct type '" << m_nestedMeta -> name() << "'" );
+            m_childIndices.push_back( i );
+            m_childReaders.push_back( createFieldReader( childArrowField, childStructField ) );
+        }
+    }
+
+    void readAll( std::vector<StructPtr> & structs, int64_t numRows ) override
+    {
+        auto & typed = static_cast<const ::arrow::StructArray &>( *m_column );
+        for( size_t i = 0; i < m_childReaders.size(); ++i )
+            m_childReaders[i] -> bindColumn( typed.field( m_childIndices[i] ).get() );
+
+        if( typed.null_count() == 0 )
+        {
+            // Pre-allocate nested structs and let children use their columnar readAll paths
+            std::vector<StructPtr> nested( numRows );
+            for( int64_t i = 0; i < numRows; ++i )
+                nested[i] = m_nestedMeta -> create();
+            for( auto & child : m_childReaders )
+                child -> readAll( nested, numRows );
+            for( int64_t row = 0; row < numRows; ++row )
+                m_field -> setValue<StructPtr>( structs[row].get(), std::move( nested[row] ) );
+        }
+        else
+        {
+            for( int64_t row = 0; row < numRows; ++row )
+            {
+                if( typed.IsValid( row ) )
+                {
+                    StructPtr nested = m_nestedMeta -> create();
+                    for( auto & child : m_childReaders )
+                        child -> readNext( nested.get() );
+                    m_field -> setValue<StructPtr>( structs[row].get(), std::move( nested ) );
+                }
+                else
+                {
+                    for( auto & child : m_childReaders )
+                        child -> skipNext();
+                }
+            }
+        }
+        m_row = numRows;
+    }
+
+protected:
+    void skipNext() override
+    {
+        for( auto & child : m_childReaders )
+            child -> skipNext();
+        ++m_row;
+    }
+
+    bool doExtract( int64_t row, StructPtr & out ) override
+    {
+        auto & typed = static_cast<const ::arrow::StructArray &>( *m_column );
+        if( row == 0 )
+            for( size_t i = 0; i < m_childReaders.size(); ++i )
+                m_childReaders[i] -> bindColumn( typed.field( m_childIndices[i] ).get() );
+
+        if( typed.IsValid( row ) )
+        {
+            StructPtr nested = m_nestedMeta -> create();
+            for( auto & child : m_childReaders )
+                child -> readNext( nested.get() );
+            out = std::move( nested );
+            return true;
+        }
+        else
+        {
+            for( auto & child : m_childReaders )
+                child -> skipNext();
+            return false;
+        }
+    }
+
+private:
+    std::shared_ptr<const StructMeta>         m_nestedMeta;
+    std::vector<int>                          m_childIndices;
+    std::vector<std::unique_ptr<FieldReader>> m_childReaders;
+};
+
+} // anonymous namespace
+
+std::unique_ptr<FieldReader> createFieldReader(
+    const std::shared_ptr<::arrow::Field> & arrowField,
+    const StructFieldPtr & structField,
+    const std::shared_ptr<const StructMeta> & structMeta )
+{
+    bool isEnum = structField && structField -> type() -> type() == CspType::Type::ENUM;
+    auto typeId = arrowField -> type() -> id();
+    auto & name = arrowField -> name();
+    auto & f    = structField;
+
+    switch( typeId )
+    {
+        // --- Numeric ---
+        case ::arrow::Type::BOOL:   return makePrimitiveReader<bool,     ::arrow::BooleanArray>( name, f );
+        case ::arrow::Type::INT8:   return makePrimitiveReader<int8_t,   ::arrow::Int8Array>( name, f );
+        case ::arrow::Type::INT16:  return makePrimitiveReader<int16_t,  ::arrow::Int16Array>( name, f );
+        case ::arrow::Type::INT32:  return makePrimitiveReader<int32_t,  ::arrow::Int32Array>( name, f );
+        case ::arrow::Type::INT64:  return makePrimitiveReader<int64_t,  ::arrow::Int64Array>( name, f );
+        case ::arrow::Type::UINT8:  return makePrimitiveReader<uint8_t,  ::arrow::UInt8Array>( name, f );
+        case ::arrow::Type::UINT16: return makePrimitiveReader<uint16_t, ::arrow::UInt16Array>( name, f );
+        case ::arrow::Type::UINT32: return makePrimitiveReader<uint32_t, ::arrow::UInt32Array>( name, f );
+        case ::arrow::Type::UINT64: return makePrimitiveReader<uint64_t, ::arrow::UInt64Array>( name, f );
+        case ::arrow::Type::FLOAT:  return makePrimitiveReader<double,   ::arrow::FloatArray>( name, f );
+        case ::arrow::Type::DOUBLE: return makePrimitiveReader<double,   ::arrow::DoubleArray>( name, f );
+
+        case ::arrow::Type::HALF_FLOAT:
+            return makeReader<::arrow::HalfFloatArray, double>( name, f,
+                []( auto & arr, int64_t i ) -> double {
+                    return ::arrow::util::Float16::FromBits( arr.Value( i ) ).ToDouble();
+                } );
+
+        // --- String ---
+        case ::arrow::Type::STRING:
+            if( isEnum ) return std::make_unique<EnumFromStringReader<::arrow::StringArray>>( name, f );
+            return makeStringReader<::arrow::StringArray>( name, f );
+        case ::arrow::Type::LARGE_STRING:
+            if( isEnum ) return std::make_unique<EnumFromStringReader<::arrow::LargeStringArray>>( name, f );
+            return makeStringReader<::arrow::LargeStringArray>( name, f );
+
+        // --- Binary / bytes ---
+        case ::arrow::Type::BINARY:            return makeStringReader<::arrow::BinaryArray>( name, f );
+        case ::arrow::Type::LARGE_BINARY:      return makeStringReader<::arrow::LargeBinaryArray>( name, f );
+        case ::arrow::Type::FIXED_SIZE_BINARY: return makeStringReader<::arrow::FixedSizeBinaryArray>( name, f );
+
+        // --- Timestamp -> DateTime ---
+        case ::arrow::Type::TIMESTAMP:
+        {
+            auto mult = timeUnitMultiplier( std::static_pointer_cast<::arrow::TimestampType>( arrowField -> type() ) -> unit() );
+            return makeNanosReader<DateTime, ::arrow::TimestampArray>( name, f, mult );
+        }
+
+        // --- Duration -> TimeDelta ---
+        case ::arrow::Type::DURATION:
+        {
+            auto mult = timeUnitMultiplier( std::static_pointer_cast<::arrow::DurationType>( arrowField -> type() ) -> unit() );
+            return makeNanosReader<TimeDelta, ::arrow::DurationArray>( name, f, mult );
+        }
+
+        // --- Date ---
+        case ::arrow::Type::DATE32:
+            return makeReader<::arrow::Date32Array, Date>( name, f,
+                []( auto & arr, int64_t i ) -> Date {
+                    return DateTime::fromNanoseconds( static_cast<int64_t>( arr.Value( i ) ) * csp::NANOS_PER_DAY ).date();
+                } );
+        case ::arrow::Type::DATE64:
+            return makeReader<::arrow::Date64Array, Date>( name, f,
+                []( auto & arr, int64_t i ) -> Date {
+                    return DateTime::fromNanoseconds( arr.Value( i ) * csp::NANOS_PER_MILLISECOND ).date();
+                } );
+
+        // --- Time ---
+        case ::arrow::Type::TIME32:
+        {
+            auto mult = timeUnitMultiplier( std::static_pointer_cast<::arrow::Time32Type>( arrowField -> type() ) -> unit() );
+            return makeNanosReader<Time, ::arrow::Time32Array>( name, f, mult );
+        }
+        case ::arrow::Type::TIME64:
+        {
+            auto mult = timeUnitMultiplier( std::static_pointer_cast<::arrow::Time64Type>( arrowField -> type() ) -> unit() );
+            return makeNanosReader<Time, ::arrow::Time64Array>( name, f, mult );
+        }
+
+        // --- Dictionary-encoded ---
+        case ::arrow::Type::DICTIONARY:
+        {
+            auto dictType = std::static_pointer_cast<::arrow::DictionaryType>( arrowField -> type() );
+            if( dictType -> value_type() -> id() != ::arrow::Type::STRING )
+                CSP_THROW( TypeError, "Unsupported dictionary value type " << dictType -> value_type() -> ToString()
+                                       << " for column '" << name << "'; only string dictionaries supported" );
+            if( isEnum ) return std::make_unique<DictEnumReader>( name, f );
+            return std::make_unique<DictStringReader>( name, f );
+        }
+
+        // --- Nested struct ---
+        case ::arrow::Type::STRUCT:
+            if( !f && !structMeta )
+                return nullptr;  // no struct info available (ColumnDispatcher without meta)
+            return std::make_unique<NestedStructReader>( name, f, arrowField -> type(), structMeta );
+
+        // --- List (requires registered factory from Python layer) ---
+        case ::arrow::Type::LIST:
+        case ::arrow::Type::LARGE_LIST:
+            CSP_TRUE_OR_THROW_RUNTIME( s_listFieldReaderFactory,
+                "List field reader factory not registered; ensure Python/numpy layer is initialized before reading list columns" );
+            return s_listFieldReaderFactory( arrowField, structField );
+
+        default:
+            CSP_THROW( TypeError, "Unsupported arrow type " << arrowField -> type() -> ToString()
+                                   << " for column '" << name << "'" );
+    }
+}
+
+}

--- a/cpp/csp/adapters/arrow/ArrowFieldReader.h
+++ b/cpp/csp/adapters/arrow/ArrowFieldReader.h
@@ -1,0 +1,155 @@
+// Per-column readers that extract values from Arrow arrays.
+//
+// FieldReader is the base class with non-virtual bindColumn()/readNext() for
+// sequential row processing.  Readers can write to a Struct field (readNext)
+// or to a raw value pointer (readNextValue) for use without structs.
+// Scalar readers use the single-column constructor; multi-column readers
+// (e.g. NDArray with data + dims) use the multi-column constructor and
+// override the virtual bindBatch().
+
+#ifndef _IN_CSP_ADAPTERS_ARROW_ArrowFieldReader_H
+#define _IN_CSP_ADAPTERS_ARROW_ArrowFieldReader_H
+
+#include <csp/engine/Struct.h>
+#include <arrow/record_batch.h>
+#include <arrow/type.h>
+#include <functional>
+#include <memory>
+#include <optional>
+#include <string>
+#include <vector>
+
+namespace csp::adapters::arrow
+{
+
+class FieldReader
+{
+public:
+    virtual ~FieldReader() = default;
+
+    // Constructor for single-column readers
+    FieldReader( const std::string & columnName, const StructFieldPtr & field )
+        : m_field( field ), m_columnNames( { columnName } )
+    {
+    }
+
+    // Constructor for multi-column readers (e.g. NDArray with data + dims columns)
+    FieldReader( std::vector<std::string> columnNames, const StructFieldPtr & field )
+        : m_field( field ), m_columnNames( std::move( columnNames ) )
+    {
+    }
+
+    // Set primary column pointer and reset row counter. Non-virtual.
+    void bindColumn( const ::arrow::Array * column )
+    {
+        m_column = column;
+        m_row = 0;
+    }
+
+    // Batch-level bind for readers that need the full RecordBatch (e.g. multi-column
+    // numpy readers).  Default does nothing; custom readers override this.
+    virtual void bindBatch( const ::arrow::RecordBatch & batch ) {}
+
+    // Read the current row into the struct and advance to the next row.
+    void readNext( Struct * s )
+    {
+        doReadNext( m_row, s );
+        ++m_row;
+    }
+
+    // Read the current row's value into an optional<T> (passed as void*) and advance.
+    // The target must point to a std::optional<T> matching this reader's value type.
+    // Null arrow values → optional.reset(); valid → optional = extracted value.
+    void readNextValue( void * optionalOut )
+    {
+        doReadNextValue( m_row, optionalOut );
+        ++m_row;
+    }
+
+    // Advance the row counter without reading (used to keep child readers in sync
+    // when a parent nested struct row is null).
+    virtual void skipNext()
+    {
+        ++m_row;
+    }
+
+    // Columnar bulk-read: read all rows for this column into pre-allocated structs.
+    // Default implementation loops over doReadNext(); concrete readers override
+    // with a null_count==0 fast path to skip per-row validity checks.
+    virtual void readAll( std::vector<StructPtr> & structs, int64_t numRows )
+    {
+        for( int64_t row = 0; row < numRows; ++row )
+            doReadNext( row, structs[row].get() );
+        m_row = numRows;
+    }
+
+    // Column names consumed by this reader.
+    const std::vector<std::string> & columnNames() const { return m_columnNames; }
+
+    // The struct field this reader targets (may be null for fieldless readers).
+    const StructFieldPtr & field() const { return m_field; }
+
+protected:
+    // Core extraction: returns true if the arrow value at row is non-null and
+    // writes the extracted value into valueOut (a raw T*).  Subclasses implement
+    // doExtract; doReadNext and doReadNextValue are provided by TypedFieldReader.
+    virtual void doReadNext( int64_t row, Struct * s ) = 0;
+    virtual void doReadNextValue( int64_t row, void * optionalOut ) = 0;
+
+    StructFieldPtr             m_field;
+    std::vector<std::string>   m_columnNames;
+    const ::arrow::Array *     m_column = nullptr;
+    int64_t                    m_row    = 0;
+};
+
+// Typed intermediate: provides default doReadNext/doReadNextValue from a single
+// doExtract(row, ValueT&) → bool.  Concrete readers inherit this and only
+// implement doExtract (+ optionally readAll for the bulk columnar fast path).
+template<typename ValueT>
+class TypedFieldReader : public FieldReader
+{
+public:
+    using FieldReader::FieldReader;  // inherit constructors
+
+protected:
+    // Single extraction point: returns true if value is non-null, writes into out.
+    virtual bool doExtract( int64_t row, ValueT & out ) = 0;
+
+    void doReadNext( int64_t row, Struct * s ) override
+    {
+        ValueT tmp{};
+        if( doExtract( row, tmp ) )
+            m_field -> template setValue<ValueT>( s, std::move( tmp ) );
+    }
+
+    void doReadNextValue( int64_t row, void * optionalOut ) override
+    {
+        auto & out = *static_cast<std::optional<ValueT> *>( optionalOut );
+        ValueT tmp{};
+        if( doExtract( row, tmp ) )
+            out = std::move( tmp );
+        else
+            out.reset();
+    }
+};
+
+// Factory: create a FieldReader for a given Arrow field + CSP struct field.
+// Handles scalar types natively; list types require a registered factory (see below).
+// Optional structMeta: for STRUCT columns when structField is nullptr (ColumnDispatcher path).
+std::unique_ptr<FieldReader> createFieldReader(
+    const std::shared_ptr<::arrow::Field> & arrowField,
+    const StructFieldPtr & structField,
+    const std::shared_ptr<const StructMeta> & structMeta = nullptr
+);
+
+// Factory type for creating FieldReaders for list/array columns.
+// Registered by the Python-aware layer which provides numpy-backed readers.
+using ListFieldReaderFactory = std::function<
+    std::unique_ptr<FieldReader>( const std::shared_ptr<::arrow::Field> &, const StructFieldPtr & )>;
+
+// Register a factory for creating list field readers.
+void registerListFieldReaderFactory( ListFieldReaderFactory factory );
+
+}
+
+#endif

--- a/cpp/csp/adapters/arrow/ArrowFieldWriter.cpp
+++ b/cpp/csp/adapters/arrow/ArrowFieldWriter.cpp
@@ -1,0 +1,392 @@
+// Concrete FieldWriter implementations for all CSP scalar types.
+//
+// Fixed-length writers use UnsafeWriter<BuilderT> — a single template
+// that takes a value-extraction callable at construction (mirrors LambdaReader).
+// Variable-length writers (StringLike, Enum) and NestedStruct are separate
+// classes because they need safe Append (variable-length) or recursive logic.
+
+#include <csp/adapters/arrow/ArrowFieldWriter.h>
+#include <csp/engine/CspType.h>
+#include <csp/engine/CspEnum.h>
+
+#include <arrow/builder.h>
+#include <arrow/type.h>
+
+namespace csp::adapters::arrow
+{
+
+#define ARROW_OK_OR_THROW( expr, msg ) \
+    do { auto _st = ( expr ); if( !_st.ok() ) CSP_THROW( RuntimeException, msg << ": " << _st.ToString() ); } while(0)
+
+// --- Base class default implementations ---
+
+void FieldWriter::reserve( int64_t numRows )
+{
+    ARROW_OK_OR_THROW( m_builder -> Reserve( numRows ), "Failed to reserve builder capacity" );
+}
+
+void FieldWriter::writeNext( const Struct * s )
+{
+    if( m_field -> isSet( s ) )
+        doWrite( s );
+    else
+        writeNull();
+}
+
+void FieldWriter::writeAll( const std::vector<StructPtr> & structs, int64_t offset, int64_t count )
+{
+    for( int64_t i = offset; i < offset + count; ++i )
+        writeNext( structs[i].get() );
+}
+
+void FieldWriter::writeNull()
+{
+    ARROW_OK_OR_THROW( m_builder -> AppendNull(), "Failed to append null" );
+}
+
+std::vector<std::shared_ptr<::arrow::Array>> FieldWriter::finish()
+{
+    std::shared_ptr<::arrow::Array> arr;
+    ARROW_OK_OR_THROW( m_builder -> Finish( &arr ), "Failed to finish array" );
+    return { arr };
+}
+
+namespace
+{
+
+// --- Generic lambda-based writer for fixed-length types ---
+// ValueFn signature: auto(const Struct *) — returns the value to UnsafeAppend/Append.
+// Covers: all numeric primitives, bool, DateTime, TimeDelta, Time, Date.
+
+template<typename ArrowBuilderT, typename ValueFn>
+class UnsafeWriter final : public FieldWriter
+{
+public:
+    UnsafeWriter( const std::string & columnName, const StructFieldPtr & field,
+                  std::shared_ptr<ArrowBuilderT> typedBuilder,
+                  std::shared_ptr<::arrow::DataType> dataType, ValueFn fn )
+        : FieldWriter( columnName, field, typedBuilder, std::move( dataType ) ),
+          m_typedBuilder( typedBuilder.get() ), m_fn( std::move( fn ) ) {}
+
+    void writeAll( const std::vector<StructPtr> & structs, int64_t offset, int64_t count ) override
+    {
+        for( int64_t i = offset; i < offset + count; ++i )
+        {
+            const Struct * s = structs[i].get();
+            if( m_field -> isSet( s ) )
+                m_typedBuilder -> UnsafeAppend( m_fn( s ) );
+            else
+                m_typedBuilder -> UnsafeAppendNull();
+        }
+    }
+
+protected:
+    void doWrite( const Struct * s ) override
+    {
+        ARROW_OK_OR_THROW( m_typedBuilder -> Append( m_fn( s ) ), "Failed to append value" );
+    }
+
+private:
+    ArrowBuilderT * m_typedBuilder;
+    ValueFn         m_fn;
+};
+
+// Factory: creates an UnsafeWriter, deducing ValueFn type, and returns CreatedFieldWriter
+template<typename ArrowBuilderT, typename ValueFn>
+CreatedFieldWriter makeUnsafeWriter( const std::string & name, const StructFieldPtr & field,
+                                     std::shared_ptr<ArrowBuilderT> builder,
+                                     std::shared_ptr<::arrow::DataType> dataType, ValueFn && fn )
+{
+    auto w = std::make_unique<UnsafeWriter<ArrowBuilderT, std::decay_t<ValueFn>>>(
+        name, field, builder, std::move( dataType ), std::forward<ValueFn>( fn ) );
+    return { std::move( w ), std::move( builder ) };
+}
+
+// Factory: primitive numeric writer (auto-creates builder from default constructor)
+template<typename CspT, typename ArrowBuilderT>
+CreatedFieldWriter makePrimitiveWriter( const std::string & name, const StructFieldPtr & f )
+{
+    auto b = std::make_shared<ArrowBuilderT>();
+    return makeUnsafeWriter( name, f, b, b -> type(), [f]( const Struct * s ) {
+        return static_cast<typename ArrowBuilderT::value_type>( f -> value<CspT>( s ) );
+    } );
+}
+
+// Factory: nanosecond-based temporal writer (DateTime, TimeDelta, Time)
+template<typename CspT, typename ArrowBuilderT>
+CreatedFieldWriter makeNanosWriter( const std::string & name, const StructFieldPtr & f,
+                                    std::shared_ptr<::arrow::DataType> dataType )
+{
+    auto b = std::make_shared<ArrowBuilderT>( dataType, ::arrow::default_memory_pool() );
+    return makeUnsafeWriter( name, f, b, std::move( dataType ), [f]( const Struct * s ) {
+        return f -> value<CspT>( s ).asNanoseconds();
+    } );
+}
+
+// --- String / Bytes writer (variable-length: needs safe Append) ---
+
+template<typename ArrowBuilderT>
+class StringLikeWriter final : public FieldWriter
+{
+public:
+    StringLikeWriter( const std::string & columnName, const StructFieldPtr & field,
+                      std::shared_ptr<::arrow::DataType> dataType )
+        : FieldWriter( columnName, field, std::make_shared<ArrowBuilderT>(), std::move( dataType ) ),
+          m_typedBuilder( static_cast<ArrowBuilderT *>( m_builder.get() ) ) {}
+
+    void writeAll( const std::vector<StructPtr> & structs, int64_t offset, int64_t count ) override
+    {
+        for( int64_t i = offset; i < offset + count; ++i )
+        {
+            const Struct * s = structs[i].get();
+            if( m_field -> isSet( s ) )
+            {
+                auto & val = m_field -> value<std::string>( s );
+                ARROW_OK_OR_THROW( m_typedBuilder -> Append( val.c_str(), val.length() ), "Failed to append string/bytes" );
+            }
+            else
+                ARROW_OK_OR_THROW( m_typedBuilder -> AppendNull(), "Failed to append null" );
+        }
+    }
+
+protected:
+    void doWrite( const Struct * s ) override
+    {
+        auto & val = m_field -> value<std::string>( s );
+        ARROW_OK_OR_THROW( m_typedBuilder -> Append( val.c_str(), val.length() ), "Failed to append string/bytes" );
+    }
+
+private:
+    ArrowBuilderT * m_typedBuilder;
+};
+
+// --- Enum writer (variable-length string: CspEnum → name()) ---
+
+class EnumWriter final : public FieldWriter
+{
+public:
+    EnumWriter( const std::string & columnName, const StructFieldPtr & field )
+        : FieldWriter( columnName, field, std::make_shared<::arrow::StringBuilder>(), ::arrow::utf8() ),
+          m_typedBuilder( static_cast<::arrow::StringBuilder *>( m_builder.get() ) ) {}
+
+    void writeAll( const std::vector<StructPtr> & structs, int64_t offset, int64_t count ) override
+    {
+        for( int64_t i = offset; i < offset + count; ++i )
+        {
+            const Struct * s = structs[i].get();
+            if( m_field -> isSet( s ) )
+            {
+                auto & n = m_field -> value<CspEnum>( s ).name();
+                ARROW_OK_OR_THROW( m_typedBuilder -> Append( n.c_str(), n.length() ), "Failed to append enum" );
+            }
+            else
+                ARROW_OK_OR_THROW( m_typedBuilder -> AppendNull(), "Failed to append null" );
+        }
+    }
+
+protected:
+    void doWrite( const Struct * s ) override
+    {
+        auto & n = m_field -> value<CspEnum>( s ).name();
+        ARROW_OK_OR_THROW( m_typedBuilder -> Append( n.c_str(), n.length() ), "Failed to append enum" );
+    }
+
+private:
+    ::arrow::StringBuilder * m_typedBuilder;
+};
+
+// --- Nested struct writer (recursive) ---
+
+class NestedStructWriter final : public FieldWriter
+{
+public:
+    NestedStructWriter( const std::string & columnName, const StructFieldPtr & field,
+                        std::shared_ptr<::arrow::StructBuilder> structBuilder,
+                        std::shared_ptr<::arrow::DataType> structType,
+                        std::vector<std::unique_ptr<FieldWriter>> childWriters )
+        : FieldWriter( columnName, field, structBuilder, std::move( structType ) ),
+          m_structBuilder( structBuilder.get() ),
+          m_childWriters( std::move( childWriters ) ) {}
+
+    void reserve( int64_t numRows ) override
+    {
+        ARROW_OK_OR_THROW( m_builder -> Reserve( numRows ), "Failed to reserve builder capacity" );
+        for( auto & cw : m_childWriters )
+            cw -> reserve( numRows );
+    }
+
+    void writeNull() override
+    {
+        for( auto & cw : m_childWriters )
+            cw -> writeNull();
+        // Append(false) sets the struct validity bit without touching children
+        // (unlike AppendNull which also calls AppendEmptyValue on each child).
+        ARROW_OK_OR_THROW( m_structBuilder -> Append( false ), "Failed to append null struct" );
+    }
+
+    void writeAll( const std::vector<StructPtr> & structs, int64_t offset, int64_t count ) override
+    {
+        // Check if any parent struct has a null nested value
+        bool hasNulls = false;
+        for( int64_t i = offset; i < offset + count && !hasNulls; ++i )
+            hasNulls = !m_field -> isSet( structs[i].get() );
+
+        if( !hasNulls )
+        {
+            // Fast path: all nested values are set — columnar child writes
+            std::vector<StructPtr> nested( count );
+            for( int64_t i = 0; i < count; ++i )
+                nested[i] = m_field -> value<StructPtr>( structs[offset + i].get() );
+            for( auto & cw : m_childWriters )
+                cw -> writeAll( nested, 0, count );
+            ARROW_OK_OR_THROW( m_structBuilder -> AppendValues( count, nullptr ), "Failed to append struct validity" );
+        }
+        else
+        {
+            for( int64_t i = offset; i < offset + count; ++i )
+                writeNext( structs[i].get() );
+        }
+    }
+
+protected:
+    void doWrite( const Struct * s ) override
+    {
+        auto & nested = m_field -> value<StructPtr>( s );
+        for( auto & cw : m_childWriters )
+            cw -> writeNext( nested.get() );
+        ARROW_OK_OR_THROW( m_structBuilder -> Append(), "Failed to append struct" );
+    }
+
+private:
+    ::arrow::StructBuilder *                  m_structBuilder;
+    std::vector<std::unique_ptr<FieldWriter>> m_childWriters;
+};
+
+// --- Factory helpers ---
+
+bool isBytesField( const StructFieldPtr & field )
+{
+    if( field -> type() -> type() != CspType::Type::STRING )
+        return false;
+    auto strType = std::static_pointer_cast<const CspStringType>( field -> type() );
+    return strType && strType -> isBytes();
+}
+
+template<typename WriterT, typename... Args>
+CreatedFieldWriter makeWriter( Args &&... args )
+{
+    auto w = std::make_unique<WriterT>( std::forward<Args>( args )... );
+    auto b = w -> builder();
+    return { std::move( w ), std::move( b ) };
+}
+
+} // anonymous namespace
+
+CreatedFieldWriter createFieldWriter(
+    const std::string & columnName,
+    const StructFieldPtr & structField )
+{
+    auto & f = structField;
+
+    switch( f -> type() -> type() )
+    {
+        // --- Numeric ---
+        case CspType::Type::BOOL:
+        {
+            auto b = std::make_shared<::arrow::BooleanBuilder>();
+            return makeUnsafeWriter( columnName, f, b, ::arrow::boolean(),
+                [f]( const Struct * s ) { return f -> value<bool>( s ); } );
+        }
+        case CspType::Type::INT8:   return makePrimitiveWriter<int8_t,   ::arrow::Int8Builder>( columnName, f );
+        case CspType::Type::INT16:  return makePrimitiveWriter<int16_t,  ::arrow::Int16Builder>( columnName, f );
+        case CspType::Type::INT32:  return makePrimitiveWriter<int32_t,  ::arrow::Int32Builder>( columnName, f );
+        case CspType::Type::INT64:  return makePrimitiveWriter<int64_t,  ::arrow::Int64Builder>( columnName, f );
+        case CspType::Type::UINT8:  return makePrimitiveWriter<uint8_t,  ::arrow::UInt8Builder>( columnName, f );
+        case CspType::Type::UINT16: return makePrimitiveWriter<uint16_t, ::arrow::UInt16Builder>( columnName, f );
+        case CspType::Type::UINT32: return makePrimitiveWriter<uint32_t, ::arrow::UInt32Builder>( columnName, f );
+        case CspType::Type::UINT64: return makePrimitiveWriter<uint64_t, ::arrow::UInt64Builder>( columnName, f );
+        case CspType::Type::DOUBLE: return makePrimitiveWriter<double,   ::arrow::DoubleBuilder>( columnName, f );
+
+        // --- String / Bytes ---
+        case CspType::Type::STRING:
+            if( isBytesField( f ) )
+                return makeWriter<StringLikeWriter<::arrow::BinaryBuilder>>( columnName, f, ::arrow::binary() );
+            return makeWriter<StringLikeWriter<::arrow::StringBuilder>>( columnName, f, ::arrow::utf8() );
+
+        case CspType::Type::ENUM: return makeWriter<EnumWriter>( columnName, f );
+
+        // --- Temporal ---
+        case CspType::Type::DATETIME:
+            return makeNanosWriter<DateTime, ::arrow::TimestampBuilder>(
+                columnName, f, std::make_shared<::arrow::TimestampType>( ::arrow::TimeUnit::NANO, "UTC" ) );
+        case CspType::Type::TIMEDELTA:
+            return makeNanosWriter<TimeDelta, ::arrow::DurationBuilder>(
+                columnName, f, std::make_shared<::arrow::DurationType>( ::arrow::TimeUnit::NANO ) );
+        case CspType::Type::TIME:
+            return makeNanosWriter<Time, ::arrow::Time64Builder>(
+                columnName, f, std::make_shared<::arrow::Time64Type>( ::arrow::TimeUnit::NANO ) );
+
+        // --- Date (days since epoch) ---
+        case CspType::Type::DATE:
+        {
+            auto b = std::make_shared<::arrow::Date32Builder>();
+            return makeUnsafeWriter( columnName, f, b, ::arrow::date32(), [f]( const Struct * s ) {
+                auto & d = f -> value<Date>( s );
+                return static_cast<int32_t>( DateTime( d.year(), d.month(), d.day() ).asNanoseconds() / csp::NANOS_PER_DAY );
+            } );
+        }
+
+        // --- Nested struct ---
+        case CspType::Type::STRUCT:
+        {
+            auto nestedMeta = std::static_pointer_cast<const CspStructType>( f -> type() ) -> meta();
+
+            std::vector<std::shared_ptr<::arrow::Field>> arrowFields;
+            std::vector<std::shared_ptr<::arrow::ArrayBuilder>> childBuilders;
+            std::vector<std::unique_ptr<FieldWriter>> childWriters;
+
+            // Use fieldNames() for stable insertion order (fields() is sorted for memory layout)
+            for( auto & subFieldName : nestedMeta -> fieldNames() )
+            {
+                auto subField = nestedMeta -> field( subFieldName );
+                auto child = createFieldWriter( subFieldName, subField );
+                arrowFields.push_back( std::make_shared<::arrow::Field>( subFieldName, child.writer -> dataTypes()[0] ) );
+                childBuilders.push_back( std::move( child.builder ) );
+                childWriters.push_back( std::move( child.writer ) );
+            }
+
+            auto structType = std::make_shared<::arrow::StructType>( arrowFields );
+            auto structBuilder = std::make_shared<::arrow::StructBuilder>(
+                structType, ::arrow::default_memory_pool(), childBuilders );
+
+            auto w = std::make_unique<NestedStructWriter>(
+                columnName, f, structBuilder,
+                std::static_pointer_cast<::arrow::DataType>( structType ), std::move( childWriters ) );
+            return { std::move( w ), std::move( structBuilder ) };
+        }
+
+        default:
+            CSP_THROW( TypeError, "Unsupported CSP type " << f -> type() -> type()
+                                   << " for field '" << columnName << "'" );
+    }
+}
+
+#undef ARROW_OK_OR_THROW
+
+// --- List field writer factory ---
+
+static ListFieldWriterFactory s_listFieldWriterFactory;
+
+void registerListFieldWriterFactory( ListFieldWriterFactory factory )
+{
+    s_listFieldWriterFactory = std::move( factory );
+}
+
+std::pair<std::shared_ptr<::arrow::ArrayBuilder>, ListItemsWriter> createListFieldWriter( const CspTypePtr & elemType )
+{
+    CSP_TRUE_OR_THROW_RUNTIME( s_listFieldWriterFactory,
+        "No list field writer factory registered (numpy support not loaded?)" );
+    return s_listFieldWriterFactory( elemType );
+}
+
+}

--- a/cpp/csp/adapters/arrow/ArrowFieldWriter.h
+++ b/cpp/csp/adapters/arrow/ArrowFieldWriter.h
@@ -1,0 +1,125 @@
+// Per-column writers that serialize CSP struct field values into Arrow array builders.
+//
+// FieldWriter is the base class.  Every writer targets exactly one struct field.
+// Scalar writers use the single-column constructor with a builder; multi-column
+// writers (e.g. NDArray with data + dims) use the multi-column constructor.
+// The non-virtual writeNext() checks isSet and delegates to the virtual doWrite().
+
+#ifndef _IN_CSP_ADAPTERS_ARROW_ArrowFieldWriter_H
+#define _IN_CSP_ADAPTERS_ARROW_ArrowFieldWriter_H
+
+#include <csp/engine/Struct.h>
+#include <csp/engine/CspType.h>
+#include <arrow/builder.h>
+#include <arrow/type.h>
+#include <functional>
+#include <memory>
+#include <string>
+#include <utility>
+#include <vector>
+
+namespace csp::adapters::arrow
+{
+
+class FieldWriter
+{
+public:
+    virtual ~FieldWriter() = default;
+
+    // Pre-allocate builder capacity for numRows.
+    // Default reserves on m_builder; override for multi-builder writers.
+    virtual void reserve( int64_t numRows );
+
+    // Write one struct's field value into the builder.
+    // Non-virtual: checks isSet, delegates to doWrite() or appendNull().
+    void writeNext( const Struct * s );
+
+    // Columnar bulk-write: write a range of structs into the builder.
+    // Default loops over writeNext(); concrete writers override with tight loops.
+    virtual void writeAll( const std::vector<StructPtr> & structs, int64_t offset, int64_t count );
+
+    // Write a null value (used by nested struct writer when parent is null).
+    // Default appends null to m_builder; NestedStructWriter overrides.
+    virtual void writeNull();
+
+    // Finalize and return the built arrays.
+    // Default finishes m_builder and returns a single array.
+    virtual std::vector<std::shared_ptr<::arrow::Array>> finish();
+
+    // Column names produced by this writer.
+    const std::vector<std::string> & columnNames() const { return m_columnNames; }
+
+    // Arrow data types per column.
+    const std::vector<std::shared_ptr<::arrow::DataType>> & dataTypes() const { return m_dataTypes; }
+
+    // Access the primary builder (needed by NestedStructWriter for StructBuilder construction).
+    const std::shared_ptr<::arrow::ArrayBuilder> & builder() const { return m_builder; }
+
+    // Constructor for scalar writers (single column, single struct field, one builder)
+    FieldWriter( const std::string & columnName,
+                 const StructFieldPtr & field,
+                 std::shared_ptr<::arrow::ArrayBuilder> builder,
+                 std::shared_ptr<::arrow::DataType> dataType )
+        : m_field( field ),
+          m_builder( std::move( builder ) ),
+          m_columnNames( { columnName } ),
+          m_dataTypes( { std::move( dataType ) } )
+    {
+    }
+
+    // Constructor for multi-column writers (e.g. NDArray with data + dims columns)
+    FieldWriter( std::vector<std::string> columnNames,
+                 std::vector<std::shared_ptr<::arrow::DataType>> dataTypes,
+                 const StructFieldPtr & field )
+        : m_field( field ),
+          m_columnNames( std::move( columnNames ) ),
+          m_dataTypes( std::move( dataTypes ) )
+    {
+    }
+
+protected:
+    // Write the field value when it is set. Concrete scalar writers implement this.
+    virtual void doWrite( const Struct * s ) = 0;
+
+    StructFieldPtr                                      m_field;
+    std::shared_ptr<::arrow::ArrayBuilder>              m_builder;
+    std::vector<std::string>                            m_columnNames;
+    std::vector<std::shared_ptr<::arrow::DataType>>     m_dataTypes;
+};
+
+// Return type for createFieldWriter: the writer plus its primary builder
+// (the builder is needed by nested struct writer to construct StructBuilder with child builders)
+struct CreatedFieldWriter
+{
+    std::unique_ptr<FieldWriter>               writer;
+    std::shared_ptr<::arrow::ArrayBuilder>     builder;
+};
+
+// Factory: given column name + struct field, produce a FieldWriter with its builder
+CreatedFieldWriter createFieldWriter(
+    const std::string & columnName,
+    const StructFieldPtr & structField
+);
+
+// --- List field writer factory (dependency injection for numpy list support) ---
+
+// A function that writes a DialectGenericType (e.g. numpy array) into an arrow list builder.
+// The function handles list-start, element conversion, etc.
+using ListItemsWriter = std::function<void( const DialectGenericType & )>;
+
+// Factory type: given an element CspType, produce an arrow value builder and a ListItemsWriter
+// that can write DialectGenericType values into that builder (wrapped in a ListBuilder).
+// Registered by the Python-aware layer which provides numpy-backed implementations.
+using ListFieldWriterFactory = std::function<
+    std::pair<std::shared_ptr<::arrow::ArrayBuilder>, ListItemsWriter>( const CspTypePtr & elemType )>;
+
+// Register a factory for creating list field writers.
+void registerListFieldWriterFactory( ListFieldWriterFactory factory );
+
+// Create a list field writer using the registered factory.
+// Returns (value_builder, write_items_function).  Throws if no factory registered.
+std::pair<std::shared_ptr<::arrow::ArrayBuilder>, ListItemsWriter> createListFieldWriter( const CspTypePtr & elemType );
+
+}
+
+#endif

--- a/cpp/csp/adapters/arrow/ArrowTypeVisitor.h
+++ b/cpp/csp/adapters/arrow/ArrowTypeVisitor.h
@@ -1,0 +1,90 @@
+// Arrow type visitor: maps arrow::Type::type to the corresponding C++ value type.
+// Eliminates repeated switch statements on arrow types across the codebase.
+//
+// Usage:
+//   visitArrowValueType( typeId,
+//       [&]( auto tag ) -> ReturnType {
+//           using T = typename decltype( tag )::type;
+//           return doSomething<T>( ... );
+//       },
+//       [&]() -> ReturnType { /* unsupported type fallback */ } );
+
+#ifndef _IN_CSP_ADAPTERS_ARROW_ArrowTypeVisitor_H
+#define _IN_CSP_ADAPTERS_ARROW_ArrowTypeVisitor_H
+
+#include <csp/core/Exception.h>
+#include <csp/core/Time.h>
+#include <csp/engine/DialectGenericType.h>
+#include <csp/engine/Struct.h>
+#include <arrow/type.h>
+
+namespace csp::adapters::arrow
+{
+
+template<typename T>
+struct TypeTag { using type = T; };
+
+// Invokes fn( TypeTag<CppType>{} ) for the C++ value type corresponding to
+// the given arrow type.  Calls onDefault() for unrecognised arrow types.
+template<typename Fn, typename DefaultFn>
+decltype(auto) visitArrowValueType( ::arrow::Type::type typeId, Fn && fn, DefaultFn && onDefault )
+{
+    switch( typeId )
+    {
+        // --- Numeric ---
+        case ::arrow::Type::BOOL:   return fn( TypeTag<bool>{} );
+        case ::arrow::Type::INT8:   return fn( TypeTag<int8_t>{} );
+        case ::arrow::Type::INT16:  return fn( TypeTag<int16_t>{} );
+        case ::arrow::Type::INT32:  return fn( TypeTag<int32_t>{} );
+        case ::arrow::Type::INT64:  return fn( TypeTag<int64_t>{} );
+        case ::arrow::Type::UINT8:  return fn( TypeTag<uint8_t>{} );
+        case ::arrow::Type::UINT16: return fn( TypeTag<uint16_t>{} );
+        case ::arrow::Type::UINT32: return fn( TypeTag<uint32_t>{} );
+        case ::arrow::Type::UINT64: return fn( TypeTag<uint64_t>{} );
+        case ::arrow::Type::HALF_FLOAT:
+        case ::arrow::Type::FLOAT:
+        case ::arrow::Type::DOUBLE: return fn( TypeTag<double>{} );
+
+        // --- String / Binary ---
+        case ::arrow::Type::STRING:
+        case ::arrow::Type::LARGE_STRING:
+        case ::arrow::Type::BINARY:
+        case ::arrow::Type::LARGE_BINARY:
+        case ::arrow::Type::FIXED_SIZE_BINARY:
+        case ::arrow::Type::DICTIONARY:
+            return fn( TypeTag<std::string>{} );
+
+        // --- Temporal ---
+        case ::arrow::Type::TIMESTAMP: return fn( TypeTag<DateTime>{} );
+        case ::arrow::Type::DURATION:  return fn( TypeTag<TimeDelta>{} );
+        case ::arrow::Type::DATE32:
+        case ::arrow::Type::DATE64:    return fn( TypeTag<Date>{} );
+        case ::arrow::Type::TIME32:
+        case ::arrow::Type::TIME64:    return fn( TypeTag<Time>{} );
+
+        // --- List / Struct ---
+        case ::arrow::Type::LIST:
+        case ::arrow::Type::LARGE_LIST:
+            return fn( TypeTag<DialectGenericType>{} );
+        case ::arrow::Type::STRUCT:
+            return fn( TypeTag<StructPtr>{} );
+
+        default:
+            return onDefault();
+    }
+}
+
+// Overload that throws TypeError for unrecognised arrow types.
+template<typename Fn>
+decltype(auto) visitArrowValueType( ::arrow::Type::type typeId, Fn && fn )
+{
+    return visitArrowValueType( typeId, std::forward<Fn>( fn ),
+        [typeId]() -> decltype( fn( TypeTag<bool>{} ) )
+        {
+            CSP_THROW( TypeError, "Unsupported arrow type id " << static_cast<int>( typeId ) );
+        } );
+}
+
+} // namespace csp::adapters::arrow
+
+#endif

--- a/cpp/csp/adapters/arrow/CMakeLists.txt
+++ b/cpp/csp/adapters/arrow/CMakeLists.txt
@@ -2,11 +2,15 @@ set(ARROW_ADAPTER_HEADER_FILES
         ArrowFieldReader.h
         ArrowFieldWriter.h
         ArrowTypeVisitor.h
+        RecordBatchToStruct.h
+        StructToRecordBatch.h
 )
 
 set(ARROW_ADAPTER_SOURCE_FILES
         ArrowFieldReader.cpp
         ArrowFieldWriter.cpp
+        RecordBatchToStruct.cpp
+        StructToRecordBatch.cpp
         ${ARROW_ADAPTER_HEADER_FILES}
 )
 

--- a/cpp/csp/adapters/arrow/CMakeLists.txt
+++ b/cpp/csp/adapters/arrow/CMakeLists.txt
@@ -1,0 +1,20 @@
+set(ARROW_ADAPTER_HEADER_FILES
+        ArrowFieldReader.h
+        ArrowFieldWriter.h
+        ArrowTypeVisitor.h
+)
+
+set(ARROW_ADAPTER_SOURCE_FILES
+        ArrowFieldReader.cpp
+        ArrowFieldWriter.cpp
+        ${ARROW_ADAPTER_HEADER_FILES}
+)
+
+add_library(csp_arrow_adapter STATIC ${ARROW_ADAPTER_SOURCE_FILES})
+set_target_properties(csp_arrow_adapter PROPERTIES PUBLIC_HEADER "${ARROW_ADAPTER_HEADER_FILES}")
+target_link_libraries(csp_arrow_adapter PRIVATE csp_core csp_types csp_engine ${CSP_ARROW_LINK_LIBS})
+install(TARGETS csp_arrow_adapter
+        PUBLIC_HEADER DESTINATION include/csp/adapters/arrow
+        RUNTIME DESTINATION ${CSP_RUNTIME_INSTALL_SUBDIR}
+        LIBRARY DESTINATION lib/
+       )

--- a/cpp/csp/adapters/arrow/RecordBatchToStruct.cpp
+++ b/cpp/csp/adapters/arrow/RecordBatchToStruct.cpp
@@ -1,0 +1,93 @@
+// Implementation of RecordBatchToStructConverter.
+
+#include <csp/adapters/arrow/RecordBatchToStruct.h>
+#include <csp/engine/CspType.h>
+
+#include <arrow/type.h>
+
+#include <unordered_set>
+
+namespace csp::adapters::arrow
+{
+
+namespace
+{
+
+// Helper to resolve column name -> struct field name mapping
+// If fieldMap is null, column name = field name (identity mapping)
+std::string resolveFieldName( const DictionaryPtr & fieldMap, const std::string & columnName )
+{
+    if( !fieldMap )
+        return columnName;
+
+    std::string fieldName;
+    if( fieldMap -> tryGet<std::string>( columnName, fieldName ) )
+        return fieldName;
+
+    return columnName;
+}
+
+} // anonymous namespace
+
+RecordBatchToStructConverter::RecordBatchToStructConverter(
+    const std::shared_ptr<::arrow::Schema> & schema,
+    const std::shared_ptr<StructMeta> & structMeta,
+    const DictionaryPtr & fieldMap,
+    std::vector<std::unique_ptr<FieldReader>> customReaders )
+    : m_structMeta( structMeta )
+{
+    // Build a set of column names handled by custom readers so we skip them in the scalar loop
+    std::unordered_set<std::string> customColumnNames;
+    for( auto & cr : customReaders )
+        for( auto & name : cr -> columnNames() )
+            customColumnNames.insert( name );
+
+    // Build scalar field readers from schema fields
+    for( int i = 0; i < schema -> num_fields(); ++i )
+    {
+        auto arrowField = schema -> field( i );
+
+        // Skip columns handled by custom readers
+        if( customColumnNames.count( arrowField -> name() ) )
+            continue;
+
+        // Skip columns that don't have a matching struct field
+        std::string fieldName = resolveFieldName( fieldMap, arrowField -> name() );
+        auto structField = structMeta -> field( fieldName );
+        if( !structField )
+            continue;
+
+        m_scalarReaders.push_back( { createFieldReader( arrowField, structField ), i } );
+    }
+
+    // Store custom readers separately
+    m_customReaders = std::move( customReaders );
+}
+
+std::vector<StructPtr> RecordBatchToStructConverter::convert( const ::arrow::RecordBatch & batch )
+{
+    int64_t numRows = batch.num_rows();
+
+    // Phase 1: pre-allocate all structs
+    std::vector<StructPtr> result;
+    result.reserve( numRows );
+    for( int64_t i = 0; i < numRows; ++i )
+        result.push_back( m_structMeta -> create() );
+
+    // Phase 2: columnar read — one readAll() call per column
+    for( auto & entry : m_scalarReaders )
+    {
+        entry.reader -> bindColumn( batch.column( entry.columnIndex ).get() );
+        entry.reader -> readAll( result, numRows );
+    }
+
+    for( auto & reader : m_customReaders )
+    {
+        reader -> bindBatch( batch );
+        reader -> readAll( result, numRows );
+    }
+
+    return result;
+}
+
+}

--- a/cpp/csp/adapters/arrow/RecordBatchToStruct.h
+++ b/cpp/csp/adapters/arrow/RecordBatchToStruct.h
@@ -1,0 +1,52 @@
+// Converts Arrow RecordBatches into csp::Struct instances.
+//
+// RecordBatchToStructConverter maps Arrow columns to CSP struct fields using
+// FieldReader subclasses.  Scalar readers are auto-detected from the schema;
+// additional readers (e.g. numpy array readers) can be injected at construction.
+
+#ifndef _IN_CSP_ADAPTERS_ARROW_RecordBatchToStruct_H
+#define _IN_CSP_ADAPTERS_ARROW_RecordBatchToStruct_H
+
+#include <csp/adapters/arrow/ArrowFieldReader.h>
+#include <csp/engine/Dictionary.h>
+#include <arrow/record_batch.h>
+#include <memory>
+#include <string>
+#include <vector>
+
+namespace csp::adapters::arrow
+{
+
+class RecordBatchToStructConverter
+{
+public:
+    // schema:         Arrow schema describing the RecordBatch columns
+    // structMeta:     CSP StructMeta describing the target struct type
+    // fieldMap:       optional column->field name mapping (null = match by column name)
+    // customReaders:  additional readers for columns that need non-scalar handling (e.g. numpy arrays);
+    //                 columns claimed by these readers are excluded from scalar auto-detection
+    RecordBatchToStructConverter(
+        const std::shared_ptr<::arrow::Schema> & schema,
+        const std::shared_ptr<StructMeta> & structMeta,
+        const DictionaryPtr & fieldMap = nullptr,
+        std::vector<std::unique_ptr<FieldReader>> customReaders = {}
+    );
+
+    // Convert all rows from a RecordBatch into a vector of CSP Structs
+    std::vector<StructPtr> convert( const ::arrow::RecordBatch & batch );
+
+private:
+    struct ScalarReaderEntry
+    {
+        std::unique_ptr<FieldReader> reader;
+        int                          columnIndex;
+    };
+
+    std::shared_ptr<StructMeta>                m_structMeta;
+    std::vector<ScalarReaderEntry>             m_scalarReaders;
+    std::vector<std::unique_ptr<FieldReader>>  m_customReaders;
+};
+
+}
+
+#endif

--- a/cpp/csp/adapters/arrow/StructToRecordBatch.cpp
+++ b/cpp/csp/adapters/arrow/StructToRecordBatch.cpp
@@ -1,0 +1,109 @@
+// Implementation of StructToRecordBatchConverter.
+
+#include <csp/adapters/arrow/StructToRecordBatch.h>
+#include <csp/engine/CspType.h>
+
+#include <arrow/builder.h>
+#include <arrow/type.h>
+
+namespace csp::adapters::arrow
+{
+
+StructToRecordBatchConverter::StructToRecordBatchConverter(
+    const std::shared_ptr<StructMeta> & structMeta,
+    const DictionaryPtr & fieldMap,
+    std::vector<std::unique_ptr<FieldWriter>> customWriters )
+    : m_structMeta( structMeta )
+{
+    std::vector<std::shared_ptr<::arrow::Field>> arrowFields;
+
+    if( fieldMap )
+    {
+        // When fieldMap is provided, only include fields listed in it
+        for( auto it = fieldMap -> begin(); it != fieldMap -> end(); ++it )
+        {
+            auto fieldName = it.key();
+            auto colName   = it.value<std::string>();
+            auto structField = structMeta -> field( fieldName );
+            if( !structField )
+                continue;
+
+            // Skip DIALECT_GENERIC fields (handled by custom writers)
+            if( structField -> type() -> type() == CspType::Type::DIALECT_GENERIC )
+                continue;
+
+            auto created = createFieldWriter( colName, structField );
+            for( auto & dt : created.writer -> dataTypes() )
+                arrowFields.push_back( std::make_shared<::arrow::Field>( colName, dt ) );
+            m_writers.push_back( std::move( created.writer ) );
+        }
+    }
+    else
+    {
+        // No fieldMap: include all non-DIALECT_GENERIC fields using fieldNames() for stable insertion order
+        // (fields() is sorted by type/size for memory layout optimization, not insertion order)
+        for( auto & fieldName : structMeta -> fieldNames() )
+        {
+            auto structField = structMeta -> field( fieldName );
+            if( !structField || structField -> type() -> type() == CspType::Type::DIALECT_GENERIC )
+                continue;
+
+            auto created = createFieldWriter( fieldName, structField );
+            for( auto & dt : created.writer -> dataTypes() )
+                arrowFields.push_back( std::make_shared<::arrow::Field>( fieldName, dt ) );
+            m_writers.push_back( std::move( created.writer ) );
+        }
+    }
+
+    // Append custom writers and their columns to schema
+    for( auto & cw : customWriters )
+    {
+        auto & names = cw -> columnNames();
+        auto & types = cw -> dataTypes();
+        CSP_TRUE_OR_THROW_RUNTIME( names.size() == types.size(),
+                                   "FieldWriter columnNames and dataTypes must have the same size" );
+        for( size_t i = 0; i < names.size(); ++i )
+            arrowFields.push_back( std::make_shared<::arrow::Field>( names[i], types[i] ) );
+        m_writers.push_back( std::move( cw ) );
+    }
+
+    m_schema = std::make_shared<::arrow::Schema>( arrowFields );
+}
+
+std::vector<std::shared_ptr<::arrow::RecordBatch>> StructToRecordBatchConverter::convert(
+    const std::vector<StructPtr> & structs, int64_t maxBatchSize )
+{
+    int64_t totalRows = static_cast<int64_t>( structs.size() );
+    if( maxBatchSize <= 0 )
+        maxBatchSize = totalRows;
+
+    std::vector<std::shared_ptr<::arrow::RecordBatch>> batches;
+
+    for( int64_t offset = 0; offset < totalRows; offset += maxBatchSize )
+    {
+        int64_t chunkRows = std::min( maxBatchSize, totalRows - offset );
+
+        // Columnar write: reserve + writeAll per column keeps builder memory cache-hot
+        for( auto & writer : m_writers )
+        {
+            writer -> reserve( chunkRows );
+            writer -> writeAll( structs, offset, chunkRows );
+        }
+
+        std::vector<std::shared_ptr<::arrow::Array>> arrays;
+        arrays.reserve( m_schema -> num_fields() );
+        for( auto & writer : m_writers )
+        {
+            auto writerArrays = writer -> finish();
+            arrays.insert( arrays.end(),
+                           std::make_move_iterator( writerArrays.begin() ),
+                           std::make_move_iterator( writerArrays.end() ) );
+        }
+
+        batches.push_back( ::arrow::RecordBatch::Make( m_schema, chunkRows, std::move( arrays ) ) );
+    }
+
+    return batches;
+}
+
+}

--- a/cpp/csp/adapters/arrow/StructToRecordBatch.h
+++ b/cpp/csp/adapters/arrow/StructToRecordBatch.h
@@ -1,0 +1,50 @@
+// Converts csp::Struct instances into Arrow RecordBatches.
+//
+// StructToRecordBatchConverter maps CSP struct fields to Arrow columns using
+// FieldWriter subclasses.  Scalar writers are auto-detected from the struct
+// metadata; additional writers (e.g. numpy array writers) can be injected at
+// construction.  Mirrors RecordBatchToStruct in the read direction.
+
+#ifndef _IN_CSP_ADAPTERS_ARROW_StructToRecordBatch_H
+#define _IN_CSP_ADAPTERS_ARROW_StructToRecordBatch_H
+
+#include <csp/adapters/arrow/ArrowFieldWriter.h>
+#include <csp/engine/Dictionary.h>
+#include <arrow/record_batch.h>
+#include <memory>
+#include <string>
+#include <vector>
+
+namespace csp::adapters::arrow
+{
+
+class StructToRecordBatchConverter
+{
+public:
+    // structMeta:     CSP StructMeta describing the source struct type
+    // fieldMap:       optional field->column name mapping (null = match by name, include all non-DIALECT_GENERIC fields)
+    //                 when provided, only scalar fields listed in fieldMap are included
+    // customWriters:  additional writers for fields that need non-scalar handling (e.g. numpy arrays)
+    StructToRecordBatchConverter(
+        const std::shared_ptr<StructMeta> & structMeta,
+        const DictionaryPtr & fieldMap = nullptr,
+        std::vector<std::unique_ptr<FieldWriter>> customWriters = {}
+    );
+
+    // Convert a vector of CSP Structs into one or more RecordBatches.
+    // maxBatchSize controls the maximum number of rows per batch (0 = no limit).
+    std::vector<std::shared_ptr<::arrow::RecordBatch>> convert( const std::vector<StructPtr> & structs,
+                                                                int64_t maxBatchSize = 0 );
+
+    // Get the Arrow schema for the output
+    const std::shared_ptr<::arrow::Schema> & schema() const { return m_schema; }
+
+private:
+    std::shared_ptr<StructMeta>               m_structMeta;
+    std::shared_ptr<::arrow::Schema>          m_schema;
+    std::vector<std::unique_ptr<FieldWriter>> m_writers;
+};
+
+}
+
+#endif

--- a/cpp/csp/python/CMakeLists.txt
+++ b/cpp/csp/python/CMakeLists.txt
@@ -90,7 +90,8 @@ target_compile_definitions(cspimpl PRIVATE CSPIMPL_EXPORTS=1)
 
 ## Baselib c++ module
 add_library(cspbaselibimpl SHARED cspbaselibimpl.cpp)
-target_link_libraries(cspbaselibimpl cspimpl baselibimpl)
+
+target_link_libraries(cspbaselibimpl cspimpl baselibimpl csp_arrow_adapter ${CSP_ARROW_LINK_LIBS})
 
 # Include exprtk include directory for exprtk node
 target_include_directories(cspbaselibimpl PRIVATE ${EXPRTK_INCLUDE_DIRS})

--- a/cpp/csp/python/adapters/ArrowCppNodes.cpp
+++ b/cpp/csp/python/adapters/ArrowCppNodes.cpp
@@ -1,0 +1,205 @@
+// CppNode implementations for record_batches_to_struct and struct_to_record_batches.
+//
+// These nodes bridge the Python/CSP graph layer with the C++ Arrow converters.
+// RecordBatches are transported across the Python/C++ boundary as PyCapsules
+// using the Arrow C Data Interface.
+
+#include <csp/adapters/arrow/RecordBatchToStruct.h>
+#include <csp/adapters/arrow/StructToRecordBatch.h>
+#include <csp/engine/CppNode.h>
+#include <csp/engine/Dictionary.h>
+#include <csp/python/Conversions.h>
+#include <csp/python/Exception.h>
+#include <csp/python/InitHelper.h>
+#include <csp/python/PyCppNode.h>
+#include <csp/python/PyNodeWrapper.h>
+#include <arrow/c/abi.h>
+#include <arrow/c/bridge.h>
+#include <arrow/record_batch.h>
+
+using namespace csp::adapters::arrow;
+
+namespace csp::cppnodes
+{
+
+// PyCapsule destructors for ArrowSchema/ArrowArray (local copies to avoid including ArrowInputAdapter.h)
+static void releaseArrowSchemaCapsule( PyObject * capsule )
+{
+    ArrowSchema * schema = reinterpret_cast<ArrowSchema *>( PyCapsule_GetPointer( capsule, "arrow_schema" ) );
+    if( schema -> release != NULL )
+        schema -> release( schema );
+    free( schema );
+}
+
+static void releaseArrowArrayCapsule( PyObject * capsule )
+{
+    ArrowArray * array = reinterpret_cast<ArrowArray *>( PyCapsule_GetPointer( capsule, "arrow_array" ) );
+    if( array -> release != NULL )
+        array -> release( array );
+    free( array );
+}
+
+DECLARE_CPPNODE( record_batches_to_struct )
+{
+    SCALAR_INPUT( DialectGenericType, schema_ptr );   // PyCapsule of ArrowSchema
+    SCALAR_INPUT( StructMetaPtr,      cls );          // target struct type
+    SCALAR_INPUT( DictionaryPtr,      properties );   // field_map, numpy config
+    TS_INPUT( Generic,                data );          // List[Tuple[capsule, capsule]]
+    TS_OUTPUT( Generic );                             // List[StructPtr]
+
+    STATE_VAR( std::unique_ptr<RecordBatchToStructConverter>, s_converter );
+    STATE_VAR( std::shared_ptr<::arrow::Schema>,              s_schema );
+
+    INIT_CPPNODE( record_batches_to_struct ) {}
+
+    START()
+    {
+        // Import the Arrow schema from PyCapsule
+        PyObject * pySchemaCapsule = csp::python::toPythonBorrowed( schema_ptr.value() );
+        if( !PyCapsule_IsValid( pySchemaCapsule, "arrow_schema" ) )
+            CSP_THROW( csp::TypeError, "schema_ptr must be a PyCapsule with name 'arrow_schema'" );
+
+        ArrowSchema * c_schema = reinterpret_cast<ArrowSchema *>( PyCapsule_GetPointer( pySchemaCapsule, "arrow_schema" ) );
+        auto schemaResult = ::arrow::ImportSchema( c_schema );
+        if( !schemaResult.ok() )
+            CSP_THROW( csp::ValueError, "Failed to import Arrow schema: " << schemaResult.status().ToString() );
+        s_schema = std::move( schemaResult.ValueUnsafe() );
+
+        // Parse properties
+        auto & props = properties.value();
+        DictionaryPtr fieldMap;
+        if( props -> exists( "field_map" ) )
+            fieldMap = props -> get<DictionaryPtr>( "field_map" );
+
+        auto structMeta = cls.value();
+
+        s_converter = std::make_unique<RecordBatchToStructConverter>( s_schema, structMeta, fieldMap );
+    }
+
+    INVOKE()
+    {
+        if( !data.ticked() )
+            return;
+
+        // data is a list of (schema_capsule, array_capsule) tuples
+        PyObject * pyList = csp::python::toPythonBorrowed( data.lastValue<DialectGenericType>() );
+        if( !PyList_Check( pyList ) )
+            CSP_THROW( csp::TypeError, "Expected list of PyCapsule tuples, got " << Py_TYPE( pyList ) -> tp_name );
+
+        Py_ssize_t numBatches = PyList_Size( pyList );
+
+        // First pass: import all record batches and compute total row count for a single reserve()
+        std::vector<std::shared_ptr<::arrow::RecordBatch>> importedBatches;
+        importedBatches.reserve( numBatches );
+        int64_t totalRows = 0;
+
+        for( Py_ssize_t i = 0; i < numBatches; ++i )
+        {
+            PyObject * pyTuple = PyList_GetItem( pyList, i );
+            if( !PyTuple_Check( pyTuple ) || PyTuple_Size( pyTuple ) != 2 )
+                CSP_THROW( csp::TypeError, "Expected tuple of 2 PyCapsules for record batch " << i );
+
+            PyObject * pyArray = PyTuple_GetItem( pyTuple, 1 );
+            if( !PyCapsule_IsValid( pyArray, "arrow_array" ) )
+                CSP_THROW( csp::TypeError, "Invalid PyCapsule for record batch array at index " << i );
+
+            ArrowArray * c_array = reinterpret_cast<ArrowArray *>( PyCapsule_GetPointer( pyArray, "arrow_array" ) );
+            auto rbResult = ::arrow::ImportRecordBatch( c_array, s_schema );
+            if( !rbResult.ok() )
+                CSP_THROW( csp::ValueError, "Failed to import record batch at index " << i << ": " << rbResult.status().ToString() );
+
+            auto rb = std::move( rbResult.ValueUnsafe() );
+            totalRows += rb -> num_rows();
+            importedBatches.push_back( std::move( rb ) );
+        }
+
+        // Second pass: convert all batches into structs with a single pre-allocated vector
+        std::vector<StructPtr> allStructs;
+        allStructs.reserve( totalRows );
+
+        for( auto & rb : importedBatches )
+        {
+            auto structs = s_converter -> convert( *rb );
+            allStructs.insert( allStructs.end(),
+                               std::make_move_iterator( structs.begin() ),
+                               std::make_move_iterator( structs.end() ) );
+        }
+
+        // Output as std::vector<StructPtr> to match the List["T"] output buffer type
+        // where "T" resolves to a csp.Struct -> CspArrayType(STRUCT) -> std::vector<StructPtr>
+        using ArrayT = std::vector<StructPtr>;
+        ArrayT & out = unnamed_output().reserveSpace<ArrayT>();
+        out = std::move( allStructs );
+    }
+};
+
+EXPORT_CPPNODE( record_batches_to_struct );
+
+DECLARE_CPPNODE( struct_to_record_batches )
+{
+    SCALAR_INPUT( StructMetaPtr,  cls );         // source struct type
+    SCALAR_INPUT( DictionaryPtr,  properties );  // field_map, numpy config
+    TS_INPUT( Generic,            data );         // vector<StructPtr>
+    TS_OUTPUT( Generic );                        // DialectGenericType (Python list of capsule tuples)
+
+    STATE_VAR( std::unique_ptr<StructToRecordBatchConverter>, s_converter );
+    STATE_VAR( int64_t, s_maxBatchSize );
+
+    INIT_CPPNODE( struct_to_record_batches ) {}
+
+    START()
+    {
+        auto & props = properties.value();
+        auto structMeta = cls.value();
+
+        s_maxBatchSize = props -> get<int64_t>( "max_batch_size", 0 );
+
+        DictionaryPtr fieldMap;
+        if( props -> exists( "field_map" ) )
+            fieldMap = props -> get<DictionaryPtr>( "field_map" );
+
+        s_converter = std::make_unique<StructToRecordBatchConverter>( structMeta, fieldMap );
+    }
+
+    INVOKE()
+    {
+        if( !data.ticked() )
+            return;
+
+        auto & structs = data.lastValue<std::vector<StructPtr>>();
+        auto batches = s_converter -> convert( structs, s_maxBatchSize );
+
+        auto py_list = csp::python::PyObjectPtr::own( PyList_New( static_cast<Py_ssize_t>( batches.size() ) ) );
+
+        for( size_t idx = 0; idx < batches.size(); ++idx )
+        {
+            ArrowSchema * rb_schema = reinterpret_cast<ArrowSchema *>( malloc( sizeof( ArrowSchema ) ) );
+            ArrowArray * rb_array   = reinterpret_cast<ArrowArray *>( malloc( sizeof( ArrowArray ) ) );
+
+            ::arrow::Status st = ::arrow::ExportRecordBatch( *batches[idx], rb_array, rb_schema );
+            if( !st.ok() )
+            {
+                free( rb_schema );
+                free( rb_array );
+                CSP_THROW( csp::ValueError, "Failed to export RecordBatch at index " << idx << ": " << st.ToString() );
+            }
+
+            auto py_schema = csp::python::PyObjectPtr::own(
+                PyCapsule_New( rb_schema, "arrow_schema", releaseArrowSchemaCapsule ) );
+            auto py_array  = csp::python::PyObjectPtr::own(
+                PyCapsule_New( rb_array, "arrow_array", releaseArrowArrayCapsule ) );
+
+            PyObject * py_tuple = PyTuple_Pack( 2, py_schema.get(), py_array.get() );
+            PyList_SET_ITEM( py_list.get(), static_cast<Py_ssize_t>( idx ), py_tuple );
+        }
+
+        unnamed_output().output( csp::python::fromPython<DialectGenericType>( py_list.get() ) );
+    }
+};
+
+EXPORT_CPPNODE( struct_to_record_batches );
+
+}
+
+REGISTER_CPPNODE( csp::cppnodes, record_batches_to_struct );
+REGISTER_CPPNODE( csp::cppnodes, struct_to_record_batches );

--- a/cpp/csp/python/adapters/ArrowCppNodes.cpp
+++ b/cpp/csp/python/adapters/ArrowCppNodes.cpp
@@ -72,15 +72,11 @@ DECLARE_CPPNODE( record_batches_to_struct )
             fieldMap = props -> get<DictionaryPtr>( "field_map" );
 
         auto structMeta = cls.value();
-
         s_converter = std::make_unique<RecordBatchToStructConverter>( s_schema, structMeta, fieldMap );
     }
 
     INVOKE()
     {
-        if( !data.ticked() )
-            return;
-
         // data is a list of (schema_capsule, array_capsule) tuples
         PyObject * pyList = csp::python::toPythonBorrowed( data.lastValue<DialectGenericType>() );
         if( !PyList_Check( pyList ) )
@@ -95,7 +91,7 @@ DECLARE_CPPNODE( record_batches_to_struct )
 
         for( Py_ssize_t i = 0; i < numBatches; ++i )
         {
-            PyObject * pyTuple = PyList_GetItem( pyList, i );
+            PyObject * pyTuple = PyList_GET_ITEM( pyList, i );
             if( !PyTuple_Check( pyTuple ) || PyTuple_Size( pyTuple ) != 2 )
                 CSP_THROW( csp::TypeError, "Expected tuple of 2 PyCapsules for record batch " << i );
 
@@ -137,9 +133,9 @@ EXPORT_CPPNODE( record_batches_to_struct );
 
 DECLARE_CPPNODE( struct_to_record_batches )
 {
-    SCALAR_INPUT( StructMetaPtr,  cls );         // source struct type
-    SCALAR_INPUT( DictionaryPtr,  properties );  // field_map, numpy config
-    TS_INPUT( Generic,            data );         // vector<StructPtr>
+    SCALAR_INPUT( StructMetaPtr,      cls );         // source struct type
+    SCALAR_INPUT( DictionaryPtr,      properties );  // field_map, numpy config
+    TS_INPUT( std::vector<StructPtr>, data );
     TS_OUTPUT( Generic );                        // DialectGenericType (Python list of capsule tuples)
 
     STATE_VAR( std::unique_ptr<StructToRecordBatchConverter>, s_converter );
@@ -163,10 +159,7 @@ DECLARE_CPPNODE( struct_to_record_batches )
 
     INVOKE()
     {
-        if( !data.ticked() )
-            return;
-
-        auto & structs = data.lastValue<std::vector<StructPtr>>();
+        auto & structs = data.lastValue();
         auto batches = s_converter -> convert( structs, s_maxBatchSize );
 
         auto py_list = csp::python::PyObjectPtr::own( PyList_New( static_cast<Py_ssize_t>( batches.size() ) ) );

--- a/cpp/csp/python/adapters/CMakeLists.txt
+++ b/cpp/csp/python/adapters/CMakeLists.txt
@@ -1,29 +1,6 @@
 if(CSP_BUILD_ARROW_ADAPTER)
-    add_library(arrowadapterimpl SHARED PyArrowInputAdapter.cpp ArrowInputAdapter.h)
-
-    if(WIN32)
-        if(CSP_USE_VCPKG)
-            set(ARROW_PACKAGES_TO_LINK Arrow::arrow_static)
-            target_compile_definitions(arrowadapterimpl PUBLIC ARROW_STATIC)
-        else()
-            # use dynamic variants
-            # Until we manage to get the fix for ws3_32.dll in arrow-16 into conda, manually fix the error here
-            get_target_property(LINK_LIBS Arrow::arrow_shared INTERFACE_LINK_LIBRARIES)
-            string(REPLACE "ws2_32.dll" "ws2_32" FIXED_LINK_LIBS "${LINK_LIBS}")
-            set_target_properties(Arrow::arrow_shared PROPERTIES INTERFACE_LINK_LIBRARIES "${FIXED_LINK_LIBS}")
-            set(ARROW_PACKAGES_TO_LINK arrow_shared)
-        endif()
-    else()
-        if(CSP_USE_VCPKG)
-            # use static variants
-            set(ARROW_PACKAGES_TO_LINK arrow_static)
-        else()
-            # use dynamic variants
-            set(ARROW_PACKAGES_TO_LINK arrow)
-        endif()
-    endif()
-
-    target_link_libraries(arrowadapterimpl csp_core csp_engine cspimpl ${ARROW_PACKAGES_TO_LINK})
+    add_library(arrowadapterimpl SHARED PyArrowInputAdapter.cpp ArrowCppNodes.cpp ArrowInputAdapter.h)
+    target_link_libraries(arrowadapterimpl csp_core csp_engine cspimpl csp_arrow_adapter ${CSP_ARROW_LINK_LIBS})
     target_include_directories(arrowadapterimpl PUBLIC ${ARROW_INCLUDE_DIR})
     install(TARGETS arrowadapterimpl RUNTIME DESTINATION ${CSP_RUNTIME_INSTALL_SUBDIR} )
 endif()

--- a/csp/adapters/arrow.py
+++ b/csp/adapters/arrow.py
@@ -7,7 +7,6 @@ from packaging.version import parse
 import csp
 from csp.impl.types.tstype import ts
 from csp.impl.wiring import input_adapter_def
-from csp.impl.wiring.node import _node_internal_use
 from csp.lib import _arrowadapterimpl
 
 __all__ = [
@@ -153,7 +152,7 @@ def write_record_batches(
                 s_prev_batch_size += len(batch)
 
 
-@_node_internal_use(cppimpl=_arrowadapterimpl.record_batches_to_struct)
+@csp.node(cppimpl=_arrowadapterimpl.record_batches_to_struct)
 def _record_batches_to_struct(
     schema_ptr: object,
     cls: "T",
@@ -202,7 +201,7 @@ def record_batches_to_struct(
     return _record_batches_to_struct(schema_capsule, cls, properties, c_data)
 
 
-@_node_internal_use(cppimpl=_arrowadapterimpl.struct_to_record_batches)
+@csp.node(cppimpl=_arrowadapterimpl.struct_to_record_batches)
 def _struct_to_record_batches(
     cls: "T",
     properties: dict,

--- a/csp/adapters/arrow.py
+++ b/csp/adapters/arrow.py
@@ -1,4 +1,4 @@
-from typing import Iterable, List, Optional, Tuple
+from typing import Dict, Iterable, List, Optional, Tuple, TypeVar
 
 import pyarrow as pa
 import pyarrow.parquet as pq
@@ -7,15 +7,20 @@ from packaging.version import parse
 import csp
 from csp.impl.types.tstype import ts
 from csp.impl.wiring import input_adapter_def
+from csp.impl.wiring.node import _node_internal_use
 from csp.lib import _arrowadapterimpl
 
 __all__ = [
     "CRecordBatchPullInputAdapter",
     "RecordBatchPullInputAdapter",
+    "record_batches_to_struct",
+    "struct_to_record_batches",
     "write_record_batches",
 ]
 
 _PYARROW_HAS_CONCAT_BATCHES = parse(pa.__version__) >= parse("19.0.0")
+
+T = TypeVar("T")
 
 
 CRecordBatchPullInputAdapter = input_adapter_def(
@@ -146,3 +151,99 @@ def write_record_batches(
             else:
                 s_prev_batch += [batch]
                 s_prev_batch_size += len(batch)
+
+
+@_node_internal_use(cppimpl=_arrowadapterimpl.record_batches_to_struct)
+def _record_batches_to_struct(
+    schema_ptr: object,
+    cls: "T",
+    properties: dict,
+    data: ts[object],
+) -> ts[List["T"]]:
+    raise NotImplementedError("C++ implementation only")
+    return None
+
+
+@csp.graph
+def record_batches_to_struct(
+    data: ts[List[pa.RecordBatch]],
+    cls: "T",
+    field_map: Dict[str, str],
+    schema: pa.Schema,
+) -> ts[List["T"]]:
+    """Convert ts[List[pa.RecordBatch]] into ts[List[T]] where T is a csp.Struct type.
+
+    Args:
+        data: Timeseries of lists of Arrow RecordBatches
+        cls: Target csp.Struct type
+        field_map: Mapping of struct field name -> arrow column name.
+        schema: Arrow schema of the record batches (required).
+
+    Returns:
+        Timeseries of lists of struct instances
+    """
+    # Build properties dict for the C++ node — invert field_map to col->field
+    scalar_field_map = {arrow_col: struct_field for struct_field, arrow_col in field_map.items()}
+
+    properties = {
+        "field_map": scalar_field_map,
+    }
+
+    # Export schema to PyCapsule
+    schema_capsule = schema.__arrow_c_schema__()
+
+    # Convert RecordBatches to PyCapsule tuples for C++ consumption
+    c_data = csp.apply(
+        data,
+        lambda batches: [rb.__arrow_c_array__() for rb in batches],
+        object,
+    )
+
+    return _record_batches_to_struct(schema_capsule, cls, properties, c_data)
+
+
+@_node_internal_use(cppimpl=_arrowadapterimpl.struct_to_record_batches)
+def _struct_to_record_batches(
+    cls: "T",
+    properties: dict,
+    data: ts[List["T"]],
+) -> ts[object]:
+    raise NotImplementedError("C++ implementation only")
+    return None
+
+
+@csp.graph
+def struct_to_record_batches(
+    data: ts[List["T"]],
+    cls: "T",
+    field_map: Optional[Dict[str, str]] = None,
+    max_batch_size: int = 65536,
+) -> ts[List[pa.RecordBatch]]:
+    """Convert ts[List[T]] into ts[List[pa.RecordBatch]] where T is a csp.Struct type.
+
+    Args:
+        data: Timeseries of lists of struct instances
+        cls: Source csp.Struct type
+        field_map: Mapping of struct field name -> arrow column name.
+            If None, all fields are included with identity naming.
+        max_batch_size: Maximum number of rows per output RecordBatch.
+            Defaults to 65536. Set to 0 to disable chunking.
+
+    Returns:
+        Timeseries of lists of RecordBatch
+    """
+    # Build properties dict for the C++ node
+    properties = {
+        "max_batch_size": max_batch_size,
+    }
+    if field_map is not None:
+        properties["field_map"] = field_map
+
+    # Call C++ node, then convert capsule tuples -> RecordBatch
+    c_data = _struct_to_record_batches(cls, properties, data)
+
+    return csp.apply(
+        c_data,
+        lambda c_tups: [pa.record_batch(_RecordBatchCSource(c_tup)) for c_tup in c_tups],
+        List[pa.RecordBatch],
+    )

--- a/csp/tests/adapters/test_arrow.py
+++ b/csp/tests/adapters/test_arrow.py
@@ -6,7 +6,7 @@ import pyarrow.parquet as pq
 import pytest
 
 import csp
-from csp.adapters.arrow import RecordBatchPullInputAdapter, write_record_batches
+from csp.adapters.arrow import RecordBatchPullInputAdapter, struct_to_record_batches, write_record_batches
 
 _STARTTIME = datetime(2020, 1, 1, 9, 0, 0)
 
@@ -405,3 +405,64 @@ class TestDeferredIterator:
         results = csp.run(G_lazy_schema, "TsCol", lazy_iter, False, starttime=_STARTTIME)
         assert len(results["data"]) == 2
         assert [len(r[1][0]) for r in results["data"]] == [5, 3]
+
+
+class TestStructConversion:
+    """Tests for struct_to_record_batches conversion."""
+
+    def test_nested_struct_with_nulls(self):
+        """Regression test: NestedStructWriter::writeNull must not double-append to child builders.
+
+        When a parent struct has a null nested struct field, the children of the
+        struct column must still have exactly one entry per row.  A prior bug caused
+        AppendNull() to also append empty values to children (on top of the explicit
+        writeNull per child), shifting all subsequent valid values to wrong indices.
+        """
+
+        class Inner(csp.Struct):
+            x: int
+            y: float
+
+        class Outer(csp.Struct):
+            name: str
+            inner: Inner
+
+        @csp.node
+        def validate_batches(batches: csp.ts[object]) -> csp.ts[object]:
+            if csp.ticked(batches):
+                return batches
+
+        @csp.graph
+        def g():
+            s1 = Outer(name="a", inner=Inner(x=1, y=1.5))
+            s2 = Outer(name="b")  # inner is unset -> null
+            s3 = Outer(name="c", inner=Inner(x=3, y=3.5))
+            s4 = Outer(name="d")  # inner is unset -> null
+            s5 = Outer(name="e", inner=Inner(x=5, y=5.5))
+
+            structs = csp.const([s1, s2, s3, s4, s5])
+            batches = struct_to_record_batches(structs, Outer, max_batch_size=100)
+            out = validate_batches(batches)
+            csp.add_graph_output("batches", out)
+
+        results = csp.run(g, starttime=_STARTTIME, endtime=_STARTTIME + timedelta(seconds=1))
+        batch_list = results["batches"][0][1]
+        batch = batch_list[0]
+
+        assert batch.num_rows == 5
+
+        struct_col = batch.column("inner")
+        x_child = struct_col.field("x")
+        y_child = struct_col.field("y")
+
+        # Child arrays must have exactly the same length as the struct column
+        assert len(x_child) == 5, f"child x length {len(x_child)} != struct length 5"
+        assert len(y_child) == 5, f"child y length {len(y_child)} != struct length 5"
+
+        # Verify actual values are correct (not shifted by double-append)
+        values = struct_col.to_pylist()
+        assert values[0] == {"x": 1, "y": 1.5}
+        assert values[1] is None
+        assert values[2] == {"x": 3, "y": 3.5}
+        assert values[3] is None
+        assert values[4] == {"x": 5, "y": 5.5}

--- a/csp/tests/adapters/test_arrow_record_batches.py
+++ b/csp/tests/adapters/test_arrow_record_batches.py
@@ -1,0 +1,1018 @@
+"""Tests for record_batches_to_struct and struct_to_record_batches.
+
+Covers all scalar types supported by the parquet adapter (bool, int, float, str,
+datetime, date, time, timedelta, enum, bytes, nested struct), numpy 1D arrays
+(float, int, str, bool), NDArrays, field mapping, null handling, multiple ticks,
+round-trips, and error cases.
+"""
+
+from datetime import date, datetime, time, timedelta
+
+import pyarrow as pa
+import pytest
+
+import csp
+from csp.adapters.arrow import record_batches_to_struct, struct_to_record_batches
+
+_STARTTIME = datetime(2020, 1, 1, 9, 0, 0)
+
+
+# =====================================================================
+# Struct definitions
+# =====================================================================
+
+
+class ScalarStruct(csp.Struct):
+    i64: int
+    f64: float
+    s: str
+    b: bool
+
+
+class NumericOnlyStruct(csp.Struct):
+    x: int
+    y: float
+
+
+class DateTimeStruct(csp.Struct):
+    dt: datetime
+    td: timedelta
+    d: date
+    t: time
+
+
+class MyEnum(csp.Enum):
+    A = 1
+    B = 2
+    C = 3
+
+
+class EnumStruct(csp.Struct):
+    label: str
+    color: MyEnum
+
+
+class BytesStruct(csp.Struct):
+    data: bytes
+
+
+class InnerStruct(csp.Struct):
+    x: int
+    y: float
+
+
+class NestedStruct(csp.Struct):
+    id: int
+    inner: InnerStruct
+
+
+class AllTypesStruct(csp.Struct):
+    b: bool
+    i: int
+    d: float
+    dt: datetime
+    dte: date
+    t: time
+    td: timedelta
+    s: str
+    e: MyEnum
+
+
+# =====================================================================
+# Helpers — reader direction (batch → struct)
+# =====================================================================
+
+
+def _run_to_struct(batches, cls, field_map, schema):
+    """Run a graph that converts record batches to structs and returns the results."""
+
+    @csp.graph
+    def G(
+        batches_: object,
+        cls_: type,
+        field_map_: dict,
+        schema_: object,
+    ):
+        data = csp.const([batches_])
+        structs = record_batches_to_struct(data, cls_, field_map_, schema_)
+        csp.add_graph_output("structs", structs)
+
+    results = csp.run(
+        G,
+        batches,
+        cls,
+        field_map,
+        schema,
+        starttime=_STARTTIME,
+        endtime=_STARTTIME + timedelta(seconds=1),
+    )
+    assert len(results["structs"]) == 1
+    return results["structs"][0][1]
+
+
+def _run_multi_tick_read(tick_batches, cls, field_map, schema):
+    """Run a graph that ticks multiple lists of record batches and returns all results."""
+
+    @csp.graph
+    def G(
+        ticks_: object,
+        cls_: type,
+        field_map_: dict,
+        schema_: object,
+    ):
+        data = csp.unroll(csp.const(ticks_))
+        structs = record_batches_to_struct(data, cls_, field_map_, schema_)
+        csp.add_graph_output("structs", structs)
+
+    results = csp.run(
+        G,
+        tick_batches,
+        cls,
+        field_map,
+        schema,
+        starttime=_STARTTIME,
+        endtime=_STARTTIME + timedelta(seconds=len(tick_batches)),
+    )
+    return [ts_val[1] for ts_val in results["structs"]]
+
+
+# =====================================================================
+# Helpers — writer direction (struct → batch)
+# =====================================================================
+
+
+def _run_to_batches(structs, cls, field_map=None):
+    """Run a graph that converts structs to record batches and returns the results."""
+
+    @csp.graph
+    def G(
+        structs_: object,
+        cls_: type,
+        field_map_: object,
+    ):
+        data = csp.const(structs_)
+        batches = struct_to_record_batches(data, cls_, field_map_)
+        csp.add_graph_output("batches", batches)
+
+    results = csp.run(
+        G,
+        structs,
+        cls,
+        field_map,
+        starttime=_STARTTIME,
+        endtime=_STARTTIME + timedelta(seconds=1),
+    )
+    assert len(results["batches"]) == 1
+    return results["batches"][0][1]
+
+
+def _run_multi_tick_write(tick_structs, cls, field_map=None):
+    """Run a graph that ticks multiple lists of structs and returns all results."""
+
+    @csp.graph
+    def G(
+        ticks_: object,
+        cls_: type,
+        field_map_: object,
+    ):
+        data = csp.unroll(csp.const(ticks_))
+        batches = struct_to_record_batches(data, cls_, field_map_)
+        csp.add_graph_output("batches", batches)
+
+    results = csp.run(
+        G,
+        tick_structs,
+        cls,
+        field_map,
+        starttime=_STARTTIME,
+        endtime=_STARTTIME + timedelta(seconds=len(tick_structs)),
+    )
+    return [ts_val[1] for ts_val in results["batches"]]
+
+
+# =====================================================================
+# Helpers — round-trip (struct → batch → struct, and batch → struct → batch)
+# =====================================================================
+
+
+def _run_round_trip(structs, cls, field_map, schema):
+    """struct → batch → struct round-trip; returns result structs."""
+
+    @csp.graph
+    def G(s_: object, cls_: type, fm_: object, schema_: object):
+        data = csp.const(s_)
+        batches = struct_to_record_batches(data, cls_, fm_)
+        result = record_batches_to_struct(batches, cls_, fm_, schema_)
+        csp.add_graph_output("result", result)
+
+    results = csp.run(
+        G, structs, cls, field_map, schema, starttime=_STARTTIME, endtime=_STARTTIME + timedelta(seconds=1)
+    )
+    return results["result"][0][1]
+
+
+def _run_reverse_round_trip(batch, cls, field_map):
+    """batch → struct → batch reverse round-trip; returns result batches."""
+    schema = batch.schema
+
+    @csp.graph
+    def G(b_: object, cls_: type, fm_: dict, schema_: object):
+        data = csp.const([b_])
+        structs = record_batches_to_struct(data, cls_, fm_, schema_)
+        batches = struct_to_record_batches(structs, cls_, fm_)
+        csp.add_graph_output("result", batches)
+
+    results = csp.run(G, batch, cls, field_map, schema, starttime=_STARTTIME, endtime=_STARTTIME + timedelta(seconds=1))
+    return results["result"][0][1]
+
+
+# =====================================================================
+# Tests: reading scalar fields (batch → struct)
+# =====================================================================
+
+
+class TestReadScalarFields:
+    def test_basic_scalar_types(self):
+        batch = pa.RecordBatch.from_pydict(
+            {
+                "i64": [1, 2, 3],
+                "f64": [1.1, 2.2, 3.3],
+                "s": ["a", "b", "c"],
+                "b": [True, False, True],
+            }
+        )
+        field_map = {"i64": "i64", "f64": "f64", "s": "s", "b": "b"}
+        structs = _run_to_struct(batch, ScalarStruct, field_map, batch.schema)
+
+        assert len(structs) == 3
+        assert structs[0].i64 == 1
+        assert structs[1].i64 == 2
+        assert structs[2].i64 == 3
+        assert structs[0].f64 == pytest.approx(1.1)
+        assert structs[1].f64 == pytest.approx(2.2)
+        assert structs[0].s == "a"
+        assert structs[1].s == "b"
+        assert structs[0].b is True
+        assert structs[1].b is False
+
+    def test_field_mapping(self):
+        batch = pa.RecordBatch.from_pydict(
+            {"col_x": [10, 20], "col_y": [1.5, 2.5]},
+            schema=pa.schema([("col_x", pa.int64()), ("col_y", pa.float64())]),
+        )
+        field_map = {"x": "col_x", "y": "col_y"}
+        structs = _run_to_struct(batch, NumericOnlyStruct, field_map, batch.schema)
+
+        assert len(structs) == 2
+        assert structs[0].x == 10
+        assert structs[0].y == pytest.approx(1.5)
+        assert structs[1].x == 20
+        assert structs[1].y == pytest.approx(2.5)
+
+    def test_single_row(self):
+        batch = pa.RecordBatch.from_pydict({"x": [42], "y": [3.14]})
+        field_map = {"x": "x", "y": "y"}
+        structs = _run_to_struct(batch, NumericOnlyStruct, field_map, batch.schema)
+
+        assert len(structs) == 1
+        assert structs[0].x == 42
+        assert structs[0].y == pytest.approx(3.14)
+
+    def test_many_rows(self):
+        n = 1000
+        batch = pa.RecordBatch.from_pydict({"x": list(range(n)), "y": [float(i) / 10.0 for i in range(n)]})
+        field_map = {"x": "x", "y": "y"}
+        structs = _run_to_struct(batch, NumericOnlyStruct, field_map, batch.schema)
+
+        assert len(structs) == n
+        for i in range(n):
+            assert structs[i].x == i
+            assert structs[i].y == pytest.approx(float(i) / 10.0)
+
+    def test_multiple_batches_single_tick(self):
+        """Multiple record batches in a single tick should all be converted."""
+        batch1 = pa.RecordBatch.from_pydict({"x": [1, 2], "y": [0.1, 0.2]})
+        batch2 = pa.RecordBatch.from_pydict({"x": [3, 4], "y": [0.3, 0.4]})
+        schema = batch1.schema
+
+        @csp.graph
+        def G():
+            data = csp.const([batch1, batch2])
+            field_map = {"x": "x", "y": "y"}
+            structs = record_batches_to_struct(data, NumericOnlyStruct, field_map, schema)
+            csp.add_graph_output("structs", structs)
+
+        results = csp.run(G, starttime=_STARTTIME, endtime=_STARTTIME + timedelta(seconds=1))
+        structs = results["structs"][0][1]
+
+        assert len(structs) == 4
+        assert [s.x for s in structs] == [1, 2, 3, 4]
+
+    def test_multiple_ticks(self):
+        """Multiple ticks each with their own batch."""
+        batch1 = pa.RecordBatch.from_pydict({"x": [10], "y": [1.0]})
+        batch2 = pa.RecordBatch.from_pydict({"x": [20], "y": [2.0]})
+        schema = batch1.schema
+
+        tick_batches = [[batch1], [batch2]]
+        all_results = _run_multi_tick_read(tick_batches, NumericOnlyStruct, {"x": "x", "y": "y"}, schema)
+
+        assert len(all_results) == 2
+        assert all_results[0][0].x == 10
+        assert all_results[1][0].x == 20
+
+    def test_datetime_types(self):
+        """datetime, timedelta, date, time fields."""
+        # Use a known UTC nanosecond value to avoid timezone ambiguity
+        # 2024-03-15T12:00:00 UTC = 1710504000 seconds since epoch
+        dt_val = datetime(2024, 3, 15, 12, 0, 0)
+        td_val = timedelta(seconds=3600)
+        d_val = date(2024, 6, 15)
+        t_val = time(14, 30, 0)
+
+        # Construct nanosecond values directly (UTC epoch-based)
+        dt_ns = 1710504000 * 10**9  # 2024-03-15T12:00:00 UTC
+        td_ns = int(td_val.total_seconds() * 1e9)
+        d_days = (d_val - date(1970, 1, 1)).days
+        t_ns = (t_val.hour * 3600 + t_val.minute * 60 + t_val.second) * 10**9
+
+        batch = pa.RecordBatch.from_arrays(
+            [
+                pa.array([dt_ns], type=pa.timestamp("ns", tz="UTC")),
+                pa.array([td_ns], type=pa.duration("ns")),
+                pa.array([d_days], type=pa.date32()),
+                pa.array([t_ns], type=pa.time64("ns")),
+            ],
+            schema=pa.schema(
+                [
+                    ("dt", pa.timestamp("ns", tz="UTC")),
+                    ("td", pa.duration("ns")),
+                    ("d", pa.date32()),
+                    ("t", pa.time64("ns")),
+                ]
+            ),
+        )
+        field_map = {"dt": "dt", "td": "td", "d": "d", "t": "t"}
+        structs = _run_to_struct(batch, DateTimeStruct, field_map, batch.schema)
+
+        assert len(structs) == 1
+        assert structs[0].dt == dt_val
+        assert structs[0].td == td_val
+        assert structs[0].d == d_val
+        assert structs[0].t == t_val
+
+    def test_enum_from_string(self):
+        """Enum fields stored as strings."""
+        batch = pa.RecordBatch.from_pydict(
+            {"label": ["x", "y"], "color": ["A", "B"]},
+        )
+        field_map = {"label": "label", "color": "color"}
+        structs = _run_to_struct(batch, EnumStruct, field_map, batch.schema)
+
+        assert len(structs) == 2
+        assert structs[0].label == "x"
+        assert structs[0].color == MyEnum.A
+        assert structs[1].color == MyEnum.B
+
+    def test_bytes_read(self):
+        """Binary/bytes field."""
+        val = b"my\x00value"
+        batch = pa.RecordBatch.from_arrays(
+            [pa.array([val], type=pa.binary())],
+            schema=pa.schema([("data", pa.binary())]),
+        )
+        field_map = {"data": "data"}
+        structs = _run_to_struct(batch, BytesStruct, field_map, batch.schema)
+
+        assert len(structs) == 1
+        assert structs[0].data == val
+
+    def test_nested_struct_read(self):
+        """Nested struct field."""
+        inner_type = pa.struct([("x", pa.int64()), ("y", pa.float64())])
+        inner_arr = pa.StructArray.from_arrays(
+            [pa.array([42]), pa.array([2.5])],
+            fields=[pa.field("x", pa.int64()), pa.field("y", pa.float64())],
+        )
+        batch = pa.RecordBatch.from_arrays(
+            [pa.array([1]), inner_arr],
+            schema=pa.schema([("id", pa.int64()), ("inner", inner_type)]),
+        )
+        field_map = {"id": "id", "inner": "inner"}
+        structs = _run_to_struct(batch, NestedStruct, field_map, batch.schema)
+
+        assert len(structs) == 1
+        assert structs[0].id == 1
+        assert structs[0].inner.x == 42
+        assert structs[0].inner.y == pytest.approx(2.5)
+
+
+# =====================================================================
+# Tests for all Arrow reader types (ensuring full type coverage)
+# =====================================================================
+
+
+class TestReadAllArrowTypes:
+    """Test every Arrow type supported by ArrowFieldReader.
+
+    CSP Python only supports int (int64) for integers. These tests verify that
+    narrow Arrow integer types (int8/16/32, uint8/16/32/64) are correctly
+    widened to int64 when reading into CSP struct fields.
+    """
+
+    # --- Narrow integer types ---
+
+    @pytest.mark.parametrize(
+        "arrow_type",
+        [pa.int8(), pa.int16(), pa.int32(), pa.uint8(), pa.uint16(), pa.uint32(), pa.uint64()],
+        ids=["int8", "int16", "int32", "uint8", "uint16", "uint32", "uint64"],
+    )
+    def test_narrow_integer_types(self, arrow_type):
+        """Arrow narrow integers should widen to CSP int64."""
+        arr = pa.array([10, 20, 30], type=arrow_type)
+        batch = pa.record_batch(
+            {
+                "i64": arr,
+                "f64": pa.array([1.0, 2.0, 3.0]),
+                "s": pa.array(["a", "b", "c"]),
+                "b": pa.array([True, False, True]),
+            }
+        )
+        field_map = {"i64": "i64", "f64": "f64", "s": "s", "b": "b"}
+        structs = _run_to_struct(batch, ScalarStruct, field_map, batch.schema)
+        assert len(structs) == 3
+        assert structs[0].i64 == 10
+        assert structs[1].i64 == 20
+        assert structs[2].i64 == 30
+
+    # --- Float types ---
+
+    def test_float32(self):
+        """Arrow float32 should widen to CSP float64."""
+        arr = pa.array([1.5, 2.5, 3.5], type=pa.float32())
+        batch = pa.record_batch(
+            {"f64": arr, "i64": pa.array([1, 2, 3]), "s": pa.array(["a", "b", "c"]), "b": pa.array([True, False, True])}
+        )
+        field_map = {"f64": "f64", "i64": "i64", "s": "s", "b": "b"}
+        structs = _run_to_struct(batch, ScalarStruct, field_map, batch.schema)
+        assert abs(structs[0].f64 - 1.5) < 1e-5
+        assert abs(structs[1].f64 - 2.5) < 1e-5
+
+    def test_float16(self):
+        """Arrow float16 (half_float) should widen to CSP float64."""
+        # PyArrow float16 has limited precision
+        arr = pa.array([1.0, 2.0, 3.0], type=pa.float16())
+        batch = pa.record_batch(
+            {"f64": arr, "i64": pa.array([1, 2, 3]), "s": pa.array(["a", "b", "c"]), "b": pa.array([True, False, True])}
+        )
+        field_map = {"f64": "f64", "i64": "i64", "s": "s", "b": "b"}
+        structs = _run_to_struct(batch, ScalarStruct, field_map, batch.schema)
+        assert abs(structs[0].f64 - 1.0) < 0.1
+        assert abs(structs[1].f64 - 2.0) < 0.1
+        assert abs(structs[2].f64 - 3.0) < 0.1
+
+    # --- String variants ---
+
+    def test_large_string(self):
+        """Arrow large_string should read into CSP str."""
+        arr = pa.array(["hello", "world", "test"], type=pa.large_string())
+        batch = pa.record_batch(
+            {"s": arr, "i64": pa.array([1, 2, 3]), "f64": pa.array([1.0, 2.0, 3.0]), "b": pa.array([True, False, True])}
+        )
+        field_map = {"s": "s", "i64": "i64", "f64": "f64", "b": "b"}
+        structs = _run_to_struct(batch, ScalarStruct, field_map, batch.schema)
+        assert structs[0].s == "hello"
+        assert structs[1].s == "world"
+        assert structs[2].s == "test"
+
+    # --- Binary variants ---
+
+    def test_large_binary(self):
+        """Arrow large_binary should read into CSP bytes."""
+        arr = pa.array([b"\x01\x02", b"\x03\x04", b"\x05"], type=pa.large_binary())
+        batch = pa.record_batch({"data": arr})
+        field_map = {"data": "data"}
+        structs = _run_to_struct(batch, BytesStruct, field_map, batch.schema)
+        assert structs[0].data == b"\x01\x02"
+        assert structs[1].data == b"\x03\x04"
+        assert structs[2].data == b"\x05"
+
+    def test_fixed_size_binary(self):
+        """Arrow fixed_size_binary should read into CSP bytes."""
+        arr = pa.array([b"\x01\x02\x03", b"\x04\x05\x06", b"\x07\x08\x09"], type=pa.binary(3))
+        batch = pa.record_batch({"data": arr})
+        field_map = {"data": "data"}
+        structs = _run_to_struct(batch, BytesStruct, field_map, batch.schema)
+        assert structs[0].data == b"\x01\x02\x03"
+        assert structs[1].data == b"\x04\x05\x06"
+        assert structs[2].data == b"\x07\x08\x09"
+
+    # --- Timestamp units ---
+
+    @pytest.mark.parametrize(
+        "unit",
+        ["s", "ms", "us", "ns"],
+        ids=["seconds", "milliseconds", "microseconds", "nanoseconds"],
+    )
+    def test_timestamp_units(self, unit):
+        """All timestamp units should read into CSP datetime."""
+        dt_val = datetime(2023, 6, 15, 12, 30, 45)
+        arr = pa.array([dt_val], type=pa.timestamp(unit))
+        batch = pa.record_batch(
+            {
+                "dt": arr,
+                "td": pa.array([timedelta(seconds=1)]),
+                "d": pa.array([date(2023, 6, 15)]),
+                "t": pa.array([time(12, 30, 45)]),
+            }
+        )
+        field_map = {"dt": "dt", "td": "td", "d": "d", "t": "t"}
+        structs = _run_to_struct(batch, DateTimeStruct, field_map, batch.schema)
+        assert structs[0].dt == dt_val
+
+    # --- Duration units ---
+
+    @pytest.mark.parametrize(
+        "unit",
+        ["s", "ms", "us", "ns"],
+        ids=["seconds", "milliseconds", "microseconds", "nanoseconds"],
+    )
+    def test_duration_units(self, unit):
+        """All duration units should read into CSP timedelta."""
+        td_val = timedelta(seconds=42)
+        arr = pa.array([td_val], type=pa.duration(unit))
+        batch = pa.record_batch(
+            {
+                "td": arr,
+                "dt": pa.array([datetime(2023, 1, 1)]),
+                "d": pa.array([date(2023, 1, 1)]),
+                "t": pa.array([time(0, 0, 0)]),
+            }
+        )
+        field_map = {"dt": "dt", "td": "td", "d": "d", "t": "t"}
+        structs = _run_to_struct(batch, DateTimeStruct, field_map, batch.schema)
+        assert structs[0].td == td_val
+
+    # --- Date64 ---
+
+    def test_date64(self):
+        """Arrow date64 should read into CSP date."""
+        d_val = date(2023, 6, 15)
+        # date64 stores milliseconds since epoch
+        arr = pa.array([d_val], type=pa.date64())
+        batch = pa.record_batch(
+            {
+                "d": arr,
+                "dt": pa.array([datetime(2023, 1, 1)]),
+                "td": pa.array([timedelta(seconds=1)]),
+                "t": pa.array([time(0, 0, 0)]),
+            }
+        )
+        field_map = {"dt": "dt", "td": "td", "d": "d", "t": "t"}
+        structs = _run_to_struct(batch, DateTimeStruct, field_map, batch.schema)
+        assert structs[0].d == d_val
+
+    # --- Time32 ---
+
+    @pytest.mark.parametrize("unit", ["s", "ms"], ids=["seconds", "milliseconds"])
+    def test_time32(self, unit):
+        """Arrow time32 (s, ms) should read into CSP time."""
+        t_val = time(12, 30, 45)
+        arr = pa.array([t_val], type=pa.time32(unit))
+        batch = pa.record_batch(
+            {
+                "t": arr,
+                "dt": pa.array([datetime(2023, 1, 1)]),
+                "td": pa.array([timedelta(seconds=1)]),
+                "d": pa.array([date(2023, 1, 1)]),
+            }
+        )
+        field_map = {"dt": "dt", "td": "td", "d": "d", "t": "t"}
+        structs = _run_to_struct(batch, DateTimeStruct, field_map, batch.schema)
+        assert structs[0].t.hour == 12
+        assert structs[0].t.minute == 30
+        assert structs[0].t.second == 45
+
+    # --- Time64 ---
+
+    @pytest.mark.parametrize("unit", ["us", "ns"], ids=["microseconds", "nanoseconds"])
+    def test_time64(self, unit):
+        """Arrow time64 (us, ns) should read into CSP time."""
+        t_val = time(14, 15, 16, 123456)
+        arr = pa.array([t_val], type=pa.time64(unit))
+        batch = pa.record_batch(
+            {
+                "t": arr,
+                "dt": pa.array([datetime(2023, 1, 1)]),
+                "td": pa.array([timedelta(seconds=1)]),
+                "d": pa.array([date(2023, 1, 1)]),
+            }
+        )
+        field_map = {"dt": "dt", "td": "td", "d": "d", "t": "t"}
+        structs = _run_to_struct(batch, DateTimeStruct, field_map, batch.schema)
+        assert structs[0].t.hour == 14
+        assert structs[0].t.minute == 15
+        assert structs[0].t.second == 16
+
+    # --- Dictionary-encoded string ---
+
+    def test_dictionary_string(self):
+        """Arrow dictionary-encoded string should read into CSP str."""
+        arr = pa.array(["foo", "bar", "foo", "baz"]).dictionary_encode()
+        batch = pa.record_batch(
+            {
+                "s": arr,
+                "i64": pa.array([1, 2, 3, 4]),
+                "f64": pa.array([1.0, 2.0, 3.0, 4.0]),
+                "b": pa.array([True, True, False, False]),
+            }
+        )
+        field_map = {"s": "s", "i64": "i64", "f64": "f64", "b": "b"}
+        structs = _run_to_struct(batch, ScalarStruct, field_map, batch.schema)
+        assert structs[0].s == "foo"
+        assert structs[1].s == "bar"
+        assert structs[2].s == "foo"
+        assert structs[3].s == "baz"
+
+    # --- Dictionary-encoded enum ---
+
+    def test_dictionary_enum(self):
+        """Arrow dictionary-encoded string should read into CSP enum."""
+        arr = pa.array(["A", "B", "C", "A"]).dictionary_encode()
+        batch = pa.record_batch({"label": pa.array(["x", "y", "z", "w"]), "color": arr})
+        field_map = {"label": "label", "color": "color"}
+        structs = _run_to_struct(batch, EnumStruct, field_map, batch.schema)
+        assert structs[0].color == MyEnum.A
+        assert structs[1].color == MyEnum.B
+        assert structs[2].color == MyEnum.C
+        assert structs[3].color == MyEnum.A
+
+    # --- Enum from large_string ---
+
+    def test_enum_from_large_string(self):
+        """Arrow large_string should read into CSP enum."""
+        arr = pa.array(["B", "C", "A"], type=pa.large_string())
+        batch = pa.record_batch({"label": pa.array(["x", "y", "z"]), "color": arr})
+        field_map = {"label": "label", "color": "color"}
+        structs = _run_to_struct(batch, EnumStruct, field_map, batch.schema)
+        assert structs[0].color == MyEnum.B
+        assert structs[1].color == MyEnum.C
+        assert structs[2].color == MyEnum.A
+
+    # --- Null handling for all types ---
+
+    def test_narrow_int_with_nulls(self):
+        """Arrow narrow int with nulls should leave CSP field unset."""
+        arr = pa.array([10, None, 30], type=pa.int16())
+        batch = pa.record_batch({"x": arr, "y": pa.array([1.0, 2.0, 3.0])})
+        field_map = {"x": "x", "y": "y"}
+        structs = _run_to_struct(batch, NumericOnlyStruct, field_map, batch.schema)
+        assert structs[0].x == 10
+        assert not hasattr(structs[1], "x")  # null -> unset
+        assert structs[2].x == 30
+
+    def test_float16_with_nulls(self):
+        """Arrow float16 with nulls should leave CSP field unset."""
+        arr = pa.array([1.0, None, 3.0], type=pa.float16())
+        batch = pa.record_batch(
+            {"f64": arr, "i64": pa.array([1, 2, 3]), "s": pa.array(["a", "b", "c"]), "b": pa.array([True, False, True])}
+        )
+        field_map = {"f64": "f64", "i64": "i64", "s": "s", "b": "b"}
+        structs = _run_to_struct(batch, ScalarStruct, field_map, batch.schema)
+        assert abs(structs[0].f64 - 1.0) < 0.1
+        assert not hasattr(structs[1], "f64")
+        assert abs(structs[2].f64 - 3.0) < 0.1
+
+    def test_large_string_with_nulls(self):
+        """Arrow large_string with nulls should leave CSP field unset."""
+        arr = pa.array(["hello", None, "world"], type=pa.large_string())
+        batch = pa.record_batch(
+            {"s": arr, "i64": pa.array([1, 2, 3]), "f64": pa.array([1.0, 2.0, 3.0]), "b": pa.array([True, False, True])}
+        )
+        field_map = {"s": "s", "i64": "i64", "f64": "f64", "b": "b"}
+        structs = _run_to_struct(batch, ScalarStruct, field_map, batch.schema)
+        assert structs[0].s == "hello"
+        assert not hasattr(structs[1], "s")
+        assert structs[2].s == "world"
+
+    def test_large_binary_with_nulls(self):
+        """Arrow large_binary with nulls should leave CSP field unset."""
+        arr = pa.array([b"\x01", None, b"\x03"], type=pa.large_binary())
+        batch = pa.record_batch({"data": arr})
+        field_map = {"data": "data"}
+        structs = _run_to_struct(batch, BytesStruct, field_map, batch.schema)
+        assert structs[0].data == b"\x01"
+        assert not hasattr(structs[1], "data")
+        assert structs[2].data == b"\x03"
+
+    def test_fixed_size_binary_with_nulls(self):
+        """Arrow fixed_size_binary with nulls should leave CSP field unset."""
+        arr = pa.array([b"\x01\x02\x03", None, b"\x07\x08\x09"], type=pa.binary(3))
+        batch = pa.record_batch({"data": arr})
+        field_map = {"data": "data"}
+        structs = _run_to_struct(batch, BytesStruct, field_map, batch.schema)
+        assert structs[0].data == b"\x01\x02\x03"
+        assert not hasattr(structs[1], "data")
+        assert structs[2].data == b"\x07\x08\x09"
+
+    def test_enum_from_string_with_nulls(self):
+        """Arrow string enum with nulls should leave CSP field unset."""
+        arr = pa.array(["A", None, "C"])
+        batch = pa.record_batch({"label": pa.array(["x", "y", "z"]), "color": arr})
+        field_map = {"label": "label", "color": "color"}
+        structs = _run_to_struct(batch, EnumStruct, field_map, batch.schema)
+        assert structs[0].color == MyEnum.A
+        assert not hasattr(structs[1], "color")
+        assert structs[2].color == MyEnum.C
+
+    def test_enum_from_large_string_with_nulls(self):
+        """Arrow large_string enum with nulls should leave CSP field unset."""
+        arr = pa.array(["B", None, "A"], type=pa.large_string())
+        batch = pa.record_batch({"label": pa.array(["x", "y", "z"]), "color": arr})
+        field_map = {"label": "label", "color": "color"}
+        structs = _run_to_struct(batch, EnumStruct, field_map, batch.schema)
+        assert structs[0].color == MyEnum.B
+        assert not hasattr(structs[1], "color")
+        assert structs[2].color == MyEnum.A
+
+    def test_dictionary_string_with_nulls(self):
+        """Arrow dictionary-encoded string with nulls should leave CSP field unset."""
+        arr = pa.array(["foo", None, "baz"]).dictionary_encode()
+        batch = pa.record_batch(
+            {"s": arr, "i64": pa.array([1, 2, 3]), "f64": pa.array([1.0, 2.0, 3.0]), "b": pa.array([True, False, True])}
+        )
+        field_map = {"s": "s", "i64": "i64", "f64": "f64", "b": "b"}
+        structs = _run_to_struct(batch, ScalarStruct, field_map, batch.schema)
+        assert structs[0].s == "foo"
+        assert not hasattr(structs[1], "s")
+        assert structs[2].s == "baz"
+
+    def test_dictionary_enum_with_nulls(self):
+        """Arrow dictionary-encoded enum with nulls should leave CSP field unset."""
+        arr = pa.array(["A", None, "C"]).dictionary_encode()
+        batch = pa.record_batch({"label": pa.array(["x", "y", "z"]), "color": arr})
+        field_map = {"label": "label", "color": "color"}
+        structs = _run_to_struct(batch, EnumStruct, field_map, batch.schema)
+        assert structs[0].color == MyEnum.A
+        assert not hasattr(structs[1], "color")
+        assert structs[2].color == MyEnum.C
+
+    def test_date64_with_nulls(self):
+        """Arrow date64 with nulls should leave CSP field unset."""
+
+        class DateOnlyStruct(csp.Struct):
+            d: date
+
+        arr = pa.array([date(2023, 6, 15), None, date(2024, 1, 1)], type=pa.date64())
+        batch = pa.record_batch({"d": arr})
+        field_map = {"d": "d"}
+        structs = _run_to_struct(batch, DateOnlyStruct, field_map, batch.schema)
+        assert structs[0].d == date(2023, 6, 15)
+        assert not hasattr(structs[1], "d")
+        assert structs[2].d == date(2024, 1, 1)
+
+    def test_time32_with_nulls(self):
+        """Arrow time32 with nulls should leave CSP field unset."""
+
+        class TimeOnlyStruct(csp.Struct):
+            t: time
+
+        arr = pa.array([time(12, 30, 0), None, time(14, 0, 0)], type=pa.time32("s"))
+        batch = pa.record_batch({"t": arr})
+        field_map = {"t": "t"}
+        structs = _run_to_struct(batch, TimeOnlyStruct, field_map, batch.schema)
+        assert structs[0].t.hour == 12
+        assert structs[0].t.minute == 30
+        assert not hasattr(structs[1], "t")
+        assert structs[2].t.hour == 14
+
+    def test_time64_with_nulls(self):
+        """Arrow time64 with nulls should leave CSP field unset."""
+
+        class TimeOnlyStruct(csp.Struct):
+            t: time
+
+        arr = pa.array([time(14, 15, 16), None, time(0, 0, 1)], type=pa.time64("us"))
+        batch = pa.record_batch({"t": arr})
+        field_map = {"t": "t"}
+        structs = _run_to_struct(batch, TimeOnlyStruct, field_map, batch.schema)
+        assert structs[0].t.hour == 14
+        assert not hasattr(structs[1], "t")
+        assert structs[2].t.hour == 0
+        assert structs[2].t.second == 1
+
+    # --- All-null column ---
+
+    def test_all_null_column(self):
+        """A column where every value is null should leave all struct fields unset."""
+        arr = pa.array([None, None, None], type=pa.int64())
+        batch = pa.record_batch({"x": arr, "y": pa.array([1.0, 2.0, 3.0])})
+        field_map = {"x": "x", "y": "y"}
+        structs = _run_to_struct(batch, NumericOnlyStruct, field_map, batch.schema)
+        assert len(structs) == 3
+        for s in structs:
+            assert not hasattr(s, "x")
+        assert structs[0].y == pytest.approx(1.0)
+
+    # --- Multiple rows with mixed narrow types ---
+
+    def test_many_rows_narrow_int(self):
+        """Read many rows from a narrow int column."""
+        n = 1000
+        arr = pa.array(list(range(n)), type=pa.int32())
+        batch = pa.record_batch({"x": arr, "y": pa.array([float(i) for i in range(n)])})
+        field_map = {"x": "x", "y": "y"}
+        structs = _run_to_struct(batch, NumericOnlyStruct, field_map, batch.schema)
+        assert len(structs) == n
+        for i in range(n):
+            assert structs[i].x == i
+            assert structs[i].y == float(i)
+
+    # --- Binary with nulls ---
+
+    def test_binary_with_nulls(self):
+        """Arrow binary with nulls should leave CSP field unset."""
+        arr = pa.array([b"\x01", None, b"\x03"])
+        batch = pa.record_batch({"data": arr})
+        field_map = {"data": "data"}
+        structs = _run_to_struct(batch, BytesStruct, field_map, batch.schema)
+        assert structs[0].data == b"\x01"
+        assert not hasattr(structs[1], "data")
+        assert structs[2].data == b"\x03"
+
+
+# =====================================================================
+# Tests: null handling for common read types
+# =====================================================================
+
+
+class TestReadNullHandling:
+    """Test that null values in various Arrow column types leave CSP struct fields unset."""
+
+    @pytest.mark.parametrize("null_field", ["i64", "f64", "s", "b"])
+    def test_null_basic_scalar(self, null_field):
+        """Null in a basic scalar column (int64, float64, string, bool) leaves the field unset."""
+        data = {"i64": [1, 2, 3], "f64": [1.0, 2.0, 3.0], "s": ["a", "b", "c"], "b": [True, False, True]}
+        data[null_field] = [data[null_field][0], None, data[null_field][2]]
+        batch = pa.record_batch(data)
+        field_map = {k: k for k in data}
+        structs = _run_to_struct(batch, ScalarStruct, field_map, batch.schema)
+        assert hasattr(structs[0], null_field)
+        assert not hasattr(structs[1], null_field)
+        assert hasattr(structs[2], null_field)
+
+    @pytest.mark.parametrize("null_field", ["dt", "td", "d", "t"])
+    def test_null_temporal(self, null_field):
+        """Null in a temporal column (datetime, timedelta, date, time) leaves the field unset."""
+        vals = {
+            "dt": [datetime(2024, 1, 1), datetime(2024, 1, 2)],
+            "td": [timedelta(seconds=42), timedelta(seconds=2)],
+            "d": [date(2024, 6, 15), date(2024, 1, 2)],
+            "t": [time(14, 30, 0), time(13, 0, 0)],
+        }
+        # Set the null field's second value to None
+        arrays = []
+        schema_fields = [
+            ("dt", pa.timestamp("ns", tz="UTC")),
+            ("td", pa.duration("ns")),
+            ("d", pa.date32()),
+            ("t", pa.time64("ns")),
+        ]
+        for field_name, arrow_type in schema_fields:
+            v = vals[field_name]
+            if field_name == null_field:
+                v = [v[0], None]
+            arrays.append(pa.array(v, type=arrow_type))
+        schema = pa.schema(schema_fields)
+        batch = pa.RecordBatch.from_arrays(arrays, schema=schema)
+        field_map = {"dt": "dt", "td": "td", "d": "d", "t": "t"}
+        structs = _run_to_struct(batch, DateTimeStruct, field_map, batch.schema)
+        assert hasattr(structs[0], null_field)
+        assert not hasattr(structs[1], null_field)
+
+    def test_null_nested_struct(self):
+        """Null nested struct should leave the field unset, and child readers stay in sync."""
+        inner_type = pa.struct([("x", pa.int64()), ("y", pa.float64())])
+        inner_arr = pa.StructArray.from_arrays(
+            [pa.array([42, None, 99]), pa.array([2.5, None, 9.9])],
+            fields=[pa.field("x", pa.int64()), pa.field("y", pa.float64())],
+            mask=pa.array([False, True, False]),  # second row is null
+        )
+        batch = pa.RecordBatch.from_arrays(
+            [pa.array([1, 2, 3]), inner_arr],
+            schema=pa.schema([("id", pa.int64()), ("inner", inner_type)]),
+        )
+        field_map = {"id": "id", "inner": "inner"}
+        structs = _run_to_struct(batch, NestedStruct, field_map, batch.schema)
+
+        assert len(structs) == 3
+        assert structs[0].inner.x == 42
+        assert structs[0].inner.y == pytest.approx(2.5)
+        assert not hasattr(structs[1], "inner")
+        assert structs[2].inner.x == 99
+        assert structs[2].inner.y == pytest.approx(9.9)
+
+    def test_empty_batch_read(self):
+        """Reading an empty RecordBatch should produce an empty list."""
+        schema = pa.schema([("x", pa.int64()), ("y", pa.float64())])
+        batch = pa.RecordBatch.from_pydict({"x": [], "y": []}, schema=schema)
+        field_map = {"x": "x", "y": "y"}
+        structs = _run_to_struct(batch, NumericOnlyStruct, field_map, batch.schema)
+        assert len(structs) == 0
+
+
+# =====================================================================
+# Tests: reverse round-trip with null values
+# =====================================================================
+
+
+class TestReverseRoundTripWithNulls:
+    """batch → struct → batch where the original batch contains null values."""
+
+    def test_scalar_nulls_reverse_round_trip(self):
+        """batch with nulls → struct → batch should preserve nulls."""
+        original = pa.RecordBatch.from_pydict(
+            {
+                "i64": pa.array([1, None, 3]),
+                "f64": pa.array([1.1, 2.2, None]),
+                "s": pa.array([None, "b", "c"]),
+                "b": pa.array([True, None, False]),
+            }
+        )
+        field_map = {"i64": "i64", "f64": "f64", "s": "s", "b": "b"}
+        result_batches = _run_reverse_round_trip(original, ScalarStruct, field_map)
+
+        assert len(result_batches) == 1
+        result = result_batches[0]
+        assert result.num_rows == 3
+        assert result.column("i64").to_pylist() == [1, None, 3]
+        assert result.column("f64").to_pylist()[0] == pytest.approx(1.1)
+        assert result.column("f64").to_pylist()[2] is None
+        assert result.column("s").to_pylist() == [None, "b", "c"]
+        assert result.column("b").to_pylist() == [True, None, False]
+
+
+# =====================================================================
+# Regression tests for specific bugs
+# =====================================================================
+
+
+class TestDateWriteRegression:
+    """Regression: DateWriter must compute days-since-epoch correctly.
+
+    Ensures the optimized DateWriter (single timegm call) matches the expected
+    Arrow Date32 representation.
+    """
+
+    def test_unix_epoch_date(self):
+        """1970-01-01 should produce Date32 value of 0."""
+        structs = [DateTimeStruct(dt=datetime(2020, 1, 1), td=timedelta(0), d=date(1970, 1, 1), t=time(0, 0, 0))]
+        field_map = {"d": "d"}
+        batches = _run_to_batches(structs, DateTimeStruct, field_map)
+        batch = batches[0]
+        assert batch.column("d").to_pylist() == [date(1970, 1, 1)]
+
+    def test_known_dates(self):
+        """Verify several known dates produce correct Date32 values."""
+        known = [
+            date(1970, 1, 1),
+            date(2000, 1, 1),
+            date(2020, 6, 15),
+            date(2024, 2, 29),  # leap day
+        ]
+        structs = [DateTimeStruct(dt=datetime(2020, 1, 1), td=timedelta(0), d=d, t=time(0, 0, 0)) for d in known]
+        field_map = {"d": "d"}
+        batches = _run_to_batches(structs, DateTimeStruct, field_map)
+        batch = batches[0]
+        result_dates = batch.column("d").to_pylist()
+        for expected, actual in zip(known, result_dates):
+            assert actual == expected, f"Expected {expected}, got {actual}"
+
+    def test_date_round_trip(self):
+        """Write dates through arrow adapter and read back - values must match."""
+        test_dates = [date(1970, 1, 1), date(1999, 12, 31), date(2025, 7, 4)]
+        structs = [DateTimeStruct(dt=datetime(2020, 1, 1), td=timedelta(0), d=d, t=time(0, 0, 0)) for d in test_dates]
+        field_map = {"d": "d"}
+        batches = _run_to_batches(structs, DateTimeStruct, field_map)
+        batch = batches[0]
+        schema = batch.schema
+        read_field_map = {"d": "d"}
+
+        result = _run_to_struct(batch, DateTimeStruct, read_field_map, schema)
+        for i, expected_date in enumerate(test_dates):
+            assert result[i].d == expected_date
+
+
+# =====================================================================
+# Struct definitions for multi-level nesting
+# =====================================================================
+
+
+class MiddleStruct(csp.Struct):
+    tag: str
+    inner: InnerStruct
+
+
+class OuterStruct(csp.Struct):
+    id: int
+    middle: MiddleStruct


### PR DESCRIPTION
## Arrow Batch Adapter: Scalar Type Support

Adds bidirectional conversion between Arrow `RecordBatch` and `csp.Struct` for all scalar types, with new CSP graph nodes for use in running graphs.

### Motivation

CSP lacked a general-purpose way to move data between Arrow RecordBatches and csp Structs. The parquet adapter had its own bespoke conversion logic, and there was no reusable building block for other Arrow-based integrations (IPC, Flight, custom adapters). This PR introduces a shared, extensible Arrow ↔ Struct conversion layer that any adapter can use.

### What's New

**Core C++ Library** (`cpp/csp/adapters/arrow/`)
- **`ArrowTypeVisitor`** — Generic Arrow type → C++ type dispatch using template metaprogramming. Eliminates repetitive switch statements across the codebase.
- **`ArrowFieldReader`** — Column-oriented extraction from Arrow arrays to CSP values. Supports scalar types, dictionary-encoded columns, enums, nested structs, and pluggable custom readers for extension types (e.g. numpy arrays).
- **`ArrowFieldWriter`** — Mirror of FieldReader for serialization. Converts CSP struct fields to Arrow arrays via builders.
- **`RecordBatchToStruct` / `StructToRecordBatch`** — Batch converters built on the readers/writers. Pre-allocate structs and use columnar `readAll()`/`writeAll()` for cache-friendly bulk conversion.

**Python Graph Nodes** (`csp/adapters/arrow.py`, `ArrowCppNodes.cpp`)
- `csp.adapters.arrow.record_batches_to_struct(data, cls, ...)` — Converts `ts[List[pa.RecordBatch]]` → `ts[List[Struct]]`
- `csp.adapters.arrow.struct_to_record_batches(data, cls, ...)` — Converts `ts[List[Struct]]` → `ts[List[pa.RecordBatch]]`
- Data crosses the Python ↔ C++ boundary via the [Arrow C Data Interface](https://arrow.apache.org/docs/format/CDataInterface.html) (zero-copy, ABI-stable PyCapsule exchange).
- Optional `field_map` for column ↔ field renaming, optional `max_batch_size` for chunked output.

**Build System**
- New `csp_arrow_adapter` static library with centralized Arrow dependency resolution (`FindDepsArrowAdapter.cmake`).
- Simplified `arrowadapterimpl` Python extension — now links against `csp_arrow_adapter` instead of resolving Arrow directly.

### Supported Types

| CSP Type | Arrow Types |
|----------|------------|
| `bool` | BOOL |
| `int` | INT8/16/32/64, UINT8/16/32/64 |
| `float` | FLOAT, DOUBLE, HALF_FLOAT |
| `str` | STRING, LARGE_STRING, DICTIONARY |
| `bytes` | BINARY, FIXED_SIZE_BINARY |
| `datetime` | TIMESTAMP (ns/us/ms/s) |
| `date` | DATE32, DATE64 |
| `time` | TIME32, TIME64 |
| `timedelta` | DURATION |
| `Enum` | STRING, DICTIONARY |
| `csp.Struct` | STRUCT (recursive) |

### Extensibility

The converters accept pluggable custom readers/writers for types not covered by the built-in scalar support (e.g. numpy list columns). Custom readers are passed at construction time and excluded from auto-detection — no core library changes needed to add new types.

This partially resolves #286 