### PR TITLE
Use autoconf 2.72 for macos builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -207,6 +207,10 @@ endif
 
 dependencies-mac:  ## install dependencies for mac
 	HOMEBREW_NO_AUTO_UPDATE=1 brew bundle install
+	brew tap-new local/old || true
+	brew extract --version=2.72 autoconf local/old
+	brew install local/old/autoconf@2.72
+	brew unlink autoconf && brew link --force autoconf@2.72
 	brew unlink bison flex && brew link --force bison flex
 
 dependencies-debian:  ## install dependencies for linux - note that zip is needed by bootstrap_vcpkg.sh, do not remove


### PR DESCRIPTION
### Problem

   All macOS CI builds are failing since the `macos-14` runner image upgraded from 14.8.4 to 14.8.5. The new image ships Homebrew with autoconf 2.73, which introduces stricter `AC_INIT` detection using word-boundary regex matching.

   The vcpkg krb5 1.22.1 port uses a custom `K5_AC_INIT` macro in `configure.ac` that expands to `AC_INIT` via m4 — but autoconf 2.73 scans for a literal `AC_INIT` token *before* m4 expansion, causing `autoreconf` to fail:


  autoreconf: error: configure.ac: AC_INIT not found; not an autoconf script?


   The upstream fix ([krb5/krb5@b7290e0c](https://github.com/krb5/krb5/commit/b7290e0cab5b)) replaces `K5_AC_INIT` with a literal `AC_INIT`, but it hasn't been included in any release yet.

   ### Fix

   Pin autoconf to 2.72 in the `dependencies-mac` Makefile target using `brew extract`, ensuring compatibility with krb5's `configure.ac` until the upstream fix is released.
