### PR TITLE
fix: avoid non-string Outputs class keys

### DIFF
--- a/csp/impl/types/common_definitions.py
+++ b/csp/impl/types/common_definitions.py
@@ -58,6 +58,10 @@ class Outputs:
             _make_pydantic_outputs(kwargs)
         except ImportError:
             pass
+        # Python 3.13 warns when a class namespace contains non-string keys.
+        # Keep None in __annotations__ to represent an unnamed output, but do
+        # not pass it as a class attribute to type().
+        kwargs.pop(None, None)
         return type("Outputs", (Outputs,), kwargs)
 
     def __init__(self, *args, **kwargs):

--- a/csp/tests/test_parsing.py
+++ b/csp/tests/test_parsing.py
@@ -1,5 +1,6 @@
 import sys
 import unittest
+import warnings
 from datetime import datetime, timedelta
 from typing import Callable, Dict, List
 
@@ -9,6 +10,14 @@ from csp.impl.types.instantiation_type_resolver import ArgTypeMismatchError
 
 
 class TestParsing(unittest.TestCase):
+    def test_unnamed_outputs_namespace_uses_string_keys(self):
+        with warnings.catch_warnings():
+            warnings.simplefilter("error", RuntimeWarning)
+            outputs = Outputs(ts[int])
+
+        self.assertTrue(all(isinstance(key, str) for key in vars(outputs)))
+        self.assertEqual(outputs.__annotations__, {None: ts[int]})
+
     def test_parse_errors(self):
         # These are roughly in order of exceptions that are thrown in node_parser.py ( as of the time of this writing )
 


### PR DESCRIPTION
## Summary

Closes #665.

Avoids passing the unnamed-output `None` sentinel as a key in the dynamically created `Outputs` class namespace. The sentinel remains in `__annotations__`, where the parser expects it, while every actual class attribute name is now a string.

Python 3.13 warns when `type()` receives a non-string namespace key. Treating that warning as an error reproduces the current failure directly:

```text
RuntimeWarning: non-string key in the __dict__ of class Outputs
```

The added regression test verifies both sides of the contract: constructing an unnamed `Outputs` type emits no `RuntimeWarning`, and its `{None: ...}` annotation metadata is preserved.

## Validation

- Python 3.13 isolated reproduction of the original `type(..., {None: ...})` warning
- Python 3.13 focused execution of the patched unnamed and named `Outputs` construction paths
- Python 3.13 focused execution with Pydantic enabled
- `ruff check csp/impl/types/common_definitions.py csp/tests/test_parsing.py`
- `ruff format --check csp/impl/types/common_definitions.py csp/tests/test_parsing.py`
- `git diff --check`

The full csp suite requires the project's compiled C++ environment and is left to CI.
