### PR TITLE
Security: Insecure Default Directory Permissions

### DIFF
--- a/cpp/csp/adapters/utils/FileUtils.h
+++ b/cpp/csp/adapters/utils/FileUtils.h
@@ -19,7 +19,7 @@ inline bool fileExists( const std::string & fileOrDir )
     return std::filesystem::exists(fileOrDir);
 }
 
-inline void mkdir( const std::string & path,  mode_t mode = S_IRWXU | S_IRWXG | S_IROTH | S_IXOTH )
+inline void mkdir( const std::string & path,  mode_t mode = S_IRWXU | S_IRGRP | S_IXGRP | S_IROTH | S_IXOTH )
 {
     size_t pos = 0;
     do


### PR DESCRIPTION
## Summary

Security: Insecure Default Directory Permissions

## Problem

**Severity**: `Medium` | **File**: `cpp/csp/adapters/utils/FileUtils.h:L24`

The `mkdir` function creates directories with default permissions that grant write access to the group (S_IRWXG). This can allow unintended modification of files by group members or other local users.

## Solution

Remove group write permissions from the default mode. Use `S_IRWXU | S_IRGRP | S_IXGRP | S_IROTH | S_IXOTH` (0755) instead of `S_IRWXU | S_IRWXG | S_IROTH | S_IXOTH` (0775).

## Changes

- `cpp/csp/adapters/utils/FileUtils.h` (modified)