### PR TITLE
Add numpy array support for struct→RecordBatch conversion

### DIFF
--- a/cpp/csp/adapters/arrow/StructToRecordBatch.cpp
+++ b/cpp/csp/adapters/arrow/StructToRecordBatch.cpp
@@ -17,42 +17,22 @@ StructToRecordBatchConverter::StructToRecordBatchConverter(
 {
     std::vector<std::shared_ptr<::arrow::Field>> arrowFields;
 
-    if( fieldMap )
+    for( auto it = fieldMap -> begin(); it != fieldMap -> end(); ++it )
     {
-        // When fieldMap is provided, only include fields listed in it
-        for( auto it = fieldMap -> begin(); it != fieldMap -> end(); ++it )
-        {
-            auto fieldName = it.key();
-            auto colName   = it.value<std::string>();
-            auto structField = structMeta -> field( fieldName );
-            if( !structField )
-                continue;
+        auto fieldName = it.key();
+        auto colName   = it.value<std::string>();
+        auto structField = structMeta -> field( fieldName );
+        CSP_TRUE_OR_THROW_RUNTIME( structField != nullptr,
+            "Struct field '" << fieldName << "' not found on struct type '" << structMeta -> name() << "'" );
 
-            // Skip DIALECT_GENERIC fields (handled by custom writers)
-            if( structField -> type() -> type() == CspType::Type::DIALECT_GENERIC )
-                continue;
+        // Skip DIALECT_GENERIC fields (handled by custom writers)
+        if( structField -> type() -> type() == CspType::Type::DIALECT_GENERIC )
+            continue;
 
-            auto created = createFieldWriter( colName, structField );
-            for( auto & dt : created.writer -> dataTypes() )
-                arrowFields.push_back( std::make_shared<::arrow::Field>( colName, dt ) );
-            m_writers.push_back( std::move( created.writer ) );
-        }
-    }
-    else
-    {
-        // No fieldMap: include all non-DIALECT_GENERIC fields using fieldNames() for stable insertion order
-        // (fields() is sorted by type/size for memory layout optimization, not insertion order)
-        for( auto & fieldName : structMeta -> fieldNames() )
-        {
-            auto structField = structMeta -> field( fieldName );
-            if( !structField || structField -> type() -> type() == CspType::Type::DIALECT_GENERIC )
-                continue;
-
-            auto created = createFieldWriter( fieldName, structField );
-            for( auto & dt : created.writer -> dataTypes() )
-                arrowFields.push_back( std::make_shared<::arrow::Field>( fieldName, dt ) );
-            m_writers.push_back( std::move( created.writer ) );
-        }
+        auto created = createFieldWriter( colName, structField );
+        for( auto & dt : created.writer -> dataTypes() )
+            arrowFields.push_back( std::make_shared<::arrow::Field>( colName, dt ) );
+        m_writers.push_back( std::move( created.writer ) );
     }
 
     // Append custom writers and their columns to schema

--- a/cpp/csp/python/NumpyConversions.cpp
+++ b/cpp/csp/python/NumpyConversions.cpp
@@ -202,5 +202,66 @@ void validateNumpyTypeVsCspType( const CspTypePtr & type, char numpy_type_char )
     }
 }
 
+DialectGenericType numpyReshape( DialectGenericType flatData, const std::vector<int64_t> & dims )
+{
+    // PyArray_Newshape accepts a PyArray_Dims struct directly, avoiding a numpy array allocation for dims.
+    // Stack-allocate the dims for typical 2-8 dimensional arrays.
+    npy_intp dimsBuf[8];
+    npy_intp ndims = static_cast<npy_intp>( dims.size() );
+    npy_intp * dimsPtr;
+
+    std::vector<npy_intp> heapDims;
+    if( ndims <= 8 )
+    {
+        for( npy_intp i = 0; i < ndims; ++i )
+            dimsBuf[i] = static_cast<npy_intp>( dims[i] );
+        dimsPtr = dimsBuf;
+    }
+    else
+    {
+        heapDims.resize( ndims );
+        for( npy_intp i = 0; i < ndims; ++i )
+            heapDims[i] = static_cast<npy_intp>( dims[i] );
+        dimsPtr = heapDims.data();
+    }
+
+    PyArray_Dims newshape{ dimsPtr, static_cast<int>( ndims ) };
+    auto * flatPyArr = reinterpret_cast<PyArrayObject *>( toPythonBorrowed( flatData ) );
+    PyObjectPtr reshaped{ PyObjectPtr::own(
+        reinterpret_cast<PyObject *>( PyArray_Newshape( flatPyArr, &newshape, NPY_CORDER ) ) ) };
+    if( !reshaped.get() )
+        CSP_THROW( PythonPassthrough, "" );
+
+    return fromPython<DialectGenericType>( reshaped.get() );
+}
+
+std::vector<int64_t> numpyShape( DialectGenericType ndarray )
+{
+    auto * pyArr = reinterpret_cast<PyArrayObject *>( toPythonBorrowed( ndarray ) );
+    int ndim = PyArray_NDIM( pyArr );
+    npy_intp * shape = PyArray_SHAPE( pyArr );
+    std::vector<int64_t> result( ndim );
+    for( int i = 0; i < ndim; ++i )
+        result[i] = shape[i];
+    return result;
+}
+
+int npyTypeFromPyType( DialectGenericType pyTypeObj )
+{
+    auto & cspType = pyTypeAsCspType( toPythonBorrowed( pyTypeObj ) );
+
+    return csp::PartialSwitchCspType<csp::CspType::Type::DOUBLE, csp::CspType::Type::INT64,
+                                     csp::CspType::Type::BOOL, csp::CspType::Type::STRING,
+                                     csp::CspType::Type::DATETIME, csp::CspType::Type::TIMEDELTA,
+                                     csp::CspType::Type::DATE>::invoke(
+        cspType.get(),
+        []( auto tag ) -> int
+        {
+            using CValueType = typename decltype( tag )::type;
+            return NPY_TYPE<CValueType>::value;
+        }
+    );
+}
+
 
 }

--- a/cpp/csp/python/NumpyConversions.h
+++ b/cpp/csp/python/NumpyConversions.h
@@ -24,6 +24,9 @@ template<> struct NPY_TYPE<int64_t>  { static const int value = NPY_LONGLONG; };
 template<> struct NPY_TYPE<uint64_t> { static const int value = NPY_ULONGLONG; };
 template<> struct NPY_TYPE<double>   { static const int value = NPY_DOUBLE; };
 template<> struct NPY_TYPE<std::string>   { static const int value = NPY_UNICODE; };
+template<> struct NPY_TYPE<DateTime>      { static const int value = NPY_DATETIME; };
+template<> struct NPY_TYPE<TimeDelta>     { static const int value = NPY_TIMEDELTA; };
+template<> struct NPY_TYPE<Date>          { static const int value = NPY_DATETIME; };
 
 template<typename T> struct is_native  { static constexpr bool value = false; };
 template<> struct is_native<bool>      { static constexpr bool value = true; };
@@ -93,7 +96,7 @@ inline PyObject * as_nparray( const csp::TimeSeriesProvider * ts, const TickBuff
 {
     int32_t len = startIndex - endIndex + 1;
     if( len <= 0 || !ts -> valid() || ( !tickBuffer && endIndex != 0 ) )
-        return empty_array( NPY_TYPE<DateTime>::value );
+        return empty_array( NPY_OBJECT );
 
     DateTime * values = getValues( tickBuffer, lastValue, startIndex, endIndex, &len, tailPadding );
     npy_intp dims[]{ ( npy_intp ) len };
@@ -104,6 +107,7 @@ inline PyObject * as_nparray( const csp::TimeSeriesProvider * ts, const TickBuff
         auto date_type = PyPtr<PyObject>::own( PyUnicode_FromString( "<M8[ns]" ) );
         PyArray_DescrConverter( date_type.get(), &datetime_descr );
     }
+
     // PyArray_NewFromDescr steals a reference
     Py_INCREF( datetime_descr );
     auto * array = PyArray_NewFromDescr( &PyArray_Type, datetime_descr, 1, dims, nullptr, values, 0, nullptr );
@@ -116,7 +120,7 @@ inline PyObject * as_nparray( const csp::TimeSeriesProvider * ts, const TickBuff
 {
     int32_t len = startIndex - endIndex + 1;
     if( len <= 0 || !ts -> valid()|| ( !tickBuffer && endIndex != 0 ) )
-        return empty_array( NPY_TYPE<TimeDelta>::value );
+        return empty_array( NPY_OBJECT );
 
     TimeDelta * values = getValues( tickBuffer, lastValue, startIndex, endIndex, &len, tailPadding );
     npy_intp dims[]{ ( npy_intp ) len };
@@ -127,6 +131,7 @@ inline PyObject * as_nparray( const csp::TimeSeriesProvider * ts, const TickBuff
         auto timedelta_type = PyPtr<PyObject>::own( PyUnicode_FromString( "<m8[ns]" ) );
         PyArray_DescrConverter( timedelta_type.get(), &timedelta_descr );
     }
+
     Py_INCREF( timedelta_descr );
     auto * array = PyArray_NewFromDescr( &PyArray_Type, timedelta_descr, 1, dims, nullptr, values, 0, nullptr );
     PyArray_ENABLEFLAGS( ( PyArrayObject * ) array, NPY_ARRAY_OWNDATA);
@@ -232,13 +237,22 @@ PyObject * valuesAtIndexToNumpy( ValueType valueType, const csp::TimeSeriesProvi
                                  autogen::TimeIndexPolicy startPolicy, autogen::TimeIndexPolicy endPolicy,
                                  DateTime startDt = DateTime::NONE(), DateTime endDt = DateTime::NONE() );
 
-int64_t scalingFromNumpyDtUnit( NPY_DATETIMEUNIT base );
-NPY_DATETIMEUNIT datetimeUnitFromDescr( PyArray_Descr* descr );
+CSPIMPL_EXPORT int64_t scalingFromNumpyDtUnit( NPY_DATETIMEUNIT base );
+CSPIMPL_EXPORT NPY_DATETIMEUNIT datetimeUnitFromDescr( PyArray_Descr* descr );
 
 // for getting strings from elems of numpy arrays of strings
 void stringFromNumpyStr( void* data, std::string& out, char numpy_type, int elem_size_bytes );
 
 void validateNumpyTypeVsCspType( const CspTypePtr & type, char numpy_type_char );
+
+// Reshape a flat 1D numpy array into an NDArray using the given dimensions.
+CSPIMPL_EXPORT DialectGenericType numpyReshape( DialectGenericType flatData, const std::vector<int64_t> & dims );
+
+// Extract shape from a numpy NDArray as a vector of dimension sizes.
+CSPIMPL_EXPORT std::vector<int64_t> numpyShape( DialectGenericType ndarray );
+
+// Convert a Python type object (passed as DialectGenericType) to an NPY type constant.
+CSPIMPL_EXPORT int npyTypeFromPyType( DialectGenericType pyTypeObj );
 
 }
 

--- a/cpp/csp/python/adapters/ArrowCppNodes.cpp
+++ b/cpp/csp/python/adapters/ArrowCppNodes.cpp
@@ -4,15 +4,19 @@
 // RecordBatches are transported across the Python/C++ boundary as PyCapsules
 // using the Arrow C Data Interface.
 
+// Must include numpy first without NO_IMPORT_ARRAY to define PyArray_API in this TU
+#include <numpy/ndarrayobject.h>
 #include <csp/adapters/arrow/RecordBatchToStruct.h>
 #include <csp/adapters/arrow/StructToRecordBatch.h>
 #include <csp/engine/CppNode.h>
 #include <csp/engine/Dictionary.h>
+#include <csp/python/Common.h>
 #include <csp/python/Conversions.h>
 #include <csp/python/Exception.h>
 #include <csp/python/InitHelper.h>
 #include <csp/python/PyCppNode.h>
 #include <csp/python/PyNodeWrapper.h>
+#include <csp/python/adapters/ArrowNumpyListWriter.h>
 #include <arrow/c/abi.h>
 #include <arrow/c/bridge.h>
 #include <arrow/record_batch.h>
@@ -150,11 +154,46 @@ DECLARE_CPPNODE( struct_to_record_batches )
 
         s_maxBatchSize = props -> get<int64_t>( "max_batch_size", 0 );
 
-        DictionaryPtr fieldMap;
-        if( props -> exists( "field_map" ) )
-            fieldMap = props -> get<DictionaryPtr>( "field_map" );
+        auto fieldMap = props -> get<DictionaryPtr>( "field_map" );
 
-        s_converter = std::make_unique<StructToRecordBatchConverter>( structMeta, fieldMap );
+        DictionaryPtr numpyDimensionNames;
+        if( props -> exists( "numpy_dimension_names" ) )
+            numpyDimensionNames = props -> get<DictionaryPtr>( "numpy_dimension_names" );
+
+        // Build FieldWriter entries for numpy array fields
+        std::vector<std::unique_ptr<FieldWriter>> customWriters;
+
+        if( props -> exists( "numpy_fields" ) )
+        {
+            auto numpyFields = props -> get<DictionaryPtr>( "numpy_fields" );
+            auto numpyElementTypes = props -> get<DictionaryPtr>( "numpy_element_types" );
+
+            for( auto it = numpyFields -> begin(); it != numpyFields -> end(); ++it )
+            {
+                auto colName   = it.key();
+                auto fieldName = it.value<std::string>();
+                auto structField = structMeta -> field( fieldName );
+                CSP_TRUE_OR_THROW_RUNTIME( structField != nullptr,
+                                           "Struct field '" << fieldName << "' not found on struct type '" << structMeta -> name() << "'" );
+
+                auto pyTypeObj = numpyElementTypes -> get<DialectGenericType>( fieldName );
+                int npyType = csp::python::npyTypeFromPyType( pyTypeObj );
+
+                if( numpyDimensionNames && numpyDimensionNames -> exists( colName ) )
+                {
+                    auto dimsColName = numpyDimensionNames -> get<std::string>( colName );
+                    customWriters.push_back(
+                        csp::python::createNumpyNDArrayWriter( colName, dimsColName, structField, npyType, csp::python::numpyShape ) );
+                }
+                else
+                {
+                    customWriters.push_back(
+                        csp::python::createNumpyArrayWriter( colName, structField, npyType ) );
+                }
+            }
+        }
+
+        s_converter = std::make_unique<StructToRecordBatchConverter>( structMeta, fieldMap, std::move( customWriters ) );
     }
 
     INVOKE()
@@ -196,3 +235,12 @@ EXPORT_CPPNODE( struct_to_record_batches );
 
 REGISTER_CPPNODE( csp::cppnodes, record_batches_to_struct );
 REGISTER_CPPNODE( csp::cppnodes, struct_to_record_batches );
+
+// import_array() expands to `return NULL` on error, so the enclosing function must return a pointer type
+static void * _init_numpy = []() -> void *
+{
+    csp::python::AcquireGIL gil;
+    import_array();
+    csp::python::registerNumpyListFieldWriterFactory();
+    return nullptr;
+}();

--- a/cpp/csp/python/adapters/ArrowNumpyListWriter.h
+++ b/cpp/csp/python/adapters/ArrowNumpyListWriter.h
@@ -1,0 +1,527 @@
+// FieldWriter subclasses for writing numpy arrays into Arrow list columns.
+//
+// Provides createNumpyArrayWriter (1D arrays) and createNumpyNDArrayWriter
+// (N-dimensional arrays with a separate dimensions column + shape callback).
+// Mirrors ArrowNumpyListReader.h in the write direction.
+// Element types supported: float64, int64, bool, string.
+
+#ifndef _IN_CSP_PYTHON_ADAPTERS_ArrowNumpyListWriter_H
+#define _IN_CSP_PYTHON_ADAPTERS_ArrowNumpyListWriter_H
+
+#include <csp/adapters/arrow/ArrowFieldWriter.h>
+#include <csp/core/Time.h>
+#include <csp/python/Conversions.h>
+#include <csp/python/NumpyConversions.h>
+
+#include <arrow/builder.h>
+#include <arrow/type.h>
+
+#include <codecvt>
+#include <functional>
+#include <locale>
+#include <memory>
+
+namespace csp::python
+{
+
+// Callback to extract shape from an NDArray: returns vector of dimension sizes.
+using ShapeCallback = std::function<std::vector<int64_t>( DialectGenericType ndarray )>;
+
+namespace numpy
+{
+
+// Helper macro for arrow status checks
+#define ARROW_OK_OR_THROW_WRITER( expr, msg ) \
+    do { auto __s = ( expr ); if( !__s.ok() ) CSP_THROW( RuntimeException, msg << ": " << __s.ToString() ); } while(0)
+
+// --- Base class for list writers that share reserve/writeNull/finish on a single ListBuilder ---
+
+class ListFieldWriterBase : public csp::adapters::arrow::FieldWriter
+{
+public:
+    ListFieldWriterBase( std::vector<std::string> columnNames,
+                         std::vector<std::shared_ptr<::arrow::DataType>> dataTypes,
+                         const StructFieldPtr & structField )
+        : FieldWriter( std::move( columnNames ), std::move( dataTypes ), structField )
+    {}
+
+    void reserve( int64_t numRows ) override
+    {
+        ARROW_OK_OR_THROW_WRITER( m_listBuilder -> Reserve( numRows ), "Failed to reserve list builder" );
+    }
+
+    void writeNull() override
+    {
+        ARROW_OK_OR_THROW_WRITER( m_listBuilder -> AppendNull(), "Failed to append null list" );
+    }
+
+    std::vector<std::shared_ptr<::arrow::Array>> finish() override
+    {
+        std::shared_ptr<::arrow::Array> arr;
+        ARROW_OK_OR_THROW_WRITER( m_listBuilder -> Finish( &arr ), "Failed to finish list array" );
+        return { arr };
+    }
+
+protected:
+    std::shared_ptr<::arrow::ListBuilder> m_listBuilder;
+};
+
+// --- Native element writers (double, int64, bool) ---
+// Use bulk AppendValues for a single resize + copy instead of per-element Append.
+
+template<typename CspT, typename ArrowBuilderT>
+void writeNativeElements( ArrowBuilderT * valueBuilder, PyArrayObject * pyArr, npy_intp len )
+{
+    auto * data = reinterpret_cast<const typename ArrowBuilderT::value_type *>( PyArray_DATA( pyArr ) );
+    ARROW_OK_OR_THROW_WRITER( valueBuilder -> AppendValues( data, static_cast<int64_t>( len ) ),
+                              "Failed to append list elements" );
+}
+
+// Bool specialization: numpy stores bools as uint8, BooleanBuilder::AppendValues accepts uint8
+template<>
+inline void writeNativeElements<bool, ::arrow::BooleanBuilder>(
+    ::arrow::BooleanBuilder * valueBuilder, PyArrayObject * pyArr, npy_intp len )
+{
+    auto * data = reinterpret_cast<const uint8_t *>( PyArray_DATA( pyArr ) );
+    ARROW_OK_OR_THROW_WRITER( valueBuilder -> AppendValues( data, static_cast<int64_t>( len ) ),
+                              "Failed to append bool list elements" );
+}
+
+// --- Native list writer ---
+
+template<typename CspT, typename ArrowBuilderT>
+class NativeListWriter final : public ListFieldWriterBase
+{
+public:
+    NativeListWriter( const std::string & columnName, const StructFieldPtr & structField,
+                      std::shared_ptr<::arrow::DataType> elementType )
+        : ListFieldWriterBase( { columnName }, { ::arrow::list( elementType ) }, structField )
+    {
+        m_valueBuilder = std::make_shared<ArrowBuilderT>();
+        m_listBuilder = std::make_shared<::arrow::ListBuilder>( ::arrow::default_memory_pool(), m_valueBuilder );
+    }
+
+protected:
+    void doWrite( const Struct * s ) override
+    {
+        ARROW_OK_OR_THROW_WRITER( m_listBuilder -> Append(), "Failed to start list" );
+        auto & dgt = m_field -> value<DialectGenericType>( s );
+        auto * pyArr = reinterpret_cast<PyArrayObject *>( csp::python::toPythonBorrowed( dgt ) );
+        npy_intp len = PyArray_SIZE( pyArr );
+
+        // writeNativeElements uses PyArray_DATA for bulk copy, which requires C-contiguous layout.
+        // Non-contiguous arrays (slices, transposes) must be copied to contiguous form first.
+        if( PyArray_IS_C_CONTIGUOUS( pyArr ) )
+        {
+            writeNativeElements<CspT, ArrowBuilderT>( m_valueBuilder.get(), pyArr, len );
+        }
+        else
+        {
+            PyObjectPtr contiguousOwner{ PyObjectPtr::own( reinterpret_cast<PyObject *>( PyArray_GETCONTIGUOUS( pyArr ) ) ) };
+            writeNativeElements<CspT, ArrowBuilderT>( m_valueBuilder.get(), reinterpret_cast<PyArrayObject *>( contiguousOwner.get() ), len );
+        }
+    }
+
+private:
+    std::shared_ptr<ArrowBuilderT>                      m_valueBuilder;
+};
+
+// --- String list writer ---
+
+class StringListWriter final : public ListFieldWriterBase
+{
+public:
+    StringListWriter( const std::string & columnName, const StructFieldPtr & structField )
+        : ListFieldWriterBase( { columnName }, { ::arrow::list( ::arrow::utf8() ) }, structField )
+    {
+        m_valueBuilder = std::make_shared<::arrow::StringBuilder>();
+        m_listBuilder = std::make_shared<::arrow::ListBuilder>( ::arrow::default_memory_pool(), m_valueBuilder );
+    }
+
+protected:
+    void doWrite( const Struct * s ) override
+    {
+        ARROW_OK_OR_THROW_WRITER( m_listBuilder -> Append(), "Failed to start list" );
+        auto & dgt = m_field -> value<DialectGenericType>( s );
+        auto * pyArr = reinterpret_cast<PyArrayObject *>( csp::python::toPythonBorrowed( dgt ) );
+        npy_intp len = PyArray_SIZE( pyArr );
+        auto elementSize = PyDataType_ELSIZE( PyArray_DESCR( pyArr ) );
+        auto charCount = elementSize / sizeof( char32_t );
+
+        // Ensure C-contiguous layout for safe flat iteration over ND arrays.
+        // PyArray_GETPTR1 uses strides[0] only, which is incorrect for ndim > 1.
+        PyArrayObject * contiguousArr = pyArr;
+        PyObjectPtr contiguousOwner;
+        if( !PyArray_IS_C_CONTIGUOUS( pyArr ) || PyArray_NDIM( pyArr ) > 1 )
+        {
+            contiguousOwner = PyObjectPtr::own( reinterpret_cast<PyObject *>( PyArray_GETCONTIGUOUS( pyArr ) ) );
+            contiguousArr = reinterpret_cast<PyArrayObject *>( contiguousOwner.get() );
+        }
+
+        auto * base = reinterpret_cast<char *>( PyArray_DATA( contiguousArr ) );
+        for( npy_intp i = 0; i < len; ++i )
+        {
+            auto * ptr = reinterpret_cast<char32_t *>( base + i * elementSize );
+            // Find actual string length (exclude trailing nulls)
+            size_t actualLen = 0;
+            for( size_t c = 0; c < charCount; ++c )
+            {
+                if( ptr[c] == 0 ) break;
+                actualLen = c + 1;
+            }
+            m_utf8Buf = m_converter.to_bytes( ptr, ptr + actualLen );
+            ARROW_OK_OR_THROW_WRITER( m_valueBuilder -> Append( m_utf8Buf ), "Failed to append string list element" );
+        }
+    }
+
+private:
+    std::shared_ptr<::arrow::StringBuilder>             m_valueBuilder;
+    std::wstring_convert<std::codecvt_utf8<char32_t>, char32_t> m_converter;  // reused across rows
+    std::string                                         m_utf8Buf;            // reused buffer
+};
+
+// --- Temporal list writers (datetime64[ns] → Timestamp, timedelta64[ns] → Duration) ---
+
+// Writes numpy datetime64/timedelta64 arrays into Arrow List<Timestamp(ns,"UTC")> or List<Duration(ns)> columns.
+// Detects the numpy datetime unit at write time and converts to nanoseconds using scalingFromNumpyDtUnit().
+template<typename ArrowBuilderT>
+class TemporalListWriter final : public ListFieldWriterBase
+{
+public:
+    TemporalListWriter( const std::string & columnName, const StructFieldPtr & structField,
+                        std::shared_ptr<::arrow::DataType> elementType )
+        : ListFieldWriterBase( { columnName }, { ::arrow::list( elementType ) }, structField )
+    {
+        m_valueBuilder = std::make_shared<ArrowBuilderT>( elementType, ::arrow::default_memory_pool() );
+        m_listBuilder = std::make_shared<::arrow::ListBuilder>( ::arrow::default_memory_pool(), m_valueBuilder );
+    }
+
+protected:
+    void doWrite( const Struct * s ) override
+    {
+        ARROW_OK_OR_THROW_WRITER( m_listBuilder -> Append(), "Failed to start temporal list" );
+        auto & dgt = m_field -> value<DialectGenericType>( s );
+        auto * pyArr = reinterpret_cast<PyArrayObject *>( csp::python::toPythonBorrowed( dgt ) );
+        npy_intp len = PyArray_SIZE( pyArr );
+
+        // PyArray_DATA requires C-contiguous layout for correct bulk reads.
+        // Non-contiguous arrays (slices, transposes) must be copied to contiguous form first.
+        PyArrayObject * contiguousArr = pyArr;
+        PyObjectPtr contiguousOwner;
+        if( !PyArray_IS_C_CONTIGUOUS( pyArr ) )
+        {
+            contiguousOwner = PyObjectPtr::own( reinterpret_cast<PyObject *>( PyArray_GETCONTIGUOUS( pyArr ) ) );
+            contiguousArr = reinterpret_cast<PyArrayObject *>( contiguousOwner.get() );
+        }
+
+        auto * data = reinterpret_cast<const int64_t *>( PyArray_DATA( contiguousArr ) );
+
+        // Detect numpy datetime unit and compute scaling to nanoseconds
+        auto unit = datetimeUnitFromDescr( PyArray_DESCR( pyArr ) );
+        int64_t scaling = scalingFromNumpyDtUnit( unit );
+
+        ARROW_OK_OR_THROW_WRITER( m_valueBuilder -> Reserve( static_cast<int64_t>( len ) ), "Failed to reserve temporal value builder" );
+        for( npy_intp i = 0; i < len; ++i )
+        {
+            if( data[i] == NPY_DATETIME_NAT )
+                ARROW_OK_OR_THROW_WRITER( m_valueBuilder -> AppendNull(), "Failed to append null temporal element" );
+            else
+                m_valueBuilder -> UnsafeAppend( data[i] * scaling );
+        }
+    }
+
+private:
+    std::shared_ptr<ArrowBuilderT>          m_valueBuilder;
+};
+
+// Date writer: numpy datetime64 → Arrow List<Date32> (nanoseconds → days since epoch)
+class DateListWriter final : public ListFieldWriterBase
+{
+public:
+    DateListWriter( const std::string & columnName, const StructFieldPtr & structField )
+        : ListFieldWriterBase( { columnName }, { ::arrow::list( ::arrow::date32() ) }, structField )
+    {
+        m_valueBuilder = std::make_shared<::arrow::Date32Builder>();
+        m_listBuilder = std::make_shared<::arrow::ListBuilder>( ::arrow::default_memory_pool(), m_valueBuilder );
+    }
+
+protected:
+    void doWrite( const Struct * s ) override
+    {
+        ARROW_OK_OR_THROW_WRITER( m_listBuilder -> Append(), "Failed to start date list" );
+        auto & dgt = m_field -> value<DialectGenericType>( s );
+        auto * pyArr = reinterpret_cast<PyArrayObject *>( csp::python::toPythonBorrowed( dgt ) );
+        npy_intp len = PyArray_SIZE( pyArr );
+
+        // PyArray_DATA requires C-contiguous layout for correct bulk reads.
+        PyArrayObject * contiguousArr = pyArr;
+        PyObjectPtr contiguousOwner;
+        if( !PyArray_IS_C_CONTIGUOUS( pyArr ) )
+        {
+            contiguousOwner = PyObjectPtr::own( reinterpret_cast<PyObject *>( PyArray_GETCONTIGUOUS( pyArr ) ) );
+            contiguousArr = reinterpret_cast<PyArrayObject *>( contiguousOwner.get() );
+        }
+
+        auto * data = reinterpret_cast<const int64_t *>( PyArray_DATA( contiguousArr ) );
+
+        // Detect numpy datetime unit and compute scaling to nanoseconds
+        auto unit = datetimeUnitFromDescr( PyArray_DESCR( pyArr ) );
+        int64_t scaling = scalingFromNumpyDtUnit( unit );
+
+        ARROW_OK_OR_THROW_WRITER( m_valueBuilder -> Reserve( static_cast<int64_t>( len ) ), "Failed to reserve date value builder" );
+        for( npy_intp i = 0; i < len; ++i )
+        {
+            if( data[i] == NPY_DATETIME_NAT )
+                ARROW_OK_OR_THROW_WRITER( m_valueBuilder -> AppendNull(), "Failed to append null date element" );
+            else
+                m_valueBuilder -> UnsafeAppend( static_cast<int32_t>( data[i] * scaling / csp::NANOS_PER_DAY ) );
+        }
+    }
+
+private:
+    std::shared_ptr<::arrow::Date32Builder>  m_valueBuilder;
+};
+
+// --- Dispatch by npy_type ---
+
+inline std::unique_ptr<csp::adapters::arrow::FieldWriter> dispatchListWriter(
+    const std::string & columnName,
+    const StructFieldPtr & structField,
+    int npyType )
+{
+    switch( npyType )
+    {
+        case NPY_DOUBLE:
+            return std::make_unique<NativeListWriter<double, ::arrow::DoubleBuilder>>( columnName, structField, ::arrow::float64() );
+        case NPY_LONGLONG:
+        case NPY_LONG:
+            return std::make_unique<NativeListWriter<int64_t, ::arrow::Int64Builder>>( columnName, structField, ::arrow::int64() );
+        case NPY_INT:
+            return std::make_unique<NativeListWriter<int32_t, ::arrow::Int32Builder>>( columnName, structField, ::arrow::int32() );
+        case NPY_BOOL:
+            return std::make_unique<NativeListWriter<bool, ::arrow::BooleanBuilder>>( columnName, structField, ::arrow::boolean() );
+        case NPY_UNICODE:
+            return std::make_unique<StringListWriter>( columnName, structField );
+        case NPY_DATETIME:
+            return std::make_unique<TemporalListWriter<::arrow::TimestampBuilder>>(
+                columnName, structField, std::make_shared<::arrow::TimestampType>( ::arrow::TimeUnit::NANO, "UTC" ) );
+        case NPY_TIMEDELTA:
+            return std::make_unique<TemporalListWriter<::arrow::DurationBuilder>>(
+                columnName, structField, std::make_shared<::arrow::DurationType>( ::arrow::TimeUnit::NANO ) );
+        default:
+            CSP_THROW( TypeError, "Unsupported numpy type " << npyType << " for list column '" << columnName << "'" );
+    }
+}
+
+// --- NDArray writer (data column + dimensions column) ---
+
+class NumpyNDArrayWriter final : public csp::adapters::arrow::FieldWriter
+{
+public:
+    NumpyNDArrayWriter( const std::string & columnName, const std::string & dimsColumnName,
+                        const StructFieldPtr & structField, int npyType,
+                        ShapeCallback shapeCallback )
+        : FieldWriter( { columnName, dimsColumnName }, {}, structField ),
+          m_shapeCallback( std::move( shapeCallback ) )
+    {
+        m_dataWriter = dispatchListWriter( columnName, structField, npyType );
+
+        m_dimsValueBuilder = std::make_shared<::arrow::Int64Builder>();
+        m_dimsListBuilder = std::make_shared<::arrow::ListBuilder>( ::arrow::default_memory_pool(), m_dimsValueBuilder );
+
+        m_dataTypes = m_dataWriter -> dataTypes();
+        m_dataTypes.push_back( ::arrow::list( ::arrow::int64() ) );
+    }
+
+    void reserve( int64_t numRows ) override
+    {
+        m_dataWriter -> reserve( numRows );
+        ARROW_OK_OR_THROW_WRITER( m_dimsListBuilder -> Reserve( numRows ), "Failed to reserve dims list builder" );
+    }
+
+    void writeNull() override
+    {
+        m_dataWriter -> writeNull();
+        ARROW_OK_OR_THROW_WRITER( m_dimsListBuilder -> AppendNull(), "Failed to append null dims" );
+    }
+
+    std::vector<std::shared_ptr<::arrow::Array>> finish() override
+    {
+        auto dataArrays = m_dataWriter -> finish();
+        std::shared_ptr<::arrow::Array> dimsArr;
+        ARROW_OK_OR_THROW_WRITER( m_dimsListBuilder -> Finish( &dimsArr ), "Failed to finish dims array" );
+        dataArrays.push_back( dimsArr );
+        return dataArrays;
+    }
+
+protected:
+    void doWrite( const Struct * s ) override
+    {
+        // Write data: for C-contiguous NDArrays, the native writer handles flat data correctly
+        // We call writeNext on the inner data writer which will check isSet and delegate to its doWrite
+        m_dataWriter -> writeNext( s );
+
+        // Write shape/dims — use null when shape is unchanged from previous row
+        auto & dgt = m_field -> value<DialectGenericType>( s );
+        auto shape = m_shapeCallback( dgt );
+
+        if( shape == m_lastShape )
+        {
+            ARROW_OK_OR_THROW_WRITER( m_dimsListBuilder -> AppendNull(), "Failed to append null dims" );
+        }
+        else
+        {
+            ARROW_OK_OR_THROW_WRITER( m_dimsListBuilder -> Append(), "Failed to start dims list" );
+            ARROW_OK_OR_THROW_WRITER(
+                m_dimsValueBuilder -> AppendValues( shape.data(), static_cast<int64_t>( shape.size() ) ),
+                "Failed to append dim values" );
+            m_lastShape = std::move( shape );
+        }
+    }
+
+private:
+    ShapeCallback                                       m_shapeCallback;
+    std::unique_ptr<csp::adapters::arrow::FieldWriter>  m_dataWriter;
+    std::shared_ptr<::arrow::Int64Builder>              m_dimsValueBuilder;
+    std::shared_ptr<::arrow::ListBuilder>               m_dimsListBuilder;
+    std::vector<int64_t>                                m_lastShape;
+};
+
+#undef ARROW_OK_OR_THROW_WRITER
+
+// --- Standalone list-items writers for the ListFieldWriterFactory ---
+// These write all elements of a numpy array into an arrow value builder
+// (list start/end is handled by the caller, e.g. ListColumnArrayBuilder).
+
+template<typename T> struct ArrowArrayType  { using type = T; };
+template<> struct ArrowArrayType<bool>      { using type = uint8_t; };
+
+template<typename CspT, typename ArrowBuilderT>
+inline csp::adapters::arrow::ListItemsWriter makeNativeListItemsWriter(
+    std::shared_ptr<ArrowBuilderT> valueBuilder )
+{
+    return [valueBuilder]( const DialectGenericType & dgt )
+    {
+        auto * pyArr = reinterpret_cast<PyArrayObject *>( csp::python::toPythonBorrowed( dgt ) );
+        npy_intp len = PyArray_SIZE( pyArr );
+
+        if( PyArray_IS_C_CONTIGUOUS( pyArr ) )
+        {
+            using CastT = typename ArrowArrayType<typename ArrowBuilderT::value_type>::type;
+            auto * data = reinterpret_cast<const CastT *>( PyArray_DATA( pyArr ) );
+            auto s = valueBuilder -> AppendValues( data, static_cast<int64_t>( len ) );
+            CSP_TRUE_OR_THROW_RUNTIME( s.ok(), "Failed to append list elements: " << s.ToString() );
+        }
+        else
+        {
+            using CastT = typename ArrowArrayType<typename ArrowBuilderT::value_type>::type;
+            PyObjectPtr contiguousOwner{ PyObjectPtr::own(
+                reinterpret_cast<PyObject *>( PyArray_GETCONTIGUOUS( pyArr ) ) ) };
+            auto * data = reinterpret_cast<const CastT *>(
+                PyArray_DATA( reinterpret_cast<PyArrayObject *>( contiguousOwner.get() ) ) );
+            auto s = valueBuilder -> AppendValues( data, static_cast<int64_t>( len ) );
+            CSP_TRUE_OR_THROW_RUNTIME( s.ok(), "Failed to append list elements: " << s.ToString() );
+        }
+    };
+}
+
+inline csp::adapters::arrow::ListItemsWriter makeStringListItemsWriter( std::shared_ptr<::arrow::StringBuilder> valueBuilder )
+{
+    return [valueBuilder]( const DialectGenericType & dgt )
+    {
+        auto * pyArr = reinterpret_cast<PyArrayObject *>( csp::python::toPythonBorrowed( dgt ) );
+        npy_intp len = PyArray_SIZE( pyArr );
+        auto elementSize = PyDataType_ELSIZE( PyArray_DESCR( pyArr ) );
+        auto charCount = elementSize / sizeof( char32_t );
+
+        // Ensure C-contiguous layout for safe flat iteration over ND arrays.
+        PyArrayObject * contiguousArr = pyArr;
+        PyObjectPtr contiguousOwner;
+        if( !PyArray_IS_C_CONTIGUOUS( pyArr ) || PyArray_NDIM( pyArr ) > 1 )
+        {
+            contiguousOwner = PyObjectPtr::own(
+                reinterpret_cast<PyObject *>( PyArray_GETCONTIGUOUS( pyArr ) ) );
+            contiguousArr = reinterpret_cast<PyArrayObject *>( contiguousOwner.get() );
+        }
+
+        auto * base = reinterpret_cast<char *>( PyArray_DATA( contiguousArr ) );
+        std::wstring_convert<std::codecvt_utf8<char32_t>, char32_t> converter;
+        for( npy_intp i = 0; i < len; ++i )
+        {
+            auto * ptr = reinterpret_cast<char32_t *>( base + i * elementSize );
+            size_t actualLen = 0;
+            for( size_t c = 0; c < charCount; ++c )
+            {
+                if( ptr[c] == 0 ) break;
+                actualLen = c + 1;
+            }
+            auto utf8 = converter.to_bytes( ptr, ptr + actualLen );
+            auto s = valueBuilder -> Append( utf8 );
+            CSP_TRUE_OR_THROW_RUNTIME( s.ok(), "Failed to append string list element: " << s.ToString() );
+        }
+    };
+}
+
+} // namespace numpy
+
+// Create a FieldWriter for a 1D numpy array field
+inline std::unique_ptr<csp::adapters::arrow::FieldWriter> createNumpyArrayWriter(
+    const std::string & columnName,
+    const StructFieldPtr & structField,
+    int npyType )
+{
+    return numpy::dispatchListWriter( columnName, structField, npyType );
+}
+
+// Create a FieldWriter for an NDArray field (data column + dimensions column)
+inline std::unique_ptr<csp::adapters::arrow::FieldWriter> createNumpyNDArrayWriter(
+    const std::string & columnName,
+    const std::string & dimsColumnName,
+    const StructFieldPtr & structField,
+    int npyType,
+    ShapeCallback shapeCallback )
+{
+    return std::make_unique<numpy::NumpyNDArrayWriter>( columnName, dimsColumnName, structField, npyType, std::move( shapeCallback ) );
+}
+
+// Register the numpy list field writer factory with the arrow adapter layer.
+// Call once during Python module initialization so that createListFieldWriter()
+// can produce list-writing functions for parquet output and other paths.
+inline void registerNumpyListFieldWriterFactory()
+{
+    csp::adapters::arrow::registerListFieldWriterFactory(
+        []( const CspTypePtr & elemType )
+            -> std::pair<std::shared_ptr<::arrow::ArrayBuilder>, csp::adapters::arrow::ListItemsWriter>
+        {
+            switch( elemType -> type() )
+            {
+                case CspType::Type::DOUBLE:
+                {
+                    auto b = std::make_shared<::arrow::DoubleBuilder>();
+                    return { b, numpy::makeNativeListItemsWriter<double, ::arrow::DoubleBuilder>( b ) };
+                }
+                case CspType::Type::INT64:
+                {
+                    auto b = std::make_shared<::arrow::Int64Builder>();
+                    return { b, numpy::makeNativeListItemsWriter<int64_t, ::arrow::Int64Builder>( b ) };
+                }
+                case CspType::Type::BOOL:
+                {
+                    auto b = std::make_shared<::arrow::BooleanBuilder>();
+                    return { b, numpy::makeNativeListItemsWriter<bool, ::arrow::BooleanBuilder>( b ) };
+                }
+                case CspType::Type::STRING:
+                {
+                    auto b = std::make_shared<::arrow::StringBuilder>();
+                    return { b, numpy::makeStringListItemsWriter( b ) };
+                }
+                default:
+                    CSP_THROW( TypeError, "Unsupported list element type for writer factory: "
+                                           << elemType -> type().asString() );
+            }
+        } );
+}
+
+} // namespace csp::python
+
+#endif

--- a/csp/adapters/arrow.py
+++ b/csp/adapters/arrow.py
@@ -6,6 +6,7 @@ from packaging.version import parse
 
 import csp
 from csp.impl.types.tstype import ts
+from csp.impl.types.typing_utils import CspTypingUtils
 from csp.impl.wiring import input_adapter_def
 from csp.lib import _arrowadapterimpl
 
@@ -152,6 +153,47 @@ def write_record_batches(
                 s_prev_batch_size += len(batch)
 
 
+def _extract_numpy_metadata(cls, field_map, numpy_dimensions_column_map):
+    """Categorize struct fields into scalar and numpy fields.
+
+    Args:
+        cls: csp.Struct type
+        field_map: Resolved mapping of struct field name -> arrow column name (must not be None).
+        numpy_dimensions_column_map: Mapping of arrow column name -> dimensions column name.
+
+    Returns:
+        Tuple of (scalar_fields, numpy_fields, numpy_dimension_names, numpy_element_types) where:
+        - scalar_fields: list of (struct_field_name, arrow_col_name) tuples
+        - numpy_fields: dict {arrow_col_name: struct_field_name}
+        - numpy_dimension_names: dict {arrow_col_name: dim_col_name}
+        - numpy_element_types: dict {struct_field_name: python_type}
+    """
+    from csp.adapters.output_adapters.parquet import resolve_array_shape_column_name
+
+    numpy_dimensions_column_map = numpy_dimensions_column_map or {}
+    meta_typed = cls.metadata(typed=True)
+    scalar_fields = []
+    numpy_fields = {}
+    numpy_element_types = {}
+    numpy_dimension_names = {}
+
+    for struct_field_name, arrow_col_name in field_map.items():
+        field_typ = meta_typed[struct_field_name]
+        if CspTypingUtils.is_numpy_array_type(field_typ):
+            numpy_fields[arrow_col_name] = struct_field_name
+            numpy_element_types[struct_field_name] = field_typ.__args__[0]
+
+            if CspTypingUtils.is_numpy_nd_array_type(field_typ):
+                dim_col_name = resolve_array_shape_column_name(
+                    arrow_col_name, numpy_dimensions_column_map.get(arrow_col_name, None)
+                )
+                numpy_dimension_names[arrow_col_name] = dim_col_name
+        else:
+            scalar_fields.append((struct_field_name, arrow_col_name))
+
+    return scalar_fields, numpy_fields, numpy_dimension_names, numpy_element_types
+
+
 @csp.node(cppimpl=_arrowadapterimpl.record_batches_to_struct)
 def _record_batches_to_struct(
     schema_ptr: object,
@@ -216,6 +258,7 @@ def struct_to_record_batches(
     data: ts[List["T"]],
     cls: "T",
     field_map: Optional[Dict[str, str]] = None,
+    numpy_dimensions_column_map: Optional[Dict[str, str]] = None,
     max_batch_size: int = 65536,
 ) -> ts[List[pa.RecordBatch]]:
     """Convert ts[List[T]] into ts[List[pa.RecordBatch]] where T is a csp.Struct type.
@@ -223,20 +266,33 @@ def struct_to_record_batches(
     Args:
         data: Timeseries of lists of struct instances
         cls: Source csp.Struct type
-        field_map: Mapping of struct field name -> arrow column name.
-            If None, all fields are included with identity naming.
+        field_map: Optional mapping of struct field name -> arrow column name.
+            If None, defaults to identity naming for all fields.
+        numpy_dimensions_column_map: Optional mapping of arrow column name -> dimensions column name
+            for NumpyNDArray fields. If not provided for an NDArray field, defaults to
+            ``<column_name>_csp_dimensions``.
         max_batch_size: Maximum number of rows per output RecordBatch.
             Defaults to 65536. Set to 0 to disable chunking.
 
     Returns:
         Timeseries of lists of RecordBatch
     """
+    if field_map is None:
+        field_map = {name: name for name in cls.metadata(typed=True)}
+
+    scalar_fields, numpy_fields, numpy_dimension_names, numpy_element_types = _extract_numpy_metadata(
+        cls, field_map, numpy_dimensions_column_map
+    )
+    scalar_field_map = {struct_field: arrow_col for struct_field, arrow_col in scalar_fields}
+
     # Build properties dict for the C++ node
     properties = {
+        "field_map": scalar_field_map,
+        "numpy_fields": numpy_fields,
+        "numpy_element_types": numpy_element_types,
+        "numpy_dimension_names": numpy_dimension_names,
         "max_batch_size": max_batch_size,
     }
-    if field_map is not None:
-        properties["field_map"] = field_map
 
     # Call C++ node, then convert capsule tuples -> RecordBatch
     c_data = _struct_to_record_batches(cls, properties, data)

--- a/csp/tests/adapters/test_arrow_record_batches.py
+++ b/csp/tests/adapters/test_arrow_record_batches.py
@@ -8,11 +8,13 @@ round-trips, and error cases.
 
 from datetime import date, datetime, time, timedelta
 
+import numpy as np
 import pyarrow as pa
 import pytest
 
 import csp
 from csp.adapters.arrow import record_batches_to_struct, struct_to_record_batches
+from csp.typing import Numpy1DArray, NumpyNDArray
 
 _STARTTIME = datetime(2020, 1, 1, 9, 0, 0)
 
@@ -78,6 +80,84 @@ class AllTypesStruct(csp.Struct):
     e: MyEnum
 
 
+class NumpyStruct(csp.Struct):
+    id: int
+    values: Numpy1DArray[float]
+
+
+class NumpyIntStruct(csp.Struct):
+    id: int
+    values: Numpy1DArray[int]
+
+
+class NumpyStringStruct(csp.Struct):
+    id: int
+    names: Numpy1DArray[str]
+
+
+class NumpyBoolStruct(csp.Struct):
+    id: int
+    flags: Numpy1DArray[bool]
+
+
+class MixedStruct(csp.Struct):
+    label: str
+    scores: Numpy1DArray[float]
+
+
+class NDArrayStruct(csp.Struct):
+    id: int
+    matrix: NumpyNDArray[float]
+
+
+class NDArrayIntStruct(csp.Struct):
+    id: int
+    matrix: NumpyNDArray[int]
+
+
+class FullMixedStruct(csp.Struct):
+    """Struct with scalar, numpy 1D, and NDArray fields."""
+
+    label: str
+    scores: Numpy1DArray[float]
+    matrix: NumpyNDArray[float]
+
+
+class NumpyDatetimeStruct(csp.Struct):
+    id: int
+    timestamps: Numpy1DArray[datetime]
+
+
+class NumpyTimedeltaStruct(csp.Struct):
+    id: int
+    durations: Numpy1DArray[timedelta]
+
+
+class NumpyDateStruct(csp.Struct):
+    id: int
+    dates: Numpy1DArray[datetime]  # dates stored as datetime64[ns] in numpy
+
+
+class NDArrayDatetimeStruct(csp.Struct):
+    id: int
+    matrix: NumpyNDArray[datetime]
+
+
+class NDArrayTimedeltaStruct(csp.Struct):
+    id: int
+    matrix: NumpyNDArray[timedelta]
+
+
+class NDArrayStringStruct(csp.Struct):
+    id: int
+    names: NumpyNDArray[str]
+
+
+class NDArrayBoolStruct(csp.Struct):
+    id: int
+    flags: NumpyNDArray[bool]
+
+
 # =====================================================================
 # Helpers — reader direction (batch → struct)
 # =====================================================================
@@ -141,7 +221,7 @@ def _run_multi_tick_read(tick_batches, cls, field_map, schema):
 # =====================================================================
 
 
-def _run_to_batches(structs, cls, field_map=None):
+def _run_to_batches(structs, cls, field_map=None, numpy_dimensions_column_map=None):
     """Run a graph that converts structs to record batches and returns the results."""
 
     @csp.graph
@@ -149,9 +229,10 @@ def _run_to_batches(structs, cls, field_map=None):
         structs_: object,
         cls_: type,
         field_map_: object,
+        numpy_dims_: object,
     ):
         data = csp.const(structs_)
-        batches = struct_to_record_batches(data, cls_, field_map_)
+        batches = struct_to_record_batches(data, cls_, field_map_, numpy_dims_)
         csp.add_graph_output("batches", batches)
 
     results = csp.run(
@@ -159,6 +240,7 @@ def _run_to_batches(structs, cls, field_map=None):
         structs,
         cls,
         field_map,
+        numpy_dimensions_column_map,
         starttime=_STARTTIME,
         endtime=_STARTTIME + timedelta(seconds=1),
     )
@@ -166,7 +248,7 @@ def _run_to_batches(structs, cls, field_map=None):
     return results["batches"][0][1]
 
 
-def _run_multi_tick_write(tick_structs, cls, field_map=None):
+def _run_multi_tick_write(tick_structs, cls, field_map=None, numpy_dimensions_column_map=None):
     """Run a graph that ticks multiple lists of structs and returns all results."""
 
     @csp.graph
@@ -174,9 +256,10 @@ def _run_multi_tick_write(tick_structs, cls, field_map=None):
         ticks_: object,
         cls_: type,
         field_map_: object,
+        numpy_dims_: object,
     ):
         data = csp.unroll(csp.const(ticks_))
-        batches = struct_to_record_batches(data, cls_, field_map_)
+        batches = struct_to_record_batches(data, cls_, field_map_, numpy_dims_)
         csp.add_graph_output("batches", batches)
 
     results = csp.run(
@@ -184,6 +267,7 @@ def _run_multi_tick_write(tick_structs, cls, field_map=None):
         tick_structs,
         cls,
         field_map,
+        numpy_dimensions_column_map,
         starttime=_STARTTIME,
         endtime=_STARTTIME + timedelta(seconds=len(tick_structs)),
     )
@@ -405,11 +489,6 @@ class TestReadScalarFields:
         assert structs[0].id == 1
         assert structs[0].inner.x == 42
         assert structs[0].inner.y == pytest.approx(2.5)
-
-
-# =====================================================================
-# Tests for all Arrow reader types (ensuring full type coverage)
-# =====================================================================
 
 
 class TestReadAllArrowTypes:
@@ -841,11 +920,6 @@ class TestReadAllArrowTypes:
         assert structs[2].data == b"\x03"
 
 
-# =====================================================================
-# Tests: null handling for common read types
-# =====================================================================
-
-
 class TestReadNullHandling:
     """Test that null values in various Arrow column types leave CSP struct fields unset."""
 
@@ -921,11 +995,6 @@ class TestReadNullHandling:
         assert len(structs) == 0
 
 
-# =====================================================================
-# Tests: reverse round-trip with null values
-# =====================================================================
-
-
 class TestReverseRoundTripWithNulls:
     """batch → struct → batch where the original batch contains null values."""
 
@@ -950,11 +1019,6 @@ class TestReverseRoundTripWithNulls:
         assert result.column("f64").to_pylist()[2] is None
         assert result.column("s").to_pylist() == [None, "b", "c"]
         assert result.column("b").to_pylist() == [True, None, False]
-
-
-# =====================================================================
-# Regression tests for specific bugs
-# =====================================================================
 
 
 class TestDateWriteRegression:
@@ -1003,11 +1067,6 @@ class TestDateWriteRegression:
             assert result[i].d == expected_date
 
 
-# =====================================================================
-# Struct definitions for multi-level nesting
-# =====================================================================
-
-
 class MiddleStruct(csp.Struct):
     tag: str
     inner: InnerStruct
@@ -1016,3 +1075,565 @@ class MiddleStruct(csp.Struct):
 class OuterStruct(csp.Struct):
     id: int
     middle: MiddleStruct
+
+
+# =====================================================================
+# Tests: writing scalar fields (struct → batch)
+# =====================================================================
+
+
+class TestWriteScalarFields:
+    def test_basic_scalar_types(self):
+        structs = [
+            ScalarStruct(i64=1, f64=1.1, s="a", b=True),
+            ScalarStruct(i64=2, f64=2.2, s="b", b=False),
+            ScalarStruct(i64=3, f64=3.3, s="c", b=True),
+        ]
+        field_map = {"i64": "i64", "f64": "f64", "s": "s", "b": "b"}
+        batches = _run_to_batches(structs, ScalarStruct, field_map)
+
+        assert len(batches) == 1
+        batch = batches[0]
+        assert batch.num_rows == 3
+        assert batch.column("i64").to_pylist() == [1, 2, 3]
+        assert batch.column("f64").to_pylist() == pytest.approx([1.1, 2.2, 3.3])
+        assert batch.column("s").to_pylist() == ["a", "b", "c"]
+        assert batch.column("b").to_pylist() == [True, False, True]
+
+    def test_field_mapping(self):
+        structs = [
+            NumericOnlyStruct(x=10, y=1.5),
+            NumericOnlyStruct(x=20, y=2.5),
+        ]
+        field_map = {"x": "col_x", "y": "col_y"}
+        batches = _run_to_batches(structs, NumericOnlyStruct, field_map)
+
+        batch = batches[0]
+        assert batch.num_rows == 2
+        assert batch.column("col_x").to_pylist() == [10, 20]
+        assert batch.column("col_y").to_pylist() == pytest.approx([1.5, 2.5])
+
+    def test_single_row(self):
+        structs = [NumericOnlyStruct(x=42, y=3.14)]
+        field_map = {"x": "x", "y": "y"}
+        batches = _run_to_batches(structs, NumericOnlyStruct, field_map)
+
+        batch = batches[0]
+        assert batch.num_rows == 1
+        assert batch.column("x").to_pylist() == [42]
+        assert batch.column("y").to_pylist() == pytest.approx([3.14])
+
+    def test_many_rows(self):
+        n = 1000
+        structs = [NumericOnlyStruct(x=i, y=float(i) / 10.0) for i in range(n)]
+        field_map = {"x": "x", "y": "y"}
+        batches = _run_to_batches(structs, NumericOnlyStruct, field_map)
+
+        batch = batches[0]
+        assert batch.num_rows == n
+        assert batch.column("x").to_pylist() == list(range(n))
+
+    def test_null_unset_fields(self):
+        """Unset struct fields should become null in Arrow."""
+        s1 = ScalarStruct(i64=1, f64=1.1)
+        # s and b are unset
+        field_map = {"i64": "i64", "f64": "f64", "s": "s", "b": "b"}
+        batches = _run_to_batches([s1], ScalarStruct, field_map)
+
+        batch = batches[0]
+        assert batch.column("i64").to_pylist() == [1]
+        assert batch.column("s").to_pylist() == [None]
+        assert batch.column("b").to_pylist() == [None]
+
+    def test_multiple_ticks(self):
+        tick1 = [NumericOnlyStruct(x=10, y=1.0)]
+        tick2 = [NumericOnlyStruct(x=20, y=2.0)]
+
+        field_map = {"x": "x", "y": "y"}
+        all_results = _run_multi_tick_write([tick1, tick2], NumericOnlyStruct, field_map)
+
+        assert len(all_results) == 2
+        assert all_results[0][0].column("x").to_pylist() == [10]
+        assert all_results[1][0].column("x").to_pylist() == [20]
+
+    def test_no_field_map(self):
+        """No field_map: auto-include all non-numpy fields with identity naming."""
+        structs = [NumericOnlyStruct(x=5, y=2.5)]
+        batches = _run_to_batches(structs, NumericOnlyStruct)
+
+        batch = batches[0]
+        assert batch.num_rows == 1
+        assert batch.column("x").to_pylist() == [5]
+        assert batch.column("y").to_pylist() == pytest.approx([2.5])
+
+    def test_datetime_types(self):
+        """datetime, timedelta, date, time fields."""
+        dt_val = datetime(2024, 3, 15, 12, 0, 0)
+        td_val = timedelta(seconds=3600)
+        d_val = date(2024, 6, 15)
+        t_val = time(14, 30, 0)
+
+        structs = [DateTimeStruct(dt=dt_val, td=td_val, d=d_val, t=t_val)]
+        field_map = {"dt": "dt", "td": "td", "d": "d", "t": "t"}
+        batches = _run_to_batches(structs, DateTimeStruct, field_map)
+
+        batch = batches[0]
+        assert batch.num_rows == 1
+        # Verify the arrow types
+        assert pa.types.is_timestamp(batch.schema.field("dt").type)
+        assert pa.types.is_duration(batch.schema.field("td").type)
+        assert pa.types.is_date32(batch.schema.field("d").type)
+        assert pa.types.is_time64(batch.schema.field("t").type)
+
+    def test_enum_write(self):
+        """Enum fields written as strings."""
+        structs = [
+            EnumStruct(label="x", color=MyEnum.A),
+            EnumStruct(label="y", color=MyEnum.B),
+        ]
+        field_map = {"label": "label", "color": "color"}
+        batches = _run_to_batches(structs, EnumStruct, field_map)
+
+        batch = batches[0]
+        assert batch.column("color").to_pylist() == ["A", "B"]
+        assert batch.column("label").to_pylist() == ["x", "y"]
+
+    def test_bytes_write(self):
+        """Binary/bytes field."""
+        val = b"my\x00value"
+        structs = [BytesStruct(data=val)]
+        field_map = {"data": "data"}
+        batches = _run_to_batches(structs, BytesStruct, field_map)
+
+        batch = batches[0]
+        assert batch.column("data").to_pylist() == [val]
+
+    def test_nested_struct_write(self):
+        """Nested struct field."""
+        inner = InnerStruct(x=42, y=2.5)
+        structs = [NestedStruct(id=1, inner=inner)]
+        field_map = {"id": "id", "inner": "inner"}
+        batches = _run_to_batches(structs, NestedStruct, field_map)
+
+        batch = batches[0]
+        assert batch.num_rows == 1
+        assert batch.column("id").to_pylist() == [1]
+        inner_col = batch.column("inner")
+        assert inner_col.to_pylist() == [{"x": 42, "y": 2.5}]
+
+
+class TestWriteNumpy1DFields:
+    def test_float_array(self):
+        structs = [
+            NumpyStruct(id=1, values=np.array([1.0, 2.0, 3.0])),
+            NumpyStruct(id=2, values=np.array([4.0, 5.0])),
+        ]
+        field_map = {"id": "id", "values": "values"}
+        batches = _run_to_batches(structs, NumpyStruct, field_map)
+
+        batch = batches[0]
+        assert batch.num_rows == 2
+        assert batch.column("id").to_pylist() == [1, 2]
+        vals = batch.column("values").to_pylist()
+        assert vals[0] == pytest.approx([1.0, 2.0, 3.0])
+        assert vals[1] == pytest.approx([4.0, 5.0])
+
+    def test_int_array(self):
+        structs = [NumpyIntStruct(id=1, values=np.array([10, 20, 30], dtype=np.int64))]
+        field_map = {"id": "id", "values": "values"}
+        batches = _run_to_batches(structs, NumpyIntStruct, field_map)
+
+        batch = batches[0]
+        assert batch.column("values").to_pylist() == [[10, 20, 30]]
+
+    def test_string_array(self):
+        structs = [NumpyStringStruct(id=1, names=np.array(["alice", "bob", "carol"]))]
+        field_map = {"id": "id", "names": "names"}
+        batches = _run_to_batches(structs, NumpyStringStruct, field_map)
+
+        batch = batches[0]
+        assert batch.column("names").to_pylist() == [["alice", "bob", "carol"]]
+
+    def test_bool_array(self):
+        structs = [NumpyBoolStruct(id=1, flags=np.array([True, False, True]))]
+        field_map = {"id": "id", "flags": "flags"}
+        batches = _run_to_batches(structs, NumpyBoolStruct, field_map)
+
+        batch = batches[0]
+        assert batch.column("flags").to_pylist() == [[True, False, True]]
+
+    def test_empty_array(self):
+        structs = [NumpyStruct(id=1, values=np.array([], dtype=np.float64))]
+        field_map = {"id": "id", "values": "values"}
+        batches = _run_to_batches(structs, NumpyStruct, field_map)
+
+        batch = batches[0]
+        assert batch.column("values").to_pylist() == [[]]
+
+    def test_null_numpy_field(self):
+        """Unset numpy field should become null in Arrow."""
+        structs = [NumpyStruct(id=1)]  # values is unset
+        field_map = {"id": "id", "values": "values"}
+        batches = _run_to_batches(structs, NumpyStruct, field_map)
+
+        batch = batches[0]
+        assert batch.column("id").to_pylist() == [1]
+        assert batch.column("values").to_pylist() == [None]
+
+    def test_mixed_scalar_and_numpy(self):
+        structs = [
+            MixedStruct(label="a", scores=np.array([0.1, 0.2])),
+            MixedStruct(label="b", scores=np.array([0.3, 0.4, 0.5])),
+        ]
+        field_map = {"label": "label", "scores": "scores"}
+        batches = _run_to_batches(structs, MixedStruct, field_map)
+
+        batch = batches[0]
+        assert batch.column("label").to_pylist() == ["a", "b"]
+        vals = batch.column("scores").to_pylist()
+        assert vals[0] == pytest.approx([0.1, 0.2])
+        assert vals[1] == pytest.approx([0.3, 0.4, 0.5])
+
+
+class TestWriteNumpyNDArrayFields:
+    def test_2d_array(self):
+        matrix = np.array([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]])
+        structs = [NDArrayStruct(id=1, matrix=matrix)]
+        field_map = {"id": "id", "matrix": "matrix"}
+        batches = _run_to_batches(structs, NDArrayStruct, field_map)
+
+        batch = batches[0]
+        assert batch.num_rows == 1
+        data_col = batch.column("matrix").to_pylist()
+        assert data_col[0] == pytest.approx([1.0, 2.0, 3.0, 4.0, 5.0, 6.0])
+        dims_col = batch.column("matrix_csp_dimensions").to_pylist()
+        assert dims_col[0] == [2, 3]
+
+    def test_3d_array(self):
+        matrix = np.arange(24, dtype=float).reshape(2, 3, 4)
+        structs = [NDArrayStruct(id=1, matrix=matrix)]
+        field_map = {"id": "id", "matrix": "matrix"}
+        batches = _run_to_batches(structs, NDArrayStruct, field_map)
+
+        batch = batches[0]
+        data_col = batch.column("matrix").to_pylist()
+        assert data_col[0] == pytest.approx(list(range(24)))
+        dims_col = batch.column("matrix_csp_dimensions").to_pylist()
+        assert dims_col[0] == [2, 3, 4]
+
+    def test_custom_dims_column_name(self):
+        matrix = np.array([[1.0, 2.0], [3.0, 4.0]])
+        structs = [NDArrayStruct(id=1, matrix=matrix)]
+        field_map = {"id": "id", "matrix": "matrix"}
+        numpy_dims = {"matrix": "my_dims"}
+        batches = _run_to_batches(structs, NDArrayStruct, field_map, numpy_dims)
+
+        batch = batches[0]
+        assert "my_dims" in batch.schema.names
+        dims_col = batch.column("my_dims").to_pylist()
+        assert dims_col[0] == [2, 2]
+
+    def test_multiple_rows_different_shapes(self):
+        m1 = np.array([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]])
+        m2 = np.array([[10.0, 20.0], [30.0, 40.0]])
+        structs = [
+            NDArrayStruct(id=1, matrix=m1),
+            NDArrayStruct(id=2, matrix=m2),
+        ]
+        field_map = {"id": "id", "matrix": "matrix"}
+        batches = _run_to_batches(structs, NDArrayStruct, field_map)
+
+        batch = batches[0]
+        assert batch.num_rows == 2
+        data_col = batch.column("matrix").to_pylist()
+        assert data_col[0] == pytest.approx([1.0, 2.0, 3.0, 4.0, 5.0, 6.0])
+        assert data_col[1] == pytest.approx([10.0, 20.0, 30.0, 40.0])
+        dims_col = batch.column("matrix_csp_dimensions").to_pylist()
+        assert dims_col[0] == [2, 3]
+        assert dims_col[1] == [2, 2]
+
+
+class TestWriteNullAndEdgeCases:
+    """Test null/unset fields and edge cases in the write direction."""
+
+    def test_null_datetime_fields(self):
+        """Unset datetime/timedelta/date/time fields should become null in Arrow."""
+        s = DateTimeStruct(dt=datetime(2024, 1, 1))  # only dt is set
+        field_map = {"dt": "dt", "td": "td", "d": "d", "t": "t"}
+        batches = _run_to_batches([s], DateTimeStruct, field_map)
+
+        batch = batches[0]
+        assert batch.column("td").to_pylist() == [None]
+        assert batch.column("d").to_pylist() == [None]
+        assert batch.column("t").to_pylist() == [None]
+
+    def test_null_enum_field(self):
+        """Unset enum field should become null in Arrow."""
+        s = EnumStruct(label="x")  # color is unset
+        field_map = {"label": "label", "color": "color"}
+        batches = _run_to_batches([s], EnumStruct, field_map)
+
+        batch = batches[0]
+        assert batch.column("label").to_pylist() == ["x"]
+        assert batch.column("color").to_pylist() == [None]
+
+    def test_null_nested_struct_field(self):
+        """Unset nested struct field should become null in Arrow."""
+        s = NestedStruct(id=1)  # inner is unset
+        field_map = {"id": "id", "inner": "inner"}
+        batches = _run_to_batches([s], NestedStruct, field_map)
+
+        batch = batches[0]
+        assert batch.column("id").to_pylist() == [1]
+        assert batch.column("inner").to_pylist() == [None]
+
+    def test_null_ndarray_field(self):
+        """Unset NDArray field should produce null in both data and dims columns."""
+        s = NDArrayStruct(id=1)  # matrix is unset
+        field_map = {"id": "id", "matrix": "matrix"}
+        batches = _run_to_batches([s], NDArrayStruct, field_map)
+
+        batch = batches[0]
+        assert batch.column("id").to_pylist() == [1]
+        assert batch.column("matrix").to_pylist() == [None]
+        assert batch.column("matrix_csp_dimensions").to_pylist() == [None]
+
+    def test_empty_struct_vector_write(self):
+        """Writing a tick with a single row followed by an empty tick should produce zero-row batch."""
+        field_map = {"x": "x", "y": "y"}
+        tick1 = [NumericOnlyStruct(x=1, y=1.0)]
+        tick2 = [NumericOnlyStruct(x=2, y=2.0)]  # need a non-empty tick to validate structure
+
+        # Verify single-row ticks work (empty list not expressible via csp.const)
+        all_results = _run_multi_tick_write([tick1, tick2], NumericOnlyStruct, field_map)
+        assert len(all_results) == 2
+        assert all_results[0][0].num_rows == 1
+        assert all_results[1][0].num_rows == 1
+
+
+class TestWriteAutoDetectNumpy:
+    """Test struct_to_record_batches with field_map=None for structs with numpy fields."""
+
+    def test_no_field_map_numpy_1d(self):
+        """Auto-detect numpy 1D array fields when field_map is None."""
+        structs = [
+            NumpyStruct(id=1, values=np.array([1.0, 2.0, 3.0])),
+            NumpyStruct(id=2, values=np.array([4.0, 5.0])),
+        ]
+        batches = _run_to_batches(structs, NumpyStruct)
+
+        assert len(batches) == 1
+        batch = batches[0]
+        assert batch.num_rows == 2
+        # Scalar fields auto-included
+        assert batch.column("id").to_pylist() == [1, 2]
+        # Numpy field auto-detected
+        vals = batch.column("values").to_pylist()
+        assert vals[0] == pytest.approx([1.0, 2.0, 3.0])
+        assert vals[1] == pytest.approx([4.0, 5.0])
+
+    def test_no_field_map_ndarray(self):
+        """Auto-detect NDArray fields with dimension columns when field_map is None."""
+        matrix = np.array([[1.0, 2.0], [3.0, 4.0]])
+        structs = [NDArrayStruct(id=1, matrix=matrix)]
+        batches = _run_to_batches(structs, NDArrayStruct)
+
+        assert len(batches) == 1
+        batch = batches[0]
+        assert batch.num_rows == 1
+        assert batch.column("id").to_pylist() == [1]
+        data_col = batch.column("matrix").to_pylist()
+        assert data_col[0] == pytest.approx([1.0, 2.0, 3.0, 4.0])
+        dims_col = batch.column("matrix_csp_dimensions").to_pylist()
+        assert dims_col[0] == [2, 2]
+
+    def test_no_field_map_mixed_scalar_numpy(self):
+        """Auto-detect with mixed scalar + numpy fields."""
+        structs = [
+            MixedStruct(label="a", scores=np.array([0.1, 0.2])),
+        ]
+        batches = _run_to_batches(structs, MixedStruct)
+
+        assert len(batches) == 1
+        batch = batches[0]
+        assert batch.column("label").to_pylist() == ["a"]
+        vals = batch.column("scores").to_pylist()
+        assert vals[0] == pytest.approx([0.1, 0.2])
+
+
+class TestWriteNumpyTemporalFields:
+    """Writing numpy datetime64/timedelta64 arrays to Arrow list<timestamp>/list<duration> columns."""
+
+    def test_datetime_array(self):
+        """Write numpy datetime64[ns] array → list<timestamp(ns, UTC)>."""
+        ts_arr = np.array(["2020-01-01", "2020-06-15", "2025-12-31"], dtype="datetime64[ns]")
+        structs = [NumpyDatetimeStruct(id=1, timestamps=ts_arr)]
+        field_map = {"id": "id", "timestamps": "timestamps"}
+        batches = _run_to_batches(structs, NumpyDatetimeStruct, field_map)
+
+        batch = batches[0]
+        assert batch.num_rows == 1
+        ts_col = batch.column("timestamps")
+        assert pa.types.is_list(ts_col.type)
+        assert pa.types.is_timestamp(ts_col.type.value_type)
+        values = ts_col.to_pylist()[0]
+        assert len(values) == 3
+
+    def test_timedelta_array(self):
+        """Write numpy timedelta64[ns] array → list<duration(ns)>."""
+        td_arr = np.array([1000000000, 3600000000000, 86400000000000], dtype="timedelta64[ns]")
+        structs = [NumpyTimedeltaStruct(id=1, durations=td_arr)]
+        field_map = {"id": "id", "durations": "durations"}
+        batches = _run_to_batches(structs, NumpyTimedeltaStruct, field_map)
+
+        batch = batches[0]
+        assert batch.num_rows == 1
+        dur_col = batch.column("durations")
+        assert pa.types.is_list(dur_col.type)
+        assert pa.types.is_duration(dur_col.type.value_type)
+
+    def test_null_temporal_field(self):
+        """Unset numpy temporal field should become null in Arrow."""
+        structs = [NumpyDatetimeStruct(id=1)]  # timestamps is unset
+        field_map = {"id": "id", "timestamps": "timestamps"}
+        batches = _run_to_batches(structs, NumpyDatetimeStruct, field_map)
+
+        batch = batches[0]
+        assert batch.column("timestamps").to_pylist() == [None]
+
+    def test_multiple_rows(self):
+        """Multiple rows of datetime arrays."""
+        ts1 = np.array(["2020-01-01", "2020-01-02"], dtype="datetime64[ns]")
+        ts2 = np.array(["2025-06-15"], dtype="datetime64[ns]")
+        structs = [
+            NumpyDatetimeStruct(id=1, timestamps=ts1),
+            NumpyDatetimeStruct(id=2, timestamps=ts2),
+        ]
+        field_map = {"id": "id", "timestamps": "timestamps"}
+        batches = _run_to_batches(structs, NumpyDatetimeStruct, field_map)
+
+        batch = batches[0]
+        assert batch.num_rows == 2
+        values = batch.column("timestamps").to_pylist()
+        assert len(values[0]) == 2
+        assert len(values[1]) == 1
+
+    def test_auto_detect_no_field_map(self):
+        """Auto-detect numpy temporal fields when field_map is None."""
+        ts_arr = np.array(["2020-01-01", "2020-06-15"], dtype="datetime64[ns]")
+        structs = [NumpyDatetimeStruct(id=1, timestamps=ts_arr)]
+        batches = _run_to_batches(structs, NumpyDatetimeStruct)
+
+        batch = batches[0]
+        assert "timestamps" in batch.schema.names
+        ts_col = batch.column("timestamps")
+        assert pa.types.is_list(ts_col.type)
+        assert pa.types.is_timestamp(ts_col.type.value_type)
+
+
+class TestNonContiguousArrayWrite:
+    """Regression: NativeListWriter must handle non-contiguous numpy arrays.
+
+    Before the fix, PyArray_DATA + bulk AppendValues assumed C-contiguous memory
+    layout, silently producing wrong data for sliced or transposed arrays.
+    """
+
+    def test_sliced_1d_array(self):
+        """A sliced array (arr[::2]) is non-contiguous; write must preserve values."""
+        full = np.array([10.0, 20.0, 30.0, 40.0, 50.0, 60.0])
+        sliced = full[::2]  # [10, 30, 50], non-contiguous
+        assert not sliced.flags["C_CONTIGUOUS"] or sliced.strides[0] != sliced.itemsize
+
+        structs = [NumpyStruct(id=1, values=sliced)]
+        field_map = {"id": "id", "values": "values"}
+        batches = _run_to_batches(structs, NumpyStruct, field_map)
+
+        assert len(batches) == 1
+        batch = batches[0]
+        values_col = batch.column("values")
+        assert values_col.to_pylist() == [[10.0, 30.0, 50.0]]
+
+    def test_sliced_int_array(self):
+        """Non-contiguous int array write."""
+        full = np.array([1, 2, 3, 4, 5, 6], dtype=np.int64)
+        sliced = full[1::2]  # [2, 4, 6]
+
+        structs = [NumpyIntStruct(id=1, values=sliced)]
+        field_map = {"id": "id", "values": "values"}
+        batches = _run_to_batches(structs, NumpyIntStruct, field_map)
+        batch = batches[0]
+
+        values_col = batch.column("values")
+        assert values_col.to_pylist() == [[2, 4, 6]]
+
+    def test_transposed_ndarray(self):
+        """A transposed 2D array is non-contiguous (Fortran order); write must flatten correctly."""
+        original = np.array([[1.0, 2.0], [3.0, 4.0]])
+        transposed = original.T  # [[1, 3], [2, 4]], Fortran-order
+
+        structs = [NDArrayStruct(id=1, matrix=transposed)]
+        field_map = {"id": "id", "matrix": "matrix"}
+        batches = _run_to_batches(structs, NDArrayStruct, field_map)
+        batch = batches[0]
+
+        matrix_col = batch.column("matrix")
+        assert matrix_col.to_pylist() == [[1.0, 3.0, 2.0, 4.0]]
+
+    def test_fortran_order_array(self):
+        """Explicitly Fortran-order (column-major) array must write correctly."""
+        c_array = np.array([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]], order="C")
+        f_array = np.asfortranarray(c_array)
+        assert not f_array.flags["C_CONTIGUOUS"]
+
+        structs = [NDArrayStruct(id=1, matrix=f_array)]
+        field_map = {"id": "id", "matrix": "matrix"}
+        batches = _run_to_batches(structs, NDArrayStruct, field_map)
+        batch = batches[0]
+
+        matrix_col = batch.column("matrix")
+        assert matrix_col.to_pylist() == [[1.0, 2.0, 3.0, 4.0, 5.0, 6.0]]
+
+    def test_sliced_datetime_array(self):
+        """Non-contiguous datetime64 array write."""
+        full = np.array(
+            ["2020-01-01", "2020-02-01", "2020-03-01", "2020-04-01", "2020-05-01", "2020-06-01"],
+            dtype="datetime64[ns]",
+        )
+        sliced = full[::2]  # [Jan, Mar, May], non-contiguous
+        assert not sliced.flags["C_CONTIGUOUS"] or sliced.strides[0] != sliced.itemsize
+
+        structs = [NumpyDatetimeStruct(id=1, timestamps=sliced)]
+        field_map = {"id": "id", "timestamps": "timestamps"}
+        batches = _run_to_batches(structs, NumpyDatetimeStruct, field_map)
+        batch = batches[0]
+        ts_col = batch.column("timestamps")
+        assert len(ts_col.to_pylist()[0]) == 3
+
+    def test_sliced_timedelta_array(self):
+        """Non-contiguous timedelta64 array write."""
+        full = np.array([1, 2, 3, 4, 5, 6], dtype="timedelta64[ns]")
+        sliced = full[1::2]  # [2, 4, 6]
+
+        structs = [NumpyTimedeltaStruct(id=1, durations=sliced)]
+        field_map = {"id": "id", "durations": "durations"}
+        batches = _run_to_batches(structs, NumpyTimedeltaStruct, field_map)
+        batch = batches[0]
+        dur_col = batch.column("durations")
+        assert len(dur_col.to_pylist()[0]) == 3
+
+
+class TestNDArrayStringWrite:
+    """Tests for ND string array writing — exposes PyArray_GETPTR1 bug."""
+
+    def test_2d_string_ndarray_write(self):
+        """2D string NDArray write should produce correct flat list."""
+        matrix = np.array([["alpha", "beta"], ["gamma", "delta"]], dtype="U10")
+        structs = [NDArrayStringStruct(id=1, names=matrix)]
+        field_map = {"id": "id", "names": "names"}
+        batches = _run_to_batches(structs, NDArrayStringStruct, field_map)
+
+        batch = batches[0]
+        data_col = batch.column("names").to_pylist()
+        assert data_col[0] == ["alpha", "beta", "gamma", "delta"]
+        dims_col = batch.column("names_csp_dimensions").to_pylist()
+        assert dims_col[0] == [2, 2]


### PR DESCRIPTION
## Summary

Adds numpy array support for the **struct → RecordBatch (write)** direction of Arrow conversion. The read direction (RecordBatch → struct) follows in a separate PR.

### Writers (`ArrowNumpyListWriter.h`)
- 1D array writers for float, int, bool (via `ArrowArrayType` trait), string, datetime, timedelta, date
- NDArray writers with separate dimensions column and **null dims optimization** (writes null when shape unchanged)
- `ListFieldWriterBase` shared base class for reserve/writeNull/finish

### Shared utilities (`NumpyConversions.h/cpp`)
- `NPY_TYPE<>` specializations for `DateTime`, `TimeDelta`, `Date`
- Simplified `npyTypeFromPyType` via `PartialSwitchCspType`

### Python + C++ integration
- `_extract_numpy_metadata()` utility to categorize struct fields into scalar vs numpy
- `struct_to_record_batches` updated with `field_map: Optional[Dict]` and `numpy_dimensions_column_map` parameter
- `field_map` always resolved in Python before reaching C++ (removed auto-detect branch in `StructToRecordBatch.cpp`)