### PR TITLE
Replace pandas date_range API with DatetimeIndex in tests

### DIFF
--- a/csp/tests/adapters/test_parquet.py
+++ b/csp/tests/adapters/test_parquet.py
@@ -205,11 +205,13 @@ class TestParquet(unittest.TestCase):
                 csp.run(graph, starttime=start_time)
                 df = pandas.read_parquet(filename)
                 expected_columns = {}
-                # pandas 3.0+: need to explicitly force ns unit and UTC tz, no longer the default
+                # Build the expected index explicitly rather than via pandas.date_range(...),
+                # which segfaults under pandas 3.0.4 + numpy<2.5 (tslibs offset ABI mismatch).
+                # This yields the same datetime64[ns, UTC] values.
                 if timestamp_column_name:
-                    expected_columns[timestamp_column_name] = pandas.date_range(
-                        start=start_time + timedelta(seconds=1), periods=10, unit="ns", freq="1s", tz="UTC"
-                    )
+                    expected_columns[timestamp_column_name] = pandas.DatetimeIndex(
+                        [start_time + timedelta(seconds=i) for i in range(1, 11)]
+                    ).as_unit("ns")
                 expected_columns.update(
                     {
                         "x": list(range(1, 11)),
@@ -242,10 +244,12 @@ class TestParquet(unittest.TestCase):
 
             expected_df = pandas.DataFrame.from_dict(
                 {
-                    # pandas 3.0+: need to explicitly force ns unit and UTC tz, no longer the default
-                    "timestamp": pandas.date_range(
-                        start=start_time + timedelta(seconds=1), periods=10, unit="ns", freq="1s", tz="UTC"
-                    ),
+                    # Build the expected index explicitly rather than via pandas.date_range(...),
+                    # which segfaults under pandas 3.0.4 + numpy<2.5 (tslibs offset ABI mismatch).
+                    # This yields the same datetime64[ns, UTC] values.
+                    "timestamp": pandas.DatetimeIndex(
+                        [start_time + timedelta(seconds=i) for i in range(1, 11)]
+                    ).as_unit("ns"),
                     "x": list(range(1, 11)),
                     "y": list(map(float, range(0, 100, 10))),
                 }


### PR DESCRIPTION
## Summary

Replaces `pandas.date_range(...)` with `pandas.DatetimeIndex([...]).as_unit("ns")` in two test helpers in `csp/tests/adapters/test_parquet.py` (`test_parquet_writer` and `test_arrow_writer`).

## Reason

`pandas.date_range(..., freq="1s", tz="UTC")` segfaults under **pandas 3.0.4 + numpy<2.5** due to a `pandas._libs.tslibs` offset ABI mismatch — the frequency/offset path is compiled Cython code that crashes when built against an incompatible numpy ABI. The new approach constructs the index directly from explicit `datetime` values, avoiding the offset code path entirely.

## Equivalence

The replacement is behaviorally identical to the original:

- Same values: `start_time + 1s … start_time + 10s` (10 timestamps).
- Same dtype: `datetime64[ns, UTC]`. UTC is preserved because `start_time` is tz-aware (`tzinfo=pytz.utc`), and `.as_unit("ns")` forces nanosecond resolution.
- Frame-level dtype and value comparisons against the read-back DataFrame match.

Both affected tests pass.
