### PR TITLE
Keep the unnamed-output None key out of the Outputs class namespace

### DIFF
--- a/csp/impl/types/common_definitions.py
+++ b/csp/impl/types/common_definitions.py
@@ -58,6 +58,9 @@ class Outputs:
             _make_pydantic_outputs(kwargs)
         except ImportError:
             pass
+        # None keys the single unnamed output in __annotations__; drop it from
+        # the class namespace, where a non-string key warns on py3.13+.
+        kwargs.pop(None, None)
         return type("Outputs", (Outputs,), kwargs)
 
     def __init__(self, *args, **kwargs):

--- a/csp/tests/impl/types/test_common_definitions.py
+++ b/csp/tests/impl/types/test_common_definitions.py
@@ -1,0 +1,23 @@
+import warnings
+from unittest import TestCase
+
+from csp import ts
+from csp.impl.types.common_definitions import Outputs
+
+
+class TestOutputs(TestCase):
+    def test_unnamed_output_does_not_warn(self):
+        # A single unnamed output is keyed by None; it belongs in __annotations__
+        # but not in the class namespace, where a non-string key raises a
+        # RuntimeWarning on Python 3.13+.
+        with warnings.catch_warnings():
+            warnings.simplefilter("error", RuntimeWarning)
+            out = Outputs(ts[int])
+        self.assertEqual(list(out.__annotations__), [None])
+        self.assertNotIn(None, vars(out))
+
+    def test_named_outputs_do_not_warn(self):
+        with warnings.catch_warnings():
+            warnings.simplefilter("error", RuntimeWarning)
+            out = Outputs(a=ts[int], b=ts[str])
+        self.assertEqual(set(out.__annotations__), {"a", "b"})


### PR DESCRIPTION
Fixes #665.

`Outputs.__new__` keys a single unnamed output as `kwargs[None]` and then passes `kwargs` straight to `type("Outputs", (Outputs,), kwargs)`. Since python/cpython@f7c05d7 (3.13+), a non-string key in a class namespace triggers `RuntimeWarning: non-string key in the __dict__ of class Outputs`, which fires on plain `import csp`.

The `None` key is only needed in `__annotations__` (that copy is taken earlier, and `_extract_outputs_from_return_annotation` reads the unnamed output back from there) and by `_make_pydantic_outputs`, which runs before this point. So it can be popped off `kwargs` right before the `type()` call - the annotations dict keeps it, the class namespace doesn't.

Added `test_common_definitions.py` covering the unnamed and named cases with `RuntimeWarning` promoted to an error.

Verification: `common_definitions.py` is identical between `main` and the latest release `v0.18.0`, and a full source build isn't available on this Windows setup, so I verified against `v0.18.0`:

```
$ python -W error::RuntimeWarning -c "import csp; from csp.impl.types.common_definitions import Outputs; Outputs(csp.ts[int])"
(clean - previously raised RuntimeWarning)

$ python -m pytest -q csp/tests/impl/types/ csp/tests/impl/wiring/ csp/tests/test_engine.py csp/tests/test_baskets.py csp/tests/test_dynamic.py csp/tests/test_baselib.py
213 passed, 4 skipped
```
`ruff check` / `ruff format --check` clean on both changed files.
